### PR TITLE
Use the new syntax to import local submodules

### DIFF
--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -21,8 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use merkle::*;
-use output::Output;
+use crate::merkle::*;
+use crate::output::Output;
 use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
 use stegos_crypto::pbc::secure::PublicKey as WitnessPublicKey;

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -24,10 +24,10 @@
 use std::collections::HashMap;
 use std::vec::Vec;
 
-use block::*;
-use genesis::*;
-use merkle::*;
-use output::*;
+use crate::block::*;
+use crate::genesis::*;
+use crate::merkle::*;
+use crate::output::*;
 use stegos_crypto::hash::*;
 
 type BlockId = usize;

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -21,10 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use block::*;
 use chrono::prelude::{TimeZone, Utc};
-use merkle::MerklePath;
-use output::*;
+use crate::block::*;
+use crate::merkle::MerklePath;
+use crate::output::*;
 use stegos_crypto::curve1174::cpt as wallet_keys;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::pbc::secure as cosi_keys;

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -28,11 +28,11 @@ mod merkle;
 mod output;
 mod transaction;
 
-pub use block::*;
-pub use blockchain::*;
-pub use merkle::*;
-pub use output::*;
-pub use transaction::*;
+pub use crate::block::*;
+pub use crate::blockchain::*;
+pub use crate::merkle::*;
+pub use crate::output::*;
+pub use crate::transaction::*;
 
 extern crate chrono;
 #[macro_use]

--- a/blockchain/src/transaction.rs
+++ b/blockchain/src/transaction.rs
@@ -21,8 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use crate::output::*;
 use failure::Error;
-use output::*;
 use stegos_crypto::curve1174::cpt::{
     sign_hash, validate_sig, Pt, PublicKey, SchnorrSig, SecretKey,
 };

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -31,8 +31,8 @@ extern crate toml;
 
 mod error;
 mod types;
-pub use error::*;
-pub use types::*;
+pub use crate::error::*;
+pub use crate::types::*;
 
 use std::fs::File;
 use std::io::ErrorKind;

--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -35,13 +35,13 @@ use std::mem;
 use hex;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use curve1174::cpt::*;
-use curve1174::ecpt::*;
-use curve1174::fields::*;
-use curve1174::*;
-use hash::*;
+use crate::curve1174::cpt::*;
+use crate::curve1174::ecpt::*;
+use crate::curve1174::fields::*;
+use crate::curve1174::*;
+use crate::hash::*;
+use crate::utils::*;
 use std::cmp::Ordering;
-use utils::*;
 
 use lazy_static::*;
 

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -24,7 +24,7 @@
 
 use super::*;
 
-use utils;
+use crate::utils;
 
 macro_rules! field_impl {
     ($name: ident, $modulus: ident, $rsquared: ident, $rcubed: ident, $one: ident, $inv: ident, $hash: expr, $fmt: expr, $min: ident) => {

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -33,9 +33,9 @@ use std::mem;
 use hex;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use hash::*;
+use crate::hash::*;
+use crate::utils::*;
 use std::cmp::Ordering;
-use utils::*;
 
 mod winvec; // window vectors for point multiplication
 use self::winvec::*;
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn chk_init() {
-        use pbc::secure;
+        use crate::pbc::secure;
         let sig_pkey = secure::PublicKey::from_str(&SIG_PKEY).expect("Invalid hexstr: SIG_PKEY");
         let sig = secure::Signature::from_str(&SIG_1174).expect("Invalid hexstr: SIG_1174");
         let h = Hash::from_hex(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn chk_encryption() {
-        use hash;
+        use crate::hash;
         let (skey, pkey, sig) = make_random_keys();
         check_keying(&pkey, &sig).expect("Random keying failed");
         let msg = hash::hash_nbytes(72, b"This is a test");
@@ -357,7 +357,7 @@ pub fn curve1174_tests() {
     let sig = sign_hash(&hmsg, &skey);
     println!("sig = (u: {}, K: {})", sig.u, sig.K);
 
-    use hash;
+    use crate::hash;
     let msg = hash::hash_nbytes(72, b"This is a test");
     println!("msg = {}", Hash::from_vector(&msg));
     let payload = aes_encrypt(&msg, &pkey).unwrap();

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -21,12 +21,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use crate::utils::*;
 use hex;
 use sha3::{Digest, Sha3_256};
 use std::fmt;
 use std::mem;
 use std::slice;
-use utils::*;
 
 use std::hash as stdhash;
 
@@ -90,8 +90,7 @@ impl Hash {
 
 impl fmt::Debug for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_str());
-        Ok(())
+        write!(f, "{}", self.to_str())
     }
 }
 

--- a/crypto/src/pbc/fast.rs
+++ b/crypto/src/pbc/fast.rs
@@ -40,9 +40,9 @@
 //! --------------------------------------------------------------------------
 
 use super::*;
-use hash::*;
+use crate::hash::*;
+use crate::utils::*;
 use rand::thread_rng;
-use utils::*;
 
 use std::cmp::Ordering;
 use std::hash as stdhash;

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -32,10 +32,10 @@ use rust_libpbc;
 pub mod fast;
 pub mod secure;
 
+use crate::utils::*;
 use hex;
-use utils::*;
 
-use hash::*;
+use crate::hash::*;
 use lazy_static::*;
 
 // -------------------------------------------------------------------

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -31,9 +31,9 @@
 //! --------------------------------------------------------------------------
 
 use super::*;
-use hash::*;
+use crate::hash::*;
+use crate::utils::*;
 use rand::thread_rng;
-use utils::*;
 
 use std::cmp::Ordering;
 use std::hash as stdhash;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -51,7 +51,7 @@ mod ncp;
 mod node;
 mod types;
 
-pub use echo::protocol::{EchoMiddleware, EchoUpgrade};
-pub use ncp::protocol;
-pub use node::broker::BrokerHandler;
-pub use node::Node;
+pub use crate::echo::protocol::{EchoMiddleware, EchoUpgrade};
+pub use crate::ncp::protocol;
+pub use crate::node::broker::BrokerHandler;
+pub use crate::node::Node;

--- a/network/src/ncp/protocol.rs
+++ b/network/src/ncp/protocol.rs
@@ -210,10 +210,10 @@ mod tests {
     extern crate simple_logger;
     extern crate tokio_current_thread;
 
+    use crate::ncp::protocol::{GetPeersResponse, NcpMsg, NcpProtocolConfig, PeerInfo};
     use futures::{Future, Sink, Stream};
     use libp2p::core::{PeerId, PublicKey, Transport};
     use libp2p::tcp::TcpConfig;
-    use ncp::protocol::{GetPeersResponse, NcpMsg, NcpProtocolConfig, PeerInfo};
     use rand;
     use std::sync::mpsc;
     use std::thread;

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -42,7 +42,7 @@ extern crate tokio_stdin;
 extern crate tokio_timer;
 
 use clap::{App, Arg, ArgMatches};
-use console::*;
+use crate::console::*;
 use log::LevelFilter;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config as LogConfig, Logger, Root};


### PR DESCRIPTION
Prepare for Rust 2018 Edition. No semantic changes.