### PR TITLE
Implement Rust-style hashing using SHA3-256

### DIFF
--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -24,6 +24,9 @@
 // SOFTWARE.
 
 use sha3::{Digest, Sha3_256};
+use std::fmt;
+use std::mem;
+use std::slice;
 use utils::*;
 
 // -----------------------------------------------------
@@ -31,7 +34,7 @@ use utils::*;
 
 pub const HASH_SIZE: usize = 32;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Hash([u8; HASH_SIZE]);
 
 impl Hash {
@@ -49,6 +52,19 @@ impl Hash {
 
     pub fn to_str(&self) -> String {
         u8v_to_typed_str("H", &self.base_vector())
+    }
+}
+
+impl fmt::Debug for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_str());
+        Ok(())
+    }
+}
+
+impl fmt::Display for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 
@@ -84,4 +100,145 @@ pub fn hash_nbytes(nb: usize, msg: &[u8]) -> Vec<u8> {
         kx += 1;
     }
     ans
+}
+
+/// Implementation of default crypto-hashing algorithm for this project.
+pub struct Hasher(Sha3_256);
+
+impl Hasher {
+    /// Create the new hasher.
+    pub fn new() -> Self {
+        Hasher(Sha3_256::new())
+    }
+
+    /// Retrieve result.
+    pub fn result(&self) -> Hash {
+        // FIXME: .clone() is used because .result() doesn't use &self
+        let ga = self.0.clone().result();
+        let mut h = [0u8; HASH_SIZE];
+        h.copy_from_slice(ga.as_slice());
+        Hash(h)
+    }
+
+    /// Digest input.
+    #[inline]
+    pub fn input<B: AsRef<[u8]>>(&mut self, data: B) {
+        self.0.input(data);
+    }
+
+    /// Digest input in a chained manner.
+    #[inline]
+    pub fn chain<B: AsRef<[u8]>>(self, data: B) -> Self {
+        Hasher(self.0.chain(data))
+    }
+
+    // Reset hasher instance to its initial state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.0.reset();
+    }
+}
+
+/// A hashable type.
+///
+/// Types implementing Hashable are able to be hashed.
+///
+pub trait Hashable {
+    /// Feeds this value into Hasher.
+    fn hash(&self, state: &mut Hasher);
+}
+
+impl Hashable for u8 {
+    fn hash(&self, state: &mut Hasher) {
+        state.input(&[*self])
+    }
+}
+
+impl Hashable for u16 {
+    fn hash(&self, state: &mut Hasher) {
+        state.input(&unsafe { mem::transmute::<_, [u8; 2]>(*self) })
+    }
+}
+
+impl Hashable for u32 {
+    fn hash(&self, state: &mut Hasher) {
+        state.input(&unsafe { mem::transmute::<_, [u8; 4]>(*self) })
+    }
+}
+
+impl Hashable for u64 {
+    fn hash(&self, state: &mut Hasher) {
+        state.input(&unsafe { mem::transmute::<_, [u8; 8]>(*self) })
+    }
+}
+
+impl Hashable for char {
+    fn hash(&self, state: &mut Hasher) {
+        let x: [u8; 4] = unsafe { mem::transmute::<_, [u8; 4]>(*self as u32) };
+        println!("HashChar {} {} {} {}", x[0], x[1], x[2], x[3]);
+
+        state.input(&unsafe { mem::transmute::<_, [u8; 4]>(*self as u32) })
+    }
+}
+
+impl Hashable for str {
+    fn hash(&self, state: &mut Hasher) {
+        state.input(self.as_bytes());
+    }
+}
+
+impl Hashable for String {
+    fn hash(&self, state: &mut Hasher) {
+        state.input(self.as_bytes());
+    }
+}
+
+impl Hashable for [u8] {
+    fn hash(&self, state: &mut Hasher) {
+        let newlen = self.len() * mem::size_of::<u8>();
+        let ptr = self.as_ptr() as *const u8;
+        state.input(unsafe { slice::from_raw_parts(ptr, newlen) })
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Define some structure
+    struct Data {
+        a: String,
+        b: u8,
+        c: [u8; 5],
+    }
+
+    /// Define custom hash function
+    impl Hashable for Data {
+        fn hash(&self, state: &mut Hasher) {
+            self.a.hash(state);
+            self.b.hash(state);
+            self.c[..].hash(state);
+        }
+    }
+
+    #[test]
+    fn hasher() {
+        let d = Data {
+            a: "Hello".to_string(),
+            b: 32,                       // space
+            c: [87, 111, 114, 108, 100], // World
+        };
+
+        let garr = Sha3_256::digest(b"Hello World");
+        let mut arr = [0u8; HASH_SIZE];
+        arr.copy_from_slice(garr.as_slice());
+        let h1 = Hash(arr);
+
+        let mut hasher = Hasher::new();
+        d.hash(&mut hasher);
+        let h2: Hash = hasher.result();
+
+        // Test that manually hashed result matches Hashable for Data implementation.
+        assert!(h1 == h2);
+    }
 }


### PR DESCRIPTION
Follow std::hash approach for hashing.
Now it possible to define hashing logging for any struct:

    // Define some structure
    struct Data {
        a: String,
        b: u8,
        c: u32,
    }

    // Define custom hashing logging
    impl Hashable for Data {
        fn hash(&self, state: &mut Hasher) {
            self.a.hash(state);
            self.b.hash(state);
            self.c.hash(state);
        }
    }

    // Calculate the hash
    let mut hasher = Hasher::new();
    d.hash(&mut hasher);
    let h2: Hash = hasher.result();

My initial version re-used std::hash::Hash and std::hash::Hasher.
Unfortunally, this approach has failed completely. Rust's
std::hash has some special logic for handling built-in types.
For example, for String they call hash(str.as_bytes()) + hash(255).
It is probably needed to workaround hashing of empty strings.
The same problem happens with arrays. I want the clear result
without extra garbage in the hash function.

Closes #26