### PR TITLE
Forbid invalid Pt and PublicKeys

### DIFF
--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -25,15 +25,13 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 
+use crate::CryptoError;
 use rand::prelude::*;
-use std::fmt::Debug;
-use std::time::{Duration, SystemTime};
-
 use std::fmt;
+use std::fmt::Debug;
 use std::mem;
-
-use hex;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::time::{Duration, SystemTime};
 
 use crate::curve1174::cpt::*;
 use crate::curve1174::ecpt::*;
@@ -590,8 +588,8 @@ fn basis_vectors(y: Int) -> (Point, BasisVect, BasisVect) {
 // ---------------------------------------------------------------------
 
 pub fn validate_range_proof(bp: &BulletProof) -> bool {
-    fn try_validate_range_proof(bp: &BulletProof) -> Result<bool, CurveError> {
-        fn compute_iter_commit(xlrs: &[LR; L2_NBASIS], init: Point) -> Result<Point, CurveError> {
+    fn try_validate_range_proof(bp: &BulletProof) -> Result<bool, CryptoError> {
+        fn compute_iter_commit(xlrs: &[LR; L2_NBASIS], init: Point) -> Result<Point, CryptoError> {
             let mut sum = init;
             for triple in xlrs.iter().rev() {
                 let x = triple.x.scaled();

--- a/crypto/src/curve1174/fq51.rs
+++ b/crypto/src/curve1174/fq51.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use super::*;
+use crate::CryptoError;
 
 const BOT_51_BITS: i64 = ((1 << 51) - 1); // Fq51 frames contain 51 bits
 const BOT_47_BITS: i64 = ((1 << 47) - 1); // MSB frame only has 47 bits
@@ -533,7 +534,7 @@ pub fn gdec2(x: &mut Fq51) {
 }
 
 #[inline(never)]
-pub fn gsqrt(x: &Fq51) -> Result<Fq51, CurveError> {
+pub fn gsqrt(x: &Fq51) -> Result<Fq51, CryptoError> {
     // we need to perform (x^((q+1)/4) mod q)
     // for (q + 1)/4 = 0x01FF_FFFF_FFFF_FFFF__FFFF_FFFF_FFFF_FFFF__FFFF_FFFF_FFFF_FFFF__FFFF_FFFF_FFFF_FFFE
     //               = 2^(2*(248-1))
@@ -633,7 +634,7 @@ pub fn gsqrt(x: &Fq51) -> Result<Fq51, CurveError> {
     if t1 == *x {
         Ok(w)
     } else {
-        Err(CurveError::NotQuadraticResidue)
+        Err(CryptoError::NotQuadraticResidue)
     }
 }
 
@@ -660,7 +661,7 @@ pub fn bin_to_elt(y: &U256, x: &mut Fq51) {
 }
 
 impl Fq51 {
-    pub fn from_str(s: &str) -> Result<Fq51, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Fq51, CryptoError> {
         let bin = U256::from_str(s)?;
         let mut e = Fq51::zero();
         bin_to_elt(&bin, &mut e);

--- a/crypto/src/curve1174/lev32.rs
+++ b/crypto/src/curve1174/lev32.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use super::*;
+use crate::CryptoError;
 
 // -----------------------------------------------------------------
 // type Lev32 represents a 256-bit bignum as a little-endian 32-byte vector

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -125,18 +125,10 @@ lazy_static! {
     };
     pub static ref G: ECp = {
         assert!(*INIT, "can't happen");
-        let gen_x = Fq::from_str(GEN_X).expect("Invalid Gen X hexstr");
-        let gen_y = Fq::from_str(GEN_Y).expect("Invalid Gen Y hexstr");
+        let gen_x = Fq::try_from_hex(GEN_X).expect("Invalid Gen X hexstr");
+        let gen_y = Fq::try_from_hex(GEN_Y).expect("Invalid Gen Y hexstr");
         ECp::try_from_xy(&gen_x, &gen_y).expect("Invalid generator description")
     };
-}
-
-#[derive(Debug, Fail)]
-pub enum CurveError {
-    #[fail(display = "CurveError::NotQuadraticResidue")]
-    NotQuadraticResidue,
-    #[fail(display = "CurveError::PointNotOnCurve")]
-    PointNotOnCurve,
 }
 
 fn check_prng() {
@@ -207,12 +199,12 @@ mod tests {
         let sx = "037FBB0CEA308C479343AEE7C029A190C021D96A492ECD6516123F27BCE29EDA";
         let sy = "06B72F82D47FB7CC6656841169840E0C4FE2DEE2AF3F976BA4CCB1BF9B46360E";
 
-        let gen_x = Fq::from_str(sx).unwrap();
-        let gen_y = Fq::from_str(sy).unwrap();
+        let gen_x = Fq::try_from_hex(sx).unwrap();
+        let gen_y = Fq::try_from_hex(sy).unwrap();
         let pt1 = ECp::try_from_xy(&gen_x, &gen_y).unwrap();
 
-        let gx = Fq::from_str(&sx).unwrap();
-        let gy = Fq::from_str(&sy).unwrap();
+        let gx = Fq::try_from_hex(&sx).unwrap();
+        let gy = Fq::try_from_hex(&sy).unwrap();
         let pt2 = ECp::try_from_xy(&gx, &gy).unwrap();
 
         assert_eq!(pt1, pt2);
@@ -288,9 +280,9 @@ pub fn curve1174_tests() {
     let sx = "037FBB0CEA308C479343AEE7C029A190C021D96A492ECD6516123F27BCE29EDA"; // *ed-gen* x
     let sy = "06B72F82D47FB7CC6656841169840E0C4FE2DEE2AF3F976BA4CCB1BF9B46360E"; // *ed-gen* y
 
-    let gx = Fq::from_str(&sx).unwrap();
-    let gy = Fq::from_str(&sy).unwrap();
-    let mx = Fr::from_str(&smul).unwrap();
+    let gx = Fq::try_from_hex(&sx).unwrap();
+    let gy = Fq::try_from_hex(&sy).unwrap();
+    let mx = Fr::try_from_hex(&smul).unwrap();
     let mut pt2: ECp = ECp::inf();
     for _ in 0..100 {
         let pt1 = ECp::try_from_xy(&gx, &gy).unwrap();
@@ -319,8 +311,8 @@ pub fn curve1174_tests() {
         println!("{:?}", &x);
     }
 
-    let gen_x = Fq::from_str(&sx).unwrap();
-    let gen_y = Fq::from_str(&sy).unwrap();
+    let gen_x = Fq::try_from_hex(&sx).unwrap();
+    let gen_y = Fq::try_from_hex(&sy).unwrap();
     let pt = ECp::try_from_xy(&gen_x, &gen_y).unwrap();
 
     println!("The Generator Point");
@@ -332,7 +324,7 @@ pub fn curve1174_tests() {
     /* */
     let ept = ECp::from(Hash::from_vector(b"Testing12")); // produces an odd Y
     let cpt = Pt::from(ept); // MSB should be set
-    let ept2 = ECp::try_from(cpt).unwrap();
+    let ept2 = ECp::decompress(cpt).unwrap();
     println!("hash -> {}", ept);
     println!("hash -> {}", cpt);
     println!("hash -> {}", ept2);
@@ -347,7 +339,7 @@ pub fn curve1174_tests() {
     println!("delta = {}", delta);
 
     let cpt = Pt::from(pkey);
-    let ept = ECp::try_from(cpt).unwrap() + delta * *G;
+    let ept = ECp::decompress(cpt).unwrap() + delta * *G;
     let delta_pkey = PublicKey::from(ept);
     println!("delta_key = {}", Pt::from(delta_pkey));
 

--- a/crypto/src/curve1174/u256.rs
+++ b/crypto/src/curve1174/u256.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use super::*;
+use crate::CryptoError;
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;
@@ -470,7 +471,7 @@ impl From<U256> for Lev32 {
 // the vector has little-endian order
 
 impl U256 {
-    pub fn from_str(s: &str) -> Result<U256, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<U256, CryptoError> {
         // construct a little-endian [u64;4] from a hexstring
         let mut x = [0u8; 32];
         hexstr_to_lev_u8(s, &mut x)?;

--- a/crypto/src/curve1174/winvec.rs
+++ b/crypto/src/curve1174/winvec.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use super::*;
+use crate::CryptoError;
 
 // -----------------------------------------------------------------
 // window vector of 4-bit values, used for fast multiply of curve points

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -22,13 +22,12 @@
 // SOFTWARE.
 
 use crate::utils::*;
-use hex;
+use crate::CryptoError;
 use sha3::{Digest, Sha3_256};
 use std::fmt;
+use std::hash as stdhash;
 use std::mem;
 use std::slice;
-
-use std::hash as stdhash;
 
 // -----------------------------------------------------
 // Hashing with SHA3
@@ -47,7 +46,7 @@ impl Hash {
         self.0
     }
 
-    pub fn from_hex(hexstr: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_hex(hexstr: &str) -> Result<Self, CryptoError> {
         // use this function to import a Hash digest facsimile from a string constant
         let mut v = [0u8; HASH_SIZE];
         hexstr_to_bev_u8(hexstr, &mut v)?;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -39,3 +39,38 @@ pub mod hash;
 pub mod keying;
 pub mod pbc;
 pub mod utils;
+
+#[derive(Debug, Fail)]
+pub enum CryptoError {
+    /// Not Quadratic Residue
+    #[fail(display = "Quadratic Residue")]
+    NotQuadraticResidue,
+    /// Point Not OnCurve
+    #[fail(display = "Point is not on a curve")]
+    PointNotOnCurve,
+    /// Point Not On Curve
+    #[fail(display = "Invalid binary string length")]
+    InvalidBinaryLength,
+    /// An invalid character was found. Valid ones are: `0...9`, `a...f`
+    #[fail(display = "Invalid hex characters")]
+    InvalidHexCharacter,
+    /// A hex string's length needs to be even, as two digits correspond to
+    /// one byte.
+    #[fail(display = "Odd number of digits in hex string")]
+    OddHexLength,
+    /// If the hex string is decoded into a fixed sized container, such as an
+    /// array, the hex string's length * 2 has to match the container's
+    /// length.
+    #[fail(display = "Invalid hex string length")]
+    InvalidHexLength,
+}
+
+impl From<hex::FromHexError> for CryptoError {
+    fn from(error: hex::FromHexError) -> Self {
+        match error {
+            hex::FromHexError::InvalidHexCharacter { .. } => CryptoError::InvalidHexCharacter,
+            hex::FromHexError::InvalidStringLength => CryptoError::InvalidHexLength,
+            hex::FromHexError::OddLength => CryptoError::OddHexLength,
+        }
+    }
+}

--- a/crypto/src/pbc/fast.rs
+++ b/crypto/src/pbc/fast.rs
@@ -40,16 +40,13 @@
 //! --------------------------------------------------------------------------
 
 use super::*;
-use crate::hash::*;
-use crate::utils::*;
+use crate::CryptoError;
+use rand::rngs::ThreadRng;
 use rand::thread_rng;
-
+use rand::Rng;
 use std::cmp::Ordering;
 use std::hash as stdhash;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-
-use rand::rngs::ThreadRng;
-use rand::Rng;
 
 // ---------------------------------------------------------------------------------
 
@@ -127,7 +124,7 @@ impl Zr {
         &self.0
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let mut v = Self::wv();
         hexstr_to_bev_u8(&s, &mut v)?;
         Ok(Zr(v))
@@ -380,7 +377,7 @@ impl G1 {
         u8v_to_typed_str("G1", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let mut v = Self::wv();
         hexstr_to_bev_u8(&s, &mut v)?;
         Ok(G1(v))
@@ -579,7 +576,7 @@ impl G2 {
         u8v_to_typed_str("G2", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let mut v = Self::wv();
         hexstr_to_bev_u8(&s, &mut v)?;
         Ok(G2(v))

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -24,19 +24,15 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+use crate::hash::*;
+use crate::utils::*;
+use lazy_static::*;
+use rust_libpbc;
 use std::fmt;
 use std::vec::*;
 
-use rust_libpbc;
-
 pub mod fast;
 pub mod secure;
-
-use crate::utils::*;
-use hex;
-
-use crate::hash::*;
-use lazy_static::*;
 
 // -------------------------------------------------------------------
 // Signature Public Key - for checking curve constants validity

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -31,16 +31,13 @@
 //! --------------------------------------------------------------------------
 
 use super::*;
-use crate::hash::*;
-use crate::utils::*;
+use crate::CryptoError;
+use rand::rngs::ThreadRng;
 use rand::thread_rng;
-
+use rand::Rng;
 use std::cmp::Ordering;
 use std::hash as stdhash;
 use std::ops::Neg;
-
-use rand::rngs::ThreadRng;
-use rand::Rng;
 
 // --------------------------------------------------------------------------------
 
@@ -108,7 +105,7 @@ impl Zr {
         Self::acceptable_random_rehash(x)
     }
 
-    pub fn from_str(s: &str) -> Result<Zr, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Zr, CryptoError> {
         // result might be larger than prime order, r,
         // but will be interpreted by PBC lib as (Zr mod r).
         let mut v = Zr::wv();
@@ -200,7 +197,7 @@ impl G1 {
         u8v_to_typed_str("G1", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<G1, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<G1, CryptoError> {
         let mut v = G1::wv();
         hexstr_to_bev_u8(&s, &mut v)?;
         Ok(G1(v))
@@ -262,7 +259,7 @@ impl G2 {
         u8v_to_typed_str("G2", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let mut v = Self::wv();
         hexstr_to_bev_u8(&s, &mut v)?;
         Ok(G2(v))
@@ -340,7 +337,7 @@ impl GT {
         u8v_to_typed_str("GT", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let mut v = GT::wv();
         hexstr_to_bev_u8(&s, &mut v)?;
         Ok(GT(v))
@@ -380,7 +377,7 @@ impl SecretKey {
         u8v_to_typed_str("SKey", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let z = Zr::from_str(s)?;
         Ok(SecretKey(z))
     }
@@ -426,7 +423,7 @@ impl PublicKey {
         u8v_to_typed_str("PKey", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let g = G2::from_str(s)?;
         Ok(PublicKey(g))
     }
@@ -500,7 +497,7 @@ impl SecretSubKey {
         u8v_to_typed_str("SSubKey", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let g = G1::from_str(s)?;
         Ok(SecretSubKey(g))
     }
@@ -539,7 +536,7 @@ impl PublicSubKey {
         u8v_to_typed_str("PSubKey", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let g = G2::from_str(s)?;
         Ok(PublicSubKey(g))
     }
@@ -579,7 +576,7 @@ impl Signature {
         u8v_to_typed_str("Sig", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let g = G1::from_str(s)?;
         Ok(Signature(g))
     }
@@ -742,7 +739,7 @@ impl RVal {
         u8v_to_typed_str("RVal", &self.base_vector())
     }
 
-    pub fn from_str(s: &str) -> Result<Self, hex::FromHexError> {
+    pub fn from_str(s: &str) -> Result<Self, CryptoError> {
         let g = G2::from_str(s)?;
         Ok(RVal(g))
     }

--- a/crypto/src/utils/mod.rs
+++ b/crypto/src/utils/mod.rs
@@ -21,18 +21,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use crate::CryptoError;
 use hex;
 use std::cmp::Ordering;
 
 // -------------------------------------------------------------------
 // general utility functions
 
-pub fn hexstr_to_bev_u8(s: &str, x: &mut [u8]) -> Result<(), hex::FromHexError> {
+pub fn hexstr_to_bev_u8(s: &str, x: &mut [u8]) -> Result<(), CryptoError> {
     // collect a big-endian vector of 8-bit values from a hex string.
     let v = hex::decode(s)?;
     let nel = x.len();
     if nel != v.len() {
-        return Err(hex::FromHexError::InvalidStringLength);
+        return Err(CryptoError::InvalidHexLength);
     }
     let mut ix = 0; // this seems dumb... isn't there a better way?
     for b in v {
@@ -42,12 +43,12 @@ pub fn hexstr_to_bev_u8(s: &str, x: &mut [u8]) -> Result<(), hex::FromHexError> 
     Ok(())
 }
 
-pub fn hexstr_to_lev_u8(s: &str, x: &mut [u8]) -> Result<bool, hex::FromHexError> {
+pub fn hexstr_to_lev_u8(s: &str, x: &mut [u8]) -> Result<bool, CryptoError> {
     // collect a little-endian vector of 8-bit values from a hex string.
     let v = hex::decode(s)?;
     let nel = x.len();
     if nel != v.len() {
-        return Err(hex::FromHexError::InvalidStringLength);
+        return Err(CryptoError::InvalidHexLength);
     }
     let mut ix = nel; // this seems dumb... isn't there a better way?
     for b in v {

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -100,9 +100,10 @@ impl KeyChain {
                 tag: SKEY_TAG.to_string(),
                 contents: skey.into_bytes().to_vec(),
             };
+            let pkey_bytes: [u8; 32] = pkey.into_bytes();
             let pkey_pem = pem::Pem {
                 tag: PKEY_TAG.to_string(),
-                contents: pkey.into_bytes().to_vec(),
+                contents: pkey_bytes.to_vec(),
             };
 
             fs::write(skey_path, pem::encode(&skey_pem))?;
@@ -131,9 +132,8 @@ impl KeyChain {
                 return Err(KeyChainError::KeyParseError(cfg.public_key.clone()).into());
             }
 
-            // TODO: validate keys on curve
-            let skey = cpt::SecretKey::from_bytes(&skey.contents);
-            let pkey = cpt::PublicKey::from_bytes(&pkey.contents);
+            let skey = cpt::SecretKey::try_from_bytes(&skey.contents)?;
+            let pkey = cpt::PublicKey::try_from_bytes(&pkey.contents[..])?;
             let pkey_check = skey.into();
 
             if pkey != pkey_check {

--- a/src/console.rs
+++ b/src/console.rs
@@ -213,7 +213,7 @@ impl ConsoleService {
             };
 
             let recipient = caps.name("recipient").unwrap().as_str();
-            let recipient = match PublicKey::from_str(recipient) {
+            let recipient = match PublicKey::try_from_hex(recipient) {
                 Ok(r) => r,
                 Err(e) => {
                     println!("Invalid public key {}: {}", recipient, e);


### PR DESCRIPTION
- Refactor Pt and PublicKeys constructors to forbin invalid points
- Unify into()/from() API for Pt, ECp, PublicKey, Fq, Fr, SecretKey
- Move PublicKey::cloak() into blockchain::Output as requested by David

Closes #157