### PR TITLE
Proof-of-concept transport muxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=e179951c74cb0c8916d27329f2dfd78917dddfb2)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-libpbc 0.1.0 (git+https://github.com/stegos/rust-pbcintf.git)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1869,6 +1870,7 @@ dependencies = [
  "tokio-current-thread 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stdin 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ tokio-io = "0.1.9"
 tokio-stdin = "0.1.1"
 tokio-current-thread = "0.1.3"
 tokio = "0.1.11"
+unsigned-varint = "0.2.1"
+log = "0.4.5"
 
 rust-libpbc = { git = "https://github.com/stegos/rust-pbcintf.git" }
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "e179951c74cb0c8916d27329f2dfd78917dddfb2" }
@@ -60,6 +62,9 @@ name = "curve1174"
 
 [[example]]
 name = "floodsub"
+
+[[example]]
+name = "muxedsub"
 
 [[example]]
 name = "echo-server"


### PR DESCRIPTION
* implemented echo-reply protocol `rust-libp2p` way, compatible with
  MT Tokio Runtime (echo-server example)
* handle finished connections in `floodsub` example
* `muxedsub` example serving both echo and floodsub on the same ip/port