### PR TITLE
change name to from_hex()

### DIFF
--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -66,20 +66,17 @@ pub fn genesis_dev() -> (Block, Vec<MerklePath>) {
 
     // Fool-proof checks.
     static PREVIOUS_HEX: &str = "daeed6308874de11ec5ba896aff636aee60821b397f88164be3eae5cf6d276d8";
-    static SKEY_HEX: &str = "daeed6308874de11ec5ba896aff636aee60821b397f88164be3eae5cf6d276d8";
-    static PKEY_HEX: &str = "bd2f2d45a439eafb3523216a652344883b3930f634a8c6e72eda55ff1f8670f9c90f139d9f9a486c6def760d2ff4e74d1f468c848c9774e63cdd0d46917eefe401";
-    static SIG_HEX: &str = "901fc4370d2b19da0c4663ab4394d3e3cb74fdca7fc0ed7c8a8f0db3d2bff7d200";
+    static SKEY_HEX: &str = "104305c39c7f664feb4ac92c10b898eb8854645454640025732c9de7902e790e";
+    static PKEY_HEX: &str = "b05872990364a0bd71087ce252732e1b4370beb78e9f94aa8415c412aafb4142689043c1832e0df0fff3c10eb845dbf80b0621fd373fe2d2f3402cf56574cf8c00";
+    static SIG_HEX: &str = "f28cde3684e3176a72203c2231615eae825bd691c04ff1a44bb3f283414b3b1701";
     // static DELTA_HEX: &str = "3987487567fa7d862b5890ba4b288efc486298ba";
     // static HASH_HEX: &str = "3334d1466924068a65de9be925059ab9ee8866f62db9432d502edd7252b483ea";
-    assert_eq!(
-        previous,
-        Hash::from_hash_facsimile_str(PREVIOUS_HEX).expect("hex")
-    );
+    assert_eq!(previous, Hash::from_hex(PREVIOUS_HEX).expect("hex"));
     assert_eq!(skey, SecretKey::from_str(SKEY_HEX).expect("hex"));
     assert_eq!(pkey, PublicKey::from_str(PKEY_HEX).expect("hex"));
     assert_eq!(sig, Signature::from_str(SIG_HEX).expect("hex"));
     // assert_eq!(delta, Zr::from_str(DELTA_HEX).expect("hex"));
-    // assert_eq!(block.header.hash, Hash::from_str(HASH_HEX).expect("hex"));
+    // assert_eq!(block.header.hash, Hash::from_hex(HASH_HEX).expect("hex"));
 
     (block, paths)
 }

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -102,7 +102,7 @@ lazy_static! {
         GEN_Y.hash(&mut state);
         format!("D{} H{}", CURVE_D, CURVE_H).hash(&mut state);
         let h = state.result();
-        let chk = Hash::from_hash_facsimile_str(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
+        let chk = Hash::from_hex(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
         assert!(h == chk, "Invalid curve constants checksum");
         check_prng();
         true
@@ -258,7 +258,7 @@ mod tests {
         use pbc::secure;
         let sig_pkey = secure::PublicKey::from_str(&SIG_PKEY).expect("Invalid hexstr: SIG_PKEY");
         let sig = secure::Signature::from_str(&SIG_1174).expect("Invalid hexstr: SIG_1174");
-        let h = Hash::from_hash_facsimile_str(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
+        let h = Hash::from_hex(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
         assert!(
             secure::check_hash(&h, &sig, &sig_pkey),
             "Invalid Curve1174 init constants"
@@ -278,6 +278,16 @@ mod tests {
         let dmsg = aes_decrypt(&payload, &skey).unwrap();
         let dchk = Hash::from_vector(&dmsg);
         assert!(mchk == dchk, "AES Decryption failed");
+    }
+
+    #[test]
+    fn chk_random() {
+        let x1 = Fr::random();
+        let x2 = Fr::random();
+        assert!(
+            x1 != x2,
+            "Random generator not working in the expected manner"
+        );
     }
 }
 
@@ -353,7 +363,7 @@ pub fn curve1174_tests() {
 
     let delta_skey = SecretKey::from(Fr::from(skey) + delta);
 
-    let hmsg = Hash::from_hash_facsimile_str(&HASH_CONSTS).unwrap();
+    let hmsg = Hash::from_hex(&HASH_CONSTS).unwrap();
     let sig = sign_hash(&hmsg, &skey);
     println!("sig = (u: {}, K: {})", sig.u, sig.K);
 

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -47,7 +47,7 @@ impl Hash {
         self.0
     }
 
-    pub fn from_hash_facsimile_str(hexstr: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_hex(hexstr: &str) -> Result<Self, hex::FromHexError> {
         // use this function to import a Hash digest facsimile from a string constant
         let mut v = [0u8; HASH_SIZE];
         hexstr_to_bev_u8(hexstr, &mut v)?;

--- a/crypto/src/keying/mod.rs
+++ b/crypto/src/keying/mod.rs
@@ -1,0 +1,300 @@
+//! Keying - Key Generation from Word Lists
+
+//
+// Copyright (c) 2018 Stegos
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+const WORDLIST: [&str; 2048] = [
+    "abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd",
+    "abuse", "access", "accident", "account", "accuse", "achieve", "acid", "acoustic", "acquire",
+    "across", "act", "action", "actor", "actress", "actual", "adapt", "add", "addict", "address",
+    "adjust", "admit", "adult", "advance", "advice", "aerobic", "affair", "afford", "afraid",
+    "again", "age", "agent", "agree", "ahead", "aim", "air", "airport", "aisle", "alarm", "album",
+    "alcohol", "alert", "alien", "all", "alley", "allow", "almost", "alone", "alpha", "already",
+    "also", "alter", "always", "amateur", "amazing", "among", "amount", "amused", "analyst",
+    "anchor", "ancient", "anger", "angle", "angry", "animal", "ankle", "announce", "annual",
+    "another", "answer", "antenna", "antique", "anxiety", "any", "apart", "apology", "appear",
+    "apple", "approve", "april", "arch", "arctic", "area", "arena", "argue", "arm", "armed",
+    "armor", "army", "around", "arrange", "arrest", "arrive", "arrow", "art", "artefact", "artist",
+    "artwork", "ask", "aspect", "assault", "asset", "assist", "assume", "asthma", "athlete",
+    "atom", "attack", "attend", "attitude", "attract", "auction", "audit", "august", "aunt",
+    "author", "auto", "autumn", "average", "avocado", "avoid", "awake", "aware", "away", "awesome",
+    "awful", "awkward", "axis", "baby", "bachelor", "bacon", "badge", "bag", "balance", "balcony",
+    "ball", "bamboo", "banana", "banner", "bar", "barely", "bargain", "barrel", "base", "basic",
+    "basket", "battle", "beach", "bean", "beauty", "because", "become", "beef", "before", "begin",
+    "behave", "behind", "believe", "below", "belt", "bench", "benefit", "best", "betray", "better",
+    "between", "beyond", "bicycle", "bid", "bike", "bind", "biology", "bird", "birth", "bitter",
+    "black", "blade", "blame", "blanket", "blast", "bleak", "bless", "blind", "blood", "blossom",
+    "blouse", "blue", "blur", "blush", "board", "boat", "body", "boil", "bomb", "bone", "bonus",
+    "book", "boost", "border", "boring", "borrow", "boss", "bottom", "bounce", "box", "boy",
+    "bracket", "brain", "brand", "brass", "brave", "bread", "breeze", "brick", "bridge", "brief",
+    "bright", "bring", "brisk", "broccoli", "broken", "bronze", "broom", "brother", "brown",
+    "brush", "bubble", "buddy", "budget", "buffalo", "build", "bulb", "bulk", "bullet", "bundle",
+    "bunker", "burden", "burger", "burst", "bus", "business", "busy", "butter", "buyer", "buzz",
+    "cabbage", "cabin", "cable", "cactus", "cage", "cake", "call", "calm", "camera", "camp", "can",
+    "canal", "cancel", "candy", "cannon", "canoe", "canvas", "canyon", "capable", "capital",
+    "captain", "car", "carbon", "card", "cargo", "carpet", "carry", "cart", "case", "cash",
+    "casino", "castle", "casual", "cat", "catalog", "catch", "category", "cattle", "caught",
+    "cause", "caution", "cave", "ceiling", "celery", "cement", "census", "century", "cereal",
+    "certain", "chair", "chalk", "champion", "change", "chaos", "chapter", "charge", "chase",
+    "chat", "cheap", "check", "cheese", "chef", "cherry", "chest", "chicken", "chief", "child",
+    "chimney", "choice", "choose", "chronic", "chuckle", "chunk", "churn", "cigar", "cinnamon",
+    "circle", "citizen", "city", "civil", "claim", "clap", "clarify", "claw", "clay", "clean",
+    "clerk", "clever", "click", "client", "cliff", "climb", "clinic", "clip", "clock", "clog",
+    "close", "cloth", "cloud", "clown", "club", "clump", "cluster", "clutch", "coach", "coast",
+    "coconut", "code", "coffee", "coil", "coin", "collect", "color", "column", "combine", "come",
+    "comfort", "comic", "common", "company", "concert", "conduct", "confirm", "congress",
+    "connect", "consider", "control", "convince", "cook", "cool", "copper", "copy", "coral",
+    "core", "corn", "correct", "cost", "cotton", "couch", "country", "couple", "course", "cousin",
+    "cover", "coyote", "crack", "cradle", "craft", "cram", "crane", "crash", "crater", "crawl",
+    "crazy", "cream", "credit", "creek", "crew", "cricket", "crime", "crisp", "critic", "crop",
+    "cross", "crouch", "crowd", "crucial", "cruel", "cruise", "crumble", "crunch", "crush", "cry",
+    "crystal", "cube", "culture", "cup", "cupboard", "curious", "current", "curtain", "curve",
+    "cushion", "custom", "cute", "cycle", "dad", "damage", "damp", "dance", "danger", "daring",
+    "dash", "daughter", "dawn", "day", "deal", "debate", "debris", "decade", "december", "decide",
+    "decline", "decorate", "decrease", "deer", "defense", "define", "defy", "degree", "delay",
+    "deliver", "demand", "demise", "denial", "dentist", "deny", "depart", "depend", "deposit",
+    "depth", "deputy", "derive", "describe", "desert", "design", "desk", "despair", "destroy",
+    "detail", "detect", "develop", "device", "devote", "diagram", "dial", "diamond", "diary",
+    "dice", "diesel", "diet", "differ", "digital", "dignity", "dilemma", "dinner", "dinosaur",
+    "direct", "dirt", "disagree", "discover", "disease", "dish", "dismiss", "disorder", "display",
+    "distance", "divert", "divide", "divorce", "dizzy", "doctor", "document", "dog", "doll",
+    "dolphin", "domain", "donate", "donkey", "donor", "door", "dose", "double", "dove", "draft",
+    "dragon", "drama", "drastic", "draw", "dream", "dress", "drift", "drill", "drink", "drip",
+    "drive", "drop", "drum", "dry", "duck", "dumb", "dune", "during", "dust", "dutch", "duty",
+    "dwarf", "dynamic", "eager", "eagle", "early", "earn", "earth", "easily", "east", "easy",
+    "echo", "ecology", "economy", "edge", "edit", "educate", "effort", "egg", "eight", "either",
+    "elbow", "elder", "electric", "elegant", "element", "elephant", "elevator", "elite", "else",
+    "embark", "embody", "embrace", "emerge", "emotion", "employ", "empower", "empty", "enable",
+    "enact", "end", "endless", "endorse", "enemy", "energy", "enforce", "engage", "engine",
+    "enhance", "enjoy", "enlist", "enough", "enrich", "enroll", "ensure", "enter", "entire",
+    "entry", "envelope", "episode", "equal", "equip", "era", "erase", "erode", "erosion", "error",
+    "erupt", "escape", "essay", "essence", "estate", "eternal", "ethics", "evidence", "evil",
+    "evoke", "evolve", "exact", "example", "excess", "exchange", "excite", "exclude", "excuse",
+    "execute", "exercise", "exhaust", "exhibit", "exile", "exist", "exit", "exotic", "expand",
+    "expect", "expire", "explain", "expose", "express", "extend", "extra", "eye", "eyebrow",
+    "fabric", "face", "faculty", "fade", "faint", "faith", "fall", "false", "fame", "family",
+    "famous", "fan", "fancy", "fantasy", "farm", "fashion", "fat", "fatal", "father", "fatigue",
+    "fault", "favorite", "feature", "february", "federal", "fee", "feed", "feel", "female",
+    "fence", "festival", "fetch", "fever", "few", "fiber", "fiction", "field", "figure", "file",
+    "film", "filter", "final", "find", "fine", "finger", "finish", "fire", "firm", "first",
+    "fiscal", "fish", "fit", "fitness", "fix", "flag", "flame", "flash", "flat", "flavor", "flee",
+    "flight", "flip", "float", "flock", "floor", "flower", "fluid", "flush", "fly", "foam",
+    "focus", "fog", "foil", "fold", "follow", "food", "foot", "force", "forest", "forget", "fork",
+    "fortune", "forum", "forward", "fossil", "foster", "found", "fox", "fragile", "frame",
+    "frequent", "fresh", "friend", "fringe", "frog", "front", "frost", "frown", "frozen", "fruit",
+    "fuel", "fun", "funny", "furnace", "fury", "future", "gadget", "gain", "galaxy", "gallery",
+    "game", "gap", "garage", "garbage", "garden", "garlic", "garment", "gas", "gasp", "gate",
+    "gather", "gauge", "gaze", "general", "genius", "genre", "gentle", "genuine", "gesture",
+    "ghost", "giant", "gift", "giggle", "ginger", "giraffe", "girl", "give", "glad", "glance",
+    "glare", "glass", "glide", "glimpse", "globe", "gloom", "glory", "glove", "glow", "glue",
+    "goat", "goddess", "gold", "good", "goose", "gorilla", "gospel", "gossip", "govern", "gown",
+    "grab", "grace", "grain", "grant", "grape", "grass", "gravity", "great", "green", "grid",
+    "grief", "grit", "grocery", "group", "grow", "grunt", "guard", "guess", "guide", "guilt",
+    "guitar", "gun", "gym", "habit", "hair", "half", "hammer", "hamster", "hand", "happy",
+    "harbor", "hard", "harsh", "harvest", "hat", "have", "hawk", "hazard", "head", "health",
+    "heart", "heavy", "hedgehog", "height", "hello", "helmet", "help", "hen", "hero", "hidden",
+    "high", "hill", "hint", "hip", "hire", "history", "hobby", "hockey", "hold", "hole", "holiday",
+    "hollow", "home", "honey", "hood", "hope", "horn", "horror", "horse", "hospital", "host",
+    "hotel", "hour", "hover", "hub", "huge", "human", "humble", "humor", "hundred", "hungry",
+    "hunt", "hurdle", "hurry", "hurt", "husband", "hybrid", "ice", "icon", "idea", "identify",
+    "idle", "ignore", "ill", "illegal", "illness", "image", "imitate", "immense", "immune",
+    "impact", "impose", "improve", "impulse", "inch", "include", "income", "increase", "index",
+    "indicate", "indoor", "industry", "infant", "inflict", "inform", "inhale", "inherit",
+    "initial", "inject", "injury", "inmate", "inner", "innocent", "input", "inquiry", "insane",
+    "insect", "inside", "inspire", "install", "intact", "interest", "into", "invest", "invite",
+    "involve", "iron", "island", "isolate", "issue", "item", "ivory", "jacket", "jaguar", "jar",
+    "jazz", "jealous", "jeans", "jelly", "jewel", "job", "join", "joke", "journey", "joy", "judge",
+    "juice", "jump", "jungle", "junior", "junk", "just", "kangaroo", "keen", "keep", "ketchup",
+    "key", "kick", "kid", "kidney", "kind", "kingdom", "kiss", "kit", "kitchen", "kite", "kitten",
+    "kiwi", "knee", "knife", "knock", "know", "lab", "label", "labor", "ladder", "lady", "lake",
+    "lamp", "language", "laptop", "large", "later", "latin", "laugh", "laundry", "lava", "law",
+    "lawn", "lawsuit", "layer", "lazy", "leader", "leaf", "learn", "leave", "lecture", "left",
+    "leg", "legal", "legend", "leisure", "lemon", "lend", "length", "lens", "leopard", "lesson",
+    "letter", "level", "liar", "liberty", "library", "license", "life", "lift", "light", "like",
+    "limb", "limit", "link", "lion", "liquid", "list", "little", "live", "lizard", "load", "loan",
+    "lobster", "local", "lock", "logic", "lonely", "long", "loop", "lottery", "loud", "lounge",
+    "love", "loyal", "lucky", "luggage", "lumber", "lunar", "lunch", "luxury", "lyrics", "machine",
+    "mad", "magic", "magnet", "maid", "mail", "main", "major", "make", "mammal", "man", "manage",
+    "mandate", "mango", "mansion", "manual", "maple", "marble", "march", "margin", "marine",
+    "market", "marriage", "mask", "mass", "master", "match", "material", "math", "matrix",
+    "matter", "maximum", "maze", "meadow", "mean", "measure", "meat", "mechanic", "medal", "media",
+    "melody", "melt", "member", "memory", "mention", "menu", "mercy", "merge", "merit", "merry",
+    "mesh", "message", "metal", "method", "middle", "midnight", "milk", "million", "mimic", "mind",
+    "minimum", "minor", "minute", "miracle", "mirror", "misery", "miss", "mistake", "mix", "mixed",
+    "mixture", "mobile", "model", "modify", "mom", "moment", "monitor", "monkey", "monster",
+    "month", "moon", "moral", "more", "morning", "mosquito", "mother", "motion", "motor",
+    "mountain", "mouse", "move", "movie", "much", "muffin", "mule", "multiply", "muscle", "museum",
+    "mushroom", "music", "must", "mutual", "myself", "mystery", "myth", "naive", "name", "napkin",
+    "narrow", "nasty", "nation", "nature", "near", "neck", "need", "negative", "neglect",
+    "neither", "nephew", "nerve", "nest", "net", "network", "neutral", "never", "news", "next",
+    "nice", "night", "noble", "noise", "nominee", "noodle", "normal", "north", "nose", "notable",
+    "note", "nothing", "notice", "novel", "now", "nuclear", "number", "nurse", "nut", "oak",
+    "obey", "object", "oblige", "obscure", "observe", "obtain", "obvious", "occur", "ocean",
+    "october", "odor", "off", "offer", "office", "often", "oil", "okay", "old", "olive", "olympic",
+    "omit", "once", "one", "onion", "online", "only", "open", "opera", "opinion", "oppose",
+    "option", "orange", "orbit", "orchard", "order", "ordinary", "organ", "orient", "original",
+    "orphan", "ostrich", "other", "outdoor", "outer", "output", "outside", "oval", "oven", "over",
+    "own", "owner", "oxygen", "oyster", "ozone", "pact", "paddle", "page", "pair", "palace",
+    "palm", "panda", "panel", "panic", "panther", "paper", "parade", "parent", "park", "parrot",
+    "party", "pass", "patch", "path", "patient", "patrol", "pattern", "pause", "pave", "payment",
+    "peace", "peanut", "pear", "peasant", "pelican", "pen", "penalty", "pencil", "people",
+    "pepper", "perfect", "permit", "person", "pet", "phone", "photo", "phrase", "physical",
+    "piano", "picnic", "picture", "piece", "pig", "pigeon", "pill", "pilot", "pink", "pioneer",
+    "pipe", "pistol", "pitch", "pizza", "place", "planet", "plastic", "plate", "play", "please",
+    "pledge", "pluck", "plug", "plunge", "poem", "poet", "point", "polar", "pole", "police",
+    "pond", "pony", "pool", "popular", "portion", "position", "possible", "post", "potato",
+    "pottery", "poverty", "powder", "power", "practice", "praise", "predict", "prefer", "prepare",
+    "present", "pretty", "prevent", "price", "pride", "primary", "print", "priority", "prison",
+    "private", "prize", "problem", "process", "produce", "profit", "program", "project", "promote",
+    "proof", "property", "prosper", "protect", "proud", "provide", "public", "pudding", "pull",
+    "pulp", "pulse", "pumpkin", "punch", "pupil", "puppy", "purchase", "purity", "purpose",
+    "purse", "push", "put", "puzzle", "pyramid", "quality", "quantum", "quarter", "question",
+    "quick", "quit", "quiz", "quote", "rabbit", "raccoon", "race", "rack", "radar", "radio",
+    "rail", "rain", "raise", "rally", "ramp", "ranch", "random", "range", "rapid", "rare", "rate",
+    "rather", "raven", "raw", "razor", "ready", "real", "reason", "rebel", "rebuild", "recall",
+    "receive", "recipe", "record", "recycle", "reduce", "reflect", "reform", "refuse", "region",
+    "regret", "regular", "reject", "relax", "release", "relief", "rely", "remain", "remember",
+    "remind", "remove", "render", "renew", "rent", "reopen", "repair", "repeat", "replace",
+    "report", "require", "rescue", "resemble", "resist", "resource", "response", "result",
+    "retire", "retreat", "return", "reunion", "reveal", "review", "reward", "rhythm", "rib",
+    "ribbon", "rice", "rich", "ride", "ridge", "rifle", "right", "rigid", "ring", "riot", "ripple",
+    "risk", "ritual", "rival", "river", "road", "roast", "robot", "robust", "rocket", "romance",
+    "roof", "rookie", "room", "rose", "rotate", "rough", "round", "route", "royal", "rubber",
+    "rude", "rug", "rule", "run", "runway", "rural", "sad", "saddle", "sadness", "safe", "sail",
+    "salad", "salmon", "salon", "salt", "salute", "same", "sample", "sand", "satisfy", "satoshi",
+    "sauce", "sausage", "save", "say", "scale", "scan", "scare", "scatter", "scene", "scheme",
+    "school", "science", "scissors", "scorpion", "scout", "scrap", "screen", "script", "scrub",
+    "sea", "search", "season", "seat", "second", "secret", "section", "security", "seed", "seek",
+    "segment", "select", "sell", "seminar", "senior", "sense", "sentence", "series", "service",
+    "session", "settle", "setup", "seven", "shadow", "shaft", "shallow", "share", "shed", "shell",
+    "sheriff", "shield", "shift", "shine", "ship", "shiver", "shock", "shoe", "shoot", "shop",
+    "short", "shoulder", "shove", "shrimp", "shrug", "shuffle", "shy", "sibling", "sick", "side",
+    "siege", "sight", "sign", "silent", "silk", "silly", "silver", "similar", "simple", "since",
+    "sing", "siren", "sister", "situate", "six", "size", "skate", "sketch", "ski", "skill", "skin",
+    "skirt", "skull", "slab", "slam", "sleep", "slender", "slice", "slide", "slight", "slim",
+    "slogan", "slot", "slow", "slush", "small", "smart", "smile", "smoke", "smooth", "snack",
+    "snake", "snap", "sniff", "snow", "soap", "soccer", "social", "sock", "soda", "soft", "solar",
+    "soldier", "solid", "solution", "solve", "someone", "song", "soon", "sorry", "sort", "soul",
+    "sound", "soup", "source", "south", "space", "spare", "spatial", "spawn", "speak", "special",
+    "speed", "spell", "spend", "sphere", "spice", "spider", "spike", "spin", "spirit", "split",
+    "spoil", "sponsor", "spoon", "sport", "spot", "spray", "spread", "spring", "spy", "square",
+    "squeeze", "squirrel", "stable", "stadium", "staff", "stage", "stairs", "stamp", "stand",
+    "start", "state", "stay", "steak", "steel", "stem", "step", "stereo", "stick", "still",
+    "sting", "stock", "stomach", "stone", "stool", "story", "stove", "strategy", "street",
+    "strike", "strong", "struggle", "student", "stuff", "stumble", "style", "subject", "submit",
+    "subway", "success", "such", "sudden", "suffer", "sugar", "suggest", "suit", "summer", "sun",
+    "sunny", "sunset", "super", "supply", "supreme", "sure", "surface", "surge", "surprise",
+    "surround", "survey", "suspect", "sustain", "swallow", "swamp", "swap", "swarm", "swear",
+    "sweet", "swift", "swim", "swing", "switch", "sword", "symbol", "symptom", "syrup", "system",
+    "table", "tackle", "tag", "tail", "talent", "talk", "tank", "tape", "target", "task", "taste",
+    "tattoo", "taxi", "teach", "team", "tell", "ten", "tenant", "tennis", "tent", "term", "test",
+    "text", "thank", "that", "theme", "then", "theory", "there", "they", "thing", "this",
+    "thought", "three", "thrive", "throw", "thumb", "thunder", "ticket", "tide", "tiger", "tilt",
+    "timber", "time", "tiny", "tip", "tired", "tissue", "title", "toast", "tobacco", "today",
+    "toddler", "toe", "together", "toilet", "token", "tomato", "tomorrow", "tone", "tongue",
+    "tonight", "tool", "tooth", "top", "topic", "topple", "torch", "tornado", "tortoise", "toss",
+    "total", "tourist", "toward", "tower", "town", "toy", "track", "trade", "traffic", "tragic",
+    "train", "transfer", "trap", "trash", "travel", "tray", "treat", "tree", "trend", "trial",
+    "tribe", "trick", "trigger", "trim", "trip", "trophy", "trouble", "truck", "true", "truly",
+    "trumpet", "trust", "truth", "try", "tube", "tuition", "tumble", "tuna", "tunnel", "turkey",
+    "turn", "turtle", "twelve", "twenty", "twice", "twin", "twist", "two", "type", "typical",
+    "ugly", "umbrella", "unable", "unaware", "uncle", "uncover", "under", "undo", "unfair",
+    "unfold", "unhappy", "uniform", "unique", "unit", "universe", "unknown", "unlock", "until",
+    "unusual", "unveil", "update", "upgrade", "uphold", "upon", "upper", "upset", "urban", "urge",
+    "usage", "use", "used", "useful", "useless", "usual", "utility", "vacant", "vacuum", "vague",
+    "valid", "valley", "valve", "van", "vanish", "vapor", "various", "vast", "vault", "vehicle",
+    "velvet", "vendor", "venture", "venue", "verb", "verify", "version", "very", "vessel",
+    "veteran", "viable", "vibrant", "vicious", "victory", "video", "view", "village", "vintage",
+    "violin", "virtual", "virus", "visa", "visit", "visual", "vital", "vivid", "vocal", "voice",
+    "void", "volcano", "volume", "vote", "voyage", "wage", "wagon", "wait", "walk", "wall",
+    "walnut", "want", "warfare", "warm", "warrior", "wash", "wasp", "waste", "water", "wave",
+    "way", "wealth", "weapon", "wear", "weasel", "weather", "web", "wedding", "weekend", "weird",
+    "welcome", "west", "wet", "whale", "what", "wheat", "wheel", "when", "where", "whip",
+    "whisper", "wide", "width", "wife", "wild", "will", "win", "window", "wine", "wing", "wink",
+    "winner", "winter", "wire", "wisdom", "wise", "wish", "witness", "wolf", "woman", "wonder",
+    "wood", "wool", "word", "work", "world", "worry", "worth", "wrap", "wreck", "wrestle", "wrist",
+    "write", "wrong", "yard", "year", "yellow", "you", "young", "youth", "zebra", "zero", "zone",
+    "zoo",
+];
+
+fn get_11_bits(vec: &[u8; 33], ix: usize) -> usize {
+    let bit = ix * 11;
+    let byt = bit >> 3;
+    let start = bit - (byt << 3);
+    match start {
+        0..=5 => {
+            let x = ((vec[byt] as u16) << 8) | (vec[byt + 1] as u16);
+            ((x >> (5 - start)) & 0x7ff) as usize
+        }
+        _ => {
+            let x =
+                ((vec[byt] as u32) << 16) | ((vec[byt + 1] as u32) << 8) | (vec[byt + 2] as u32);
+            (((x >> (6 + (7 - start))) as u16) & 0x7ff) as usize
+        }
+    }
+}
+
+fn put_11_bits(vec: &mut [u8; 33], ix: usize, val: usize) {
+    let bit = ix * 11;
+    let byt = bit >> 3;
+    let start = bit - (byt << 3);
+    match start {
+        0..=5 => {
+            let x = ((vec[byt] as u16) << 8) | (vec[byt + 1] as u16);
+            let nsh = 5 - start;
+            let mask = 0xffff ^ (0x7ff << nsh);
+            let z = (x & mask) | ((val << nsh) as u16);
+            vec[byt] = (z >> 8) as u8;
+            vec[byt + 1] = z as u8;
+        }
+        _ => {
+            let x =
+                ((vec[byt] as u32) << 16) | ((vec[byt + 1] as u32) << 8) | (vec[byt + 2] as u32);
+            let nsh = 6 + (7 - start);
+            let mask = 0xffff_ffff ^ (0x7ff << nsh);
+            let z = (x & mask) | ((val << nsh) as u32);
+            vec[byt] = (z >> 16) as u8;
+            vec[byt + 1] = (z >> 8) as u8;
+            vec[byt + 2] = z as u8;
+        }
+    }
+}
+
+pub fn convert_int_to_wordlist(val: &[u8; 33]) -> [&str; 24] {
+    // convert a 264-bit bignum, in big-endian order, to a list of 24 words.
+    // Each word represents an 11-bit field.
+    let mut ans = [""; 24];
+    for ix in 0..24 {
+        ans[ix] = WORDLIST[get_11_bits(val, ix)];
+    }
+    ans
+}
+
+pub fn convert_wordlist_to_int(lst: &[&str; 24], val: &mut [u8; 33]) -> Result<(), usize> {
+    for ix in 0..24 {
+        let pos = WORDLIST.binary_search(&lst[ix])?;
+        put_11_bits(val, ix, pos);
+    }
+    Ok(())
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -33,5 +33,6 @@ extern crate typenum;
 pub mod bulletproofs;
 pub mod curve1174;
 pub mod hash;
+pub mod keying;
 pub mod pbc;
 pub mod utils;

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -184,7 +184,7 @@ fn private_init_pairings(
     g1.hash(&mut state);
     g2.hash(&mut state);
     let h = state.result();
-    let chk = Hash::from_hash_facsimile_str(hchk).expect("Invalid check hash");
+    let chk = Hash::from_hex(hchk).expect("Invalid check hash");
     assert!(h == chk, "Init constants have changed");
 
     // yes - all the assert!() should panic fail. We are useless without PBC.
@@ -253,14 +253,14 @@ pub mod tests {
 
         let sig_pkey = secure::PublicKey::from_str(&SIG_PKEY).expect("Invalid hexstring: SIG_PKEY");
 
-        let h = Hash::from_hash_facsimile_str(&HASH_AR160).expect("Invalid hexstring: HASH_AR160");
+        let h = Hash::from_hex(&HASH_AR160).expect("Invalid hexstring: HASH_AR160");
         let sig = secure::Signature::from_str(&SIG_AR160).expect("Invalid hexstring: SIG_AR160");
         assert!(
             secure::check_hash(&h, &sig, &sig_pkey),
             "Invalid curve constants for AR160"
         );
 
-        let h = Hash::from_hash_facsimile_str(&HASH_FR256).expect("Invalid hexstring: HASH_FR256");
+        let h = Hash::from_hex(&HASH_FR256).expect("Invalid hexstring: HASH_FR256");
         let sig = secure::Signature::from_str(SIG_FR256).expect("Invalid hexstring: SIG_FR256");
         assert!(
             secure::check_hash(&h, &sig, &sig_pkey),

--- a/examples/curve1174.rs
+++ b/examples/curve1174.rs
@@ -34,10 +34,17 @@
 //!
 //! -----------------------------------------------------------------------------
 
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+extern crate rand;
 extern crate stegos_crypto;
 
+use rand::thread_rng;
+use rand::{Rng, ThreadRng};
 use stegos_crypto::curve1174::*;
 use stegos_crypto::hash::*;
+use stegos_crypto::keying::*;
 
 // -------------------------------------------------------------------------------
 fn main() {
@@ -45,4 +52,23 @@ fn main() {
     let hv = Hash::from_vector(b"1FE9AB");
     let hs = Hash::from_str("1FE9AB");
     assert_eq!(hv, hs);
+
+    //  let mut rng: ThreadRng = thread_rng();
+    let mut x = [0u8; 33];
+    for ix in 0..33 {
+        let v = rand::random::<u8>();
+        println!("{:x}", v);
+        x[ix] = v;
+    }
+    println!("----");
+    // println!("x = {:#?}", x);
+    let lst = convert_int_to_wordlist(&x);
+    for w in lst.iter() {
+        println!("{}", w);
+    }
+    let mut xx = [0u8; 33];
+    convert_wordlist_to_int(&lst, &mut xx);
+    for ix in 0..33 {
+        assert!(x[ix] == xx[ix], "Mismatch on wordlist conversion");
+    }
 }

--- a/examples/pbc.rs
+++ b/examples/pbc.rs
@@ -64,4 +64,9 @@ fn main() {
     println!("chk Zr: 0x{:x} -> {}", a, fast::Zr::from(a));
     println!("chk Zr: -1 -> {}", fast::Zr::from(-1));
     println!("chk Zr: -1 + 1 -> {}", fast::Zr::from(-1) + 1);
+
+    let (skey, pkey, sig) = secure::make_deterministic_keys(b"dev");
+    println!("skey = {}", skey);
+    println!("pkey = {}", pkey);
+    println!("sig = {}", sig);
 }


### PR DESCRIPTION
patch up to use from_hex()

make PBC abide by synthetic_random for choosing keys

add unit test to verify that PRNG is not being re-init on each call to functions that use thread_rng()

Add keying module to crypto lib - this will handle conversions to/from keys and wordlists

Add wordlist to/from bignum support