### PR TITLE
Refactor network code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,8 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2109,12 +2111,18 @@ dependencies = [
 name = "stegos_randhound"
 version = "0.1.0"
 dependencies = [
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_crypto 0.1.0",
+ "stegos_network 0.1.0",
+ "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ tokio-timer = "0.2.7"
 tokio = "0.1.11"
 unsigned-varint = "0.2.1"
 log = "0.4.5"
+failure = "0.1.2"
+failure_derive = "0.1.2"
 
 rust-libpbc = { git = "https://github.com/stegos/rust-pbcintf.git" }
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "e179951c74cb0c8916d27329f2dfd78917dddfb2" }

--- a/randhound/Cargo.toml
+++ b/randhound/Cargo.toml
@@ -5,9 +5,15 @@ authors = ["Stegos AG <info@stegos.cc>"]
 
 [dependencies]
 stegos_crypto = { path = "../crypto" }
+stegos_network = { path = "../network" }
 generic-array = "0.12.0"
 hex = "0.3.2"
 lazy_static = "1.1.0"
 parking_lot = "0.6.4"
 rand = "0.5"
 typenum = "1.10.0"
+futures = "0.1.25"
+tokio = "0.1.11"
+tokio-timer = "0.2.7"
+failure = "0.1.2"
+failure_derive = "0.1.2"

--- a/randhound/src/lib.rs
+++ b/randhound/src/lib.rs
@@ -21,9 +21,128 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+extern crate failure;
+extern crate futures;
 extern crate lazy_static;
 extern crate parking_lot;
 extern crate rand;
 extern crate stegos_crypto;
+extern crate stegos_network;
+extern crate tokio;
+extern crate tokio_timer;
 
-pub mod randhound;
+use failure::Error;
+use futures::{Async, Future, Poll, Stream};
+use std::thread;
+use std::thread::ThreadId;
+use std::time::Duration;
+use stegos_network::Node;
+use tokio::timer::Interval;
+
+mod randhound;
+
+const TOPIC: &'static str = "randhound";
+
+/// RandHound++ network service.
+pub struct RandHoundService {
+    /// Network node
+    node: Node,
+    /// Timer
+    timer: Interval,
+    /// Input Messages.
+    inbox: Box<Stream<Item = Vec<u8>, Error = ()>>,
+    /// Network node id.
+    my_id: String,
+    /// Thread Id (just for debug).
+    thread_id: ThreadId,
+}
+
+impl RandHoundService {
+    /// Send an unicast message to RandHound peer.
+    fn unicast(&self, node_id: &String, data: Vec<u8>) -> Result<(), Error> {
+        self.node.publish(&format!("{}-{}", node_id, TOPIC), data)
+    }
+
+    /// Send a broadcast message to RandHound peer.
+    fn broadcast(&self, data: Vec<u8>) -> Result<(), Error> {
+        self.node.publish(&TOPIC.to_string(), data)
+    }
+
+    /// Called on a new message.
+    fn on_message(&mut self, msg: Vec<u8>) {
+        println!(
+            "randhound: *message: {}*",
+            String::from_utf8_lossy(msg.as_slice())
+        );
+    }
+
+    /// Called on timer event.
+    fn on_timer(&mut self) {
+        // println!("randhound: *timer*");
+        let hello_msg1 = format!("hello from: {} to node01", &self.my_id);
+        let hello_msg2 = format!("hello from: {} to node02", &self.my_id);
+        let hello_msg3 = format!("hello from: {} to node03", &self.my_id);
+        let hello_broadcast = format!("broadcast hello from: {}", &self.my_id);
+
+        self.unicast(&"node01".to_string(), hello_msg1.as_bytes().to_vec())
+            .unwrap();
+        self.unicast(&"node02".to_string(), hello_msg2.as_bytes().to_vec())
+            .unwrap();
+        self.unicast(&"node03".to_string(), hello_msg3.as_bytes().to_vec())
+            .unwrap();
+
+        self.broadcast(hello_broadcast.as_bytes().to_vec()).unwrap();
+    }
+}
+
+/// Tokio boilerplate.
+impl Future for RandHoundService {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        assert_eq!(self.thread_id, thread::current().id());
+
+        // Process incoming messages
+        loop {
+            match self.inbox.poll() {
+                Ok(Async::Ready(Some(msg))) => self.on_message(msg),
+                Ok(Async::Ready(None)) => unreachable!(), // never happens
+                Ok(Async::NotReady) => break,             // fall through
+                Err(()) => panic!("Network failure"),
+            }
+        }
+
+        // Process timer events
+        loop {
+            match self.timer.poll() {
+                Ok(Async::Ready(Some(_instant))) => self.on_timer(),
+                Ok(Async::Ready(None)) => unreachable!(), // never happens
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(e) => panic!("Timer failure: {}", e),
+            };
+        }
+    }
+}
+
+impl RandHoundService {
+    pub fn new(node: Node, my_id: &String, inbox: Box<Stream<Item = Vec<u8>, Error = ()>>) -> Self {
+        let my_id = my_id.clone();
+
+        // Subscribe to unicast topic.
+        node.subscribe(&format!("{}-{}", my_id, TOPIC));
+        // Subscribe to broadcast topic.
+        node.subscribe(&TOPIC.to_string());
+        // Set up timer event.
+        let timer = Interval::new_interval(Duration::from_secs(10));
+
+        let thread_id = thread::current().id();
+        RandHoundService {
+            node,
+            my_id,
+            timer,
+            inbox,
+            thread_id,
+        }
+    }
+}

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2018 Stegos
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use futures::sync::mpsc::UnboundedReceiver;
+use futures::{Async, Future, Poll, Stream};
+use libp2p::Multiaddr;
+use std::mem;
+use std::thread;
+use std::thread::ThreadId;
+use stegos_network::Node;
+use tokio_stdin;
+
+/// Console (stdin) service.
+pub struct ConsoleService {
+    /// Network node.
+    node: Node,
+    /// A channel to receive message from stdin thread.
+    stdin: UnboundedReceiver<u8>,
+    /// Input buffer.
+    buf: Vec<u8>,
+    /// Thread Id (just for debug).
+    thread_id: ThreadId,
+}
+
+impl ConsoleService {
+    fn on_input(&mut self, ch: u8) {
+        if ch != b'\r' && ch != b'\n' {
+            self.buf.push(ch);
+            return;
+        } else if self.buf.is_empty() {
+            return;
+        }
+
+        let msg = String::from_utf8(mem::replace(&mut self.buf, Vec::new())).unwrap();
+        if msg.starts_with("/dial ") {
+            let target: Multiaddr = msg[6..].parse().unwrap();
+            println!("main: *Dialing {}*", target);
+            self.node.dial(target).unwrap();
+        } else if msg.starts_with("/publish ") {
+            let sep_pos = msg[9..].find(' ').unwrap_or(0);
+            let topic: String = msg[9..9 + sep_pos].to_string();
+            let msg: String = msg[9 + sep_pos + 1..].to_string();
+            println!("main: *Publishing to topic '{}': {} *", topic, msg);
+            self.node.publish(&topic, msg.as_bytes().to_vec()).unwrap();
+        } else {
+            eprintln!("Usage:");
+            eprintln!("/dial multiaddr");
+            eprintln!("/publish topic message");
+        }
+    }
+}
+
+impl ConsoleService {
+    /// Constructor.
+    pub fn new(net: Node) -> Self {
+        let stdin = tokio_stdin::spawn_stdin_stream_unbounded();
+        let buf = Vec::<u8>::new();
+        let thread_id = thread::current().id();
+        ConsoleService {
+            node: net,
+            stdin,
+            buf,
+            thread_id,
+        }
+    }
+}
+
+/// Tokio boilerplate.
+impl Future for ConsoleService {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        assert_eq!(self.thread_id, thread::current().id());
+        loop {
+            match self.stdin.poll() {
+                Ok(Async::Ready(Some(ch))) => self.on_input(ch),
+                Ok(Async::Ready(None)) => unreachable!(),
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(()) => panic!(),
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Get rid of closures in main() and use tokio's futures explicitly.
- Extract command line handling into a separate service.
- Remove implicit subscriptions to topics.
- Replace node.send_to_id() with node.publish().
- Implement a stateful service for RandHound++.

Closes #122