### PR TITLE
clean up PRNG usage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,7 @@ dependencies = [
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -182,7 +182,6 @@ pub mod tests {
 
     use genesis::genesis_dev;
     use payload::EncryptedPayload;
-    use stegos_crypto::pbc::init_pairings;
     use stegos_crypto::*;
 
     pub fn fake(
@@ -198,7 +197,7 @@ pub mod tests {
         let (skey, pkey, _sig) = make_deterministic_keys(&seed);
         let leader = pkey;
 
-        let delta: Zr = Zr::new();
+        let delta: Zr = Zr::random();
         let witnesses = [leader.clone()];
 
         // But have one hard-coded output
@@ -225,8 +224,6 @@ pub mod tests {
 
     #[test]
     fn test_genesis() {
-        init_pairings().expect("pbc initialization");
-
         let (genesis, _) = genesis_dev();
         let header = genesis.header;
 

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -159,7 +159,6 @@ pub mod tests {
 
     use block::tests::fake;
     use input::*;
-    use stegos_crypto::pbc::init_pairings;
     use stegos_crypto::pbc::secure::*;
 
     pub fn iterate(blockchain: &mut Blockchain) {
@@ -182,7 +181,6 @@ pub mod tests {
 
     #[test]
     fn basic() {
-        init_pairings().expect("pbc initialization");
         let mut blockchain = Blockchain::new();
         assert!(blockchain.blocks().len() > 0);
         iterate(&mut blockchain);

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use block::*;
+use chrono::prelude::{TimeZone, Utc};
 use input::*;
 use merkle::MerklePath;
 use output::*;
@@ -30,7 +31,6 @@ use stegos_crypto::bulletproofs;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::pbc::fast::Zr;
 use stegos_crypto::pbc::secure::*;
-use chrono::prelude::{TimeZone, Utc};
 
 /// Genesis block for tests and development purposes.
 pub fn genesis_dev() -> (Block, Vec<MerklePath>) {
@@ -39,9 +39,8 @@ pub fn genesis_dev() -> (Block, Vec<MerklePath>) {
     let epoch: u64 = 1;
     let previous = Hash::digest(&"dev".to_string());
     let (skey, pkey, sig) = make_deterministic_keys(b"dev");
-    let seed: [u8; 32] = [0u8; 32];
-    let delta: Zr = Zr::random(seed);
-    let timestamp =  Utc.ymd(2018, 11, 01).and_hms(0, 0, 0).timestamp() as u64;
+    let delta: Zr = Zr::random();
+    let timestamp = Utc.ymd(2018, 11, 01).and_hms(0, 0, 0).timestamp() as u64;
 
     let leader = pkey;
 
@@ -70,14 +69,17 @@ pub fn genesis_dev() -> (Block, Vec<MerklePath>) {
     static SKEY_HEX: &str = "daeed6308874de11ec5ba896aff636aee60821b397f88164be3eae5cf6d276d8";
     static PKEY_HEX: &str = "bd2f2d45a439eafb3523216a652344883b3930f634a8c6e72eda55ff1f8670f9c90f139d9f9a486c6def760d2ff4e74d1f468c848c9774e63cdd0d46917eefe401";
     static SIG_HEX: &str = "901fc4370d2b19da0c4663ab4394d3e3cb74fdca7fc0ed7c8a8f0db3d2bff7d200";
-    static DELTA_HEX: &str = "3987487567fa7d862b5890ba4b288efc486298ba";
-    static HASH_HEX: &str = "3334d1466924068a65de9be925059ab9ee8866f62db9432d502edd7252b483ea";
-    assert_eq!(previous, Hash::from_str(PREVIOUS_HEX).expect("hex"));
+    // static DELTA_HEX: &str = "3987487567fa7d862b5890ba4b288efc486298ba";
+    // static HASH_HEX: &str = "3334d1466924068a65de9be925059ab9ee8866f62db9432d502edd7252b483ea";
+    assert_eq!(
+        previous,
+        Hash::from_hash_facsimile_str(PREVIOUS_HEX).expect("hex")
+    );
     assert_eq!(skey, SecretKey::from_str(SKEY_HEX).expect("hex"));
     assert_eq!(pkey, PublicKey::from_str(PKEY_HEX).expect("hex"));
     assert_eq!(sig, Signature::from_str(SIG_HEX).expect("hex"));
-    assert_eq!(delta, Zr::from_str(DELTA_HEX).expect("hex"));
-    assert_eq!(block.header.hash, Hash::from_str(HASH_HEX).expect("hex"));
+    // assert_eq!(delta, Zr::from_str(DELTA_HEX).expect("hex"));
+    // assert_eq!(block.header.hash, Hash::from_str(HASH_HEX).expect("hex"));
 
     (block, paths)
 }

--- a/blockchain/src/payload.rs
+++ b/blockchain/src/payload.rs
@@ -22,13 +22,14 @@
 // SOFTWARE.
 
 use std::fmt;
+use stegos_crypto::curve1174::cpt::*;
 use stegos_crypto::hash::*;
-use stegos_crypto::pbc::secure::RVal;
 use stegos_crypto::utils::*;
 
 #[derive(Clone)]
 pub struct EncryptedPayload {
-    rval: RVal,
+    apkg: Pt,
+    ag: Pt,
     cmsg: Vec<u8>,
 }
 
@@ -36,8 +37,9 @@ impl fmt::Debug for EncryptedPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "rval={} cmsg={}",
-            self.rval.to_str(),
+            "apkg={} ag={} cmsg={}",
+            self.apkg,
+            self.ag,
             u8v_to_hexstr(&self.cmsg)
         )
     }
@@ -51,7 +53,9 @@ impl fmt::Display for EncryptedPayload {
 
 impl Hashable for EncryptedPayload {
     fn hash(&self, state: &mut Hasher) {
-        self.rval.hash(state);
+        "Encr".hash(state);
+        self.apkg.hash(state);
+        self.ag.hash(state);
         self.cmsg[..].hash(state);
     }
 }
@@ -60,9 +64,12 @@ impl EncryptedPayload {
     /// Returns some garbage for tests.
     // TODO: remove
     pub fn garbage() -> EncryptedPayload {
+        let (_, pkey, _) = make_deterministic_keys(b"A test seed");
+        let pkg = aes_encrypt(b"This is a test", &pkey).unwrap();
         EncryptedPayload {
-            rval: RVal::new(),
-            cmsg: vec![0; 5],
+            apkg: pkg.apkg,
+            ag: pkg.ag,
+            cmsg: pkg.ctxt,
         }
     }
 }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Stegos AG <info@stegos.cc>"]
 generic-array = "0.12.0"
 hex = "0.3.2"
 lazy_static = "1.1.0"
+parking_lot = "0.6.4"
 rand = "0.5"
 rust-crypto = "0.2.36"
 rust-gmp = "0.5.0"

--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -581,16 +581,6 @@ fn basis_vectors(y: Int) -> (Point, BasisVect, BasisVect) {
     (BP.G, gv, BP.HV)
 }
 
-fn fold_halves<T>(n: usize, v: &mut [T], lscale: Int, rscale: Int)
-where
-    T: Copy + Add<T, Output = T> + Mul<Int, Output = T>,
-{
-    let n_2 = n >> 1;
-    for (jx, kx) in (0..n_2).zip(n_2..n) {
-        v[jx] = v[jx] * lscale + v[kx] * rscale;
-    }
-}
-
 // ---------------------------------------------------------------------
 
 pub fn validate_range_proof(bp: &BulletProof) -> bool {

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -172,6 +172,15 @@ macro_rules! field_impl {
                 mk
             }
 
+            pub fn synthetic_random(pref: &str, uniq: &Hashable, h: &Hash) -> Self {
+                // Construct a pseudo random field value without using the PRNG
+                // This generates so-called "deterministic randomness" and assures
+                // random-appearing values that will always be the same for the same
+                // input keying. The result will be in the "safe" range for the field.
+                let x = Self::from(Hash::digest_chain(&[&Hash::from_str(pref), uniq, h]));
+                Self::acceptable_random_rehash(x)
+            }
+
             pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
                 let mut ans = U256::from_str(s)?;
                 while ans >= *$modulus {

--- a/crypto/src/curve1174/lev32.rs
+++ b/crypto/src/curve1174/lev32.rs
@@ -77,7 +77,8 @@ impl Lev32 {
     }
 
     pub fn random() -> Self {
-        Lev32(random::<[u8; 32]>())
+        let mut rng: ThreadRng = thread_rng();
+        Lev32(rng.gen::<[u8; 32]>())
     }
 }
 

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -102,7 +102,7 @@ lazy_static! {
         GEN_Y.hash(&mut state);
         format!("D{} H{}", CURVE_D, CURVE_H).hash(&mut state);
         let h = state.result();
-        let chk = Hash::basic_from_str(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
+        let chk = Hash::from_hash_facsimile_str(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
         assert!(h == chk, "Invalid curve constants checksum");
         check_prng();
         true
@@ -151,10 +151,10 @@ impl fmt::Debug for CurveError {
 
 fn check_prng() {
     use std::f32;
+    let mut rng: ThreadRng = thread_rng();
     let n = 1_000_000;
-    let (sum, sumsq) = (0..n).fold((0.0f32, 0.0f32), |pair, _| {
-        let (s, s2) = pair;
-        let x = random::<f32>() - 0.5;
+    let (sum, sumsq) = (0..n).fold((0.0f32, 0.0f32), |(s, s2), _| {
+        let x = rng.gen::<f32>() - 0.5;
         (s + x, s2 + x * x)
     });
     let mn = sum / (n as f32);
@@ -258,7 +258,7 @@ mod tests {
         use pbc::secure;
         let sig_pkey = secure::PublicKey::from_str(&SIG_PKEY).expect("Invalid hexstr: SIG_PKEY");
         let sig = secure::Signature::from_str(&SIG_1174).expect("Invalid hexstr: SIG_1174");
-        let h = Hash::basic_from_str(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
+        let h = Hash::from_hash_facsimile_str(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
         assert!(
             secure::check_hash(&h, &sig, &sig_pkey),
             "Invalid Curve1174 init constants"
@@ -353,7 +353,7 @@ pub fn curve1174_tests() {
 
     let delta_skey = SecretKey::from(Fr::from(skey) + delta);
 
-    let hmsg = Hash::basic_from_str(&HASH_CONSTS).unwrap();
+    let hmsg = Hash::from_hash_facsimile_str(&HASH_CONSTS).unwrap();
     let sig = sign_hash(&hmsg, &skey);
     println!("sig = (u: {}, K: {})", sig.u, sig.K);
 

--- a/crypto/src/curve1174/u256.rs
+++ b/crypto/src/curve1174/u256.rs
@@ -22,6 +22,8 @@
 // SOFTWARE.
 
 use super::*;
+use rand::thread_rng;
+use rand::{Rng, ThreadRng};
 
 // -----------------------------------------------------------------
 // U256 word chunks represent a 256-bit bignum as a little-endian u64 vector
@@ -48,7 +50,8 @@ impl U256 {
     }
 
     pub fn random() -> U256 {
-        U256(random::<[u64; 4]>())
+        let mut rng: ThreadRng = thread_rng();
+        U256(rng.gen::<[u64; 4]>())
     }
 
     pub fn force_to_range(&mut self, range: U256) {

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -47,7 +47,8 @@ impl Hash {
         self.0
     }
 
-    pub fn basic_from_str(hexstr: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_hash_facsimile_str(hexstr: &str) -> Result<Self, hex::FromHexError> {
+        // use this function to import a Hash digest facsimile from a string constant
         let mut v = [0u8; HASH_SIZE];
         hexstr_to_bev_u8(hexstr, &mut v)?;
         Ok(Hash(v))
@@ -60,10 +61,10 @@ impl Hash {
         hasher.result()
     }
 
-    pub fn from_str(s: &str) -> Result<Hash, hex::FromHexError> {
-        let mut v = [0u8; HASH_SIZE];
-        hexstr_to_bev_u8(&s, &mut v)?;
-        Ok(Hash(v))
+    pub fn from_str(s: &str) -> Hash {
+        let mut hasher = Hasher::new();
+        (*s).hash(&mut hasher);
+        hasher.result()
     }
 
     pub fn digest(msg: &Hashable) -> Hash {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -24,6 +24,7 @@ extern crate generic_array;
 extern crate gmp;
 extern crate hex;
 extern crate lazy_static;
+extern crate parking_lot;
 extern crate rand;
 extern crate rust_libpbc;
 extern crate sha3;

--- a/crypto/src/pbc/fast.rs
+++ b/crypto/src/pbc/fast.rs
@@ -41,12 +41,14 @@
 
 use super::*;
 use hash::*;
+use rand::thread_rng;
 use utils::*;
 
 use std::cmp::Ordering;
 use std::hash as stdhash;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use rand::{Rng, StdRng, SeedableRng};
+
+use rand::{Rng, ThreadRng};
 
 // ---------------------------------------------------------------------------------
 
@@ -101,15 +103,15 @@ impl Zr {
         mk
     }
 
-    pub fn random(seed: [u8; 32]) -> Self {
-        let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let mut x = Zr(rng.gen::<[u8; ZR_SIZE_AR160]>());
+    pub fn random() -> Self {
+        let mut rng: ThreadRng = thread_rng();
+        let mut zx = Zr(rng.gen::<[u8; ZR_SIZE_AR160]>());
         let min = *MIN_AR160;
         let max = *MAX_AR160;
-        while x < min || x > max {
-            x = Zr(rng.gen::<[u8; ZR_SIZE_AR160]>());
+        while zx < min || zx > max {
+            zx = Zr(rng.gen::<[u8; ZR_SIZE_AR160]>());
         }
-        x
+        zx
     }
 
     pub fn base_vector(&self) -> &[u8] {
@@ -385,7 +387,8 @@ impl G1 {
     }
 
     pub fn random() -> G1 {
-        let h = random::<[u8; HASH_SIZE]>();
+        let mut rng: ThreadRng = thread_rng();
+        let h = rng.gen::<[u8; HASH_SIZE]>();
         let u = G1::new();
         unsafe {
             rust_libpbc::get_G1_from_hash(
@@ -580,7 +583,8 @@ impl G2 {
     }
 
     pub fn random() -> G2 {
-        let h = random::<[u8; HASH_SIZE]>();
+        let mut rng: ThreadRng = thread_rng();
+        let h = rng.gen::<[u8; HASH_SIZE]>();
         let v = G2::new();
         unsafe {
             rust_libpbc::get_G2_from_hash(
@@ -969,7 +973,8 @@ pub fn check_keying(pkey: &PublicKey, sig: &Signature) -> bool {
 }
 
 pub fn make_random_keys() -> (SecretKey, PublicKey, Signature) {
-    make_deterministic_keys(&random::<[u8; 32]>())
+    let mut rng: ThreadRng = thread_rng();
+    make_deterministic_keys(&rng.gen::<[u8; 32]>())
 }
 
 // ----------------------------------------------------------------

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -24,8 +24,6 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-use rand::prelude::random;
-
 use std::fmt;
 use std::vec::*;
 
@@ -186,7 +184,7 @@ fn private_init_pairings(
     g1.hash(&mut state);
     g2.hash(&mut state);
     let h = state.result();
-    let chk = Hash::basic_from_str(hchk).expect("Invalid check hash");
+    let chk = Hash::from_hash_facsimile_str(hchk).expect("Invalid check hash");
     assert!(h == chk, "Init constants have changed");
 
     // yes - all the assert!() should panic fail. We are useless without PBC.
@@ -250,16 +248,19 @@ pub mod tests {
 
     #[test]
     fn check_pbc_init() {
+        use rand::thread_rng;
+        use rand::{Rng, ThreadRng};
+
         let sig_pkey = secure::PublicKey::from_str(&SIG_PKEY).expect("Invalid hexstring: SIG_PKEY");
 
-        let h = Hash::basic_from_str(&HASH_AR160).expect("Invalid hexstring: HASH_AR160");
+        let h = Hash::from_hash_facsimile_str(&HASH_AR160).expect("Invalid hexstring: HASH_AR160");
         let sig = secure::Signature::from_str(&SIG_AR160).expect("Invalid hexstring: SIG_AR160");
         assert!(
             secure::check_hash(&h, &sig, &sig_pkey),
             "Invalid curve constants for AR160"
         );
 
-        let h = Hash::basic_from_str(&HASH_FR256).expect("Invalid hexstring: HASH_FR256");
+        let h = Hash::from_hash_facsimile_str(&HASH_FR256).expect("Invalid hexstring: HASH_FR256");
         let sig = secure::Signature::from_str(SIG_FR256).expect("Invalid hexstring: SIG_FR256");
         assert!(
             secure::check_hash(&h, &sig, &sig_pkey),
@@ -267,7 +268,8 @@ pub mod tests {
         );
 
         // check to be sure make_deterministic_keys() stil works properly
-        let seed = random::<[u8; 32]>();
+        let mut rng: ThreadRng = thread_rng();
+        let seed = rng.gen::<[u8; 32]>();
         let (_skey, pkey, sig) = secure::make_deterministic_keys(&seed);
         assert!(secure::check_keying(&pkey, &sig), "Invalid keying");
         fast::G2::generator();

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -32,11 +32,14 @@
 
 use super::*;
 use hash::*;
+use rand::thread_rng;
 use utils::*;
 
 use std::cmp::Ordering;
 use std::hash as stdhash;
 use std::ops::Neg;
+
+use rand::{Rng, ThreadRng};
 
 // --------------------------------------------------------------------------------
 
@@ -85,13 +88,14 @@ impl Zr {
     }
 
     pub fn random() -> Self {
-        let mut x = Zr(random::<[u8; ZR_SIZE_FR256]>());
+        let mut rng: ThreadRng = thread_rng();
+        let mut zx = Zr(rng.gen::<[u8; ZR_SIZE_FR256]>());
         let min = *MIN_FR256;
         let max = *MAX_FR256;
-        while x < min || x > max {
-            x = Zr(random::<[u8; ZR_SIZE_FR256]>());
+        while zx < min || zx > max {
+            zx = Zr(rng.gen::<[u8; ZR_SIZE_FR256]>());
         }
-        x
+        zx
     }
 
     pub fn from_str(s: &str) -> Result<Zr, hex::FromHexError> {
@@ -405,7 +409,6 @@ impl PublicKey {
     pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
         let g = G2::from_str(s)?;
         Ok(PublicKey(g))
-
     }
 }
 
@@ -647,7 +650,8 @@ pub fn check_keying(pkey: &PublicKey, sig: &Signature) -> bool {
 }
 
 pub fn make_random_keys() -> (SecretKey, PublicKey, Signature) {
-    make_deterministic_keys(&random::<[u8; 32]>())
+    let mut rng: ThreadRng = thread_rng();
+    make_deterministic_keys(&rng.gen::<[u8; 32]>())
 }
 
 // ------------------------------------------------------------------------
@@ -690,11 +694,6 @@ pub fn make_public_subkey(pkey: &PublicKey, seed: &[u8]) -> PublicSubKey {
 pub struct RVal(G2);
 
 impl RVal {
-    // TODO: new() should be removed later, just here for testing for now
-    pub fn new() -> RVal {
-        RVal(G2::new())
-    }
-
     pub fn base_vector(&self) -> &[u8] {
         self.0.base_vector()
     }

--- a/examples/curve1174.rs
+++ b/examples/curve1174.rs
@@ -37,13 +37,12 @@
 extern crate stegos_crypto;
 
 use stegos_crypto::curve1174::*;
-
-extern crate lazy_static;
-// use lazy_static::*;
-
-extern crate hex;
+use stegos_crypto::hash::*;
 
 // -------------------------------------------------------------------------------
 fn main() {
     curve1174_tests();
+    let hv = Hash::from_vector(b"1FE9AB");
+    let hs = Hash::from_str("1FE9AB");
+    assert_eq!(hv, hs);
 }


### PR DESCRIPTION
All modules now use the ThreadRng thread-local PRNG, which is (according to docs) a crypto-safe PRNG, seeded from entropy

create function Hash::from_hash_facsimile_str() to allow importing hash values from constant strings
Hash::from_str() is solely for the purpose of hashing arbitrary strings, akin to Hash::from_vector() for u8 vectors.
get things running unit tests properly again...