### PR TITLE
Implement data UTXO

### DIFF
--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -307,7 +307,7 @@ pub mod tests {
 
         let amount: i64 = 112;
         let (output, gamma) =
-            Output::new(timestamp, &skey, &pkey, amount).expect("tests have valid keys");
+            Output::new_monetary(timestamp, &skey, &pkey, amount).expect("tests have valid keys");
         let outputs = [output];
 
         let block = MonetaryBlock::new(base, gamma, &inputs, &outputs);

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -68,7 +68,7 @@ pub fn genesis(keychains: &[KeyChain]) -> (KeyBlock, MonetaryBlock) {
         let sender_skey = &keychains[0].wallet_skey;
         let recipient_pkey = &keychains[0].wallet_pkey;
 
-        let (output, gamma) = Output::new(timestamp, sender_skey, recipient_pkey, amount)
+        let (output, gamma) = Output::new_monetary(timestamp, sender_skey, recipient_pkey, amount)
             .expect("genesis has valid public keys");
         let outputs = [output];
 

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -24,7 +24,7 @@
 use failure::{Error, Fail};
 use std::fmt;
 use std::mem::transmute;
-use stegos_crypto::bulletproofs::{make_range_proof, BulletProof};
+use stegos_crypto::bulletproofs::{make_range_proof, pedersen_commitment, BulletProof};
 use stegos_crypto::curve1174::cpt::{
     aes_decrypt, aes_encrypt, EncryptedPayload, Pt, PublicKey, SecretKey,
 };
@@ -35,10 +35,16 @@ use stegos_crypto::hash::{Hash, Hashable, Hasher};
 use stegos_crypto::CryptoError;
 
 /// A magic value used to encode/decode payload.
-const PAYLOAD_MAGIC: [u8; 4] = [112, 97, 121, 109]; // "paym"
+const MONETARY_PAYLOAD_MAGIC: [u8; 4] = [112, 97, 121, 109]; // "paym"
 
-/// Payload size.
-const PAYLOAD_LEN: usize = 76;
+/// Monetary payload size.
+const MONETARY_PAYLOAD_LEN: usize = 76;
+
+/// A magic value used to encode/decode payload.
+const DATA_PAYLOAD_MAGIC: [u8; 4] = [100, 97, 116, 97]; // "data"
+
+/// Data payload size.
+const DATA_PAYLOAD_LEN: usize = 68;
 
 /// Errors.
 #[derive(Debug, Fail)]
@@ -47,10 +53,11 @@ pub enum OutputError {
     PayloadDecryptionError,
 }
 
+/// Monetary UTXO.
 /// Transaction output.
 /// (ID, P_{M, δ}, Bp, E_M(x, γ, δ))
 #[derive(Debug, Clone)]
-pub struct Output {
+pub struct MonetaryOutput {
     /// Clocked public key of recipient.
     /// P_M + δG
     pub recipient: PublicKey,
@@ -70,8 +77,64 @@ pub struct Output {
     pub payload: EncryptedPayload,
 }
 
-impl Output {
-    /// Constructor for Output.
+/// Data UTXO.
+#[derive(Debug, Clone)]
+pub struct DataOutput {
+    /// Clocked public key of recipient.
+    /// P_M + δG
+    pub recipient: PublicKey,
+
+    /// Pedersen commitment to zero.
+    pub vcmt: Pt,
+
+    /// The number of blocks for which this UTXO should be kept on the blockchain since
+    /// it has been added to it.
+    pub ttl: u64,
+
+    /// Encrypted payload.
+    ///
+    /// E_M(x, γ, δ)
+    /// Represents an encrypted packet contain the information about x, γ, δ
+    /// that only receiver can red
+    /// Size is approx 137 Bytes =
+    ///     (R-val 65B, crypto-text 72B = (amount 8B, gamma 32B, delta 32B))
+    pub payload: EncryptedPayload,
+}
+
+/// Blockchain UTXO - either monetary or data.
+#[derive(Debug, Clone)]
+pub enum Output {
+    MonetaryOutput(MonetaryOutput),
+    DataOutput(DataOutput),
+}
+
+/// Cloak recipient's public key.
+fn cloak_key(
+    sender_skey: &SecretKey,
+    recipient_pkey: &PublicKey,
+    timestamp: u64,
+) -> Result<(PublicKey, Fr), CryptoError> {
+    // h is the digest of the recipients actual public key mixed with a timestamp.
+    let mut hasher = Hasher::new();
+    recipient_pkey.hash(&mut hasher);
+    timestamp.hash(&mut hasher);
+    let h = hasher.result();
+
+    // Use deterministic randomness here too, to protect against PRNG attacks.
+    let delta: Fr = Fr::synthetic_random(&"PKey", sender_skey, &h);
+
+    // Resulting publickey will be a random-like value in a safe range of the field,
+    // not too small, and not too large. This helps avoid brute force attacks, looking
+    // for the discrete log corresponding to delta.
+
+    let pt = Pt::from(*recipient_pkey);
+    let pt = ECp::decompress(pt)?;
+    let cloaked_pkey = PublicKey::from(pt + delta * (*G));
+    Ok((cloaked_pkey, delta))
+}
+
+impl MonetaryOutput {
+    /// Constructor for monetary UTXO.
     pub fn new(
         timestamp: u64,
         sender_skey: &SecretKey,
@@ -79,45 +142,21 @@ impl Output {
         amount: i64,
     ) -> Result<(Self, Fr), Error> {
         // Clock recipient public key
-        let (cloaked_pkey, delta) = Self::cloak_key(sender_skey, recipient_pkey, timestamp)?;
+        let (cloaked_pkey, delta) = cloak_key(sender_skey, recipient_pkey, timestamp)?;
 
+        // Create range proofs.
         let (proof, gamma) = make_range_proof(amount);
 
-        // NOTE: real public key should be used to encrypt payload.
+        // NOTE: real public key should be used to encrypt payload
         let payload = Self::encrypt_payload(delta, gamma, amount, recipient_pkey)?;
 
-        let output = Output {
+        let output = MonetaryOutput {
             recipient: cloaked_pkey,
             proof,
             payload,
         };
 
         Ok((output, gamma))
-    }
-
-    /// Cloak recipient's public key.
-    fn cloak_key(
-        sender_skey: &SecretKey,
-        recipient_pkey: &PublicKey,
-        timestamp: u64,
-    ) -> Result<(PublicKey, Fr), CryptoError> {
-        // h is the digest of the recipients actual public key mixed with a timestamp.
-        let mut hasher = Hasher::new();
-        recipient_pkey.hash(&mut hasher);
-        timestamp.hash(&mut hasher);
-        let h = hasher.result();
-
-        // Use deterministic randomness here too, to protect against PRNG attacks.
-        let delta: Fr = Fr::synthetic_random(&"PKey", sender_skey, &h);
-
-        // Resulting publickey will be a random-like value in a safe range of the field,
-        // not too small, and not too large. This helps avoid brute force attacks, looking
-        // for the discrete log corresponding to delta.
-
-        let pt = Pt::from(*recipient_pkey);
-        let pt = ECp::decompress(pt)?;
-        let cloaked_pkey = PublicKey::from(pt + delta * (*G));
-        Ok((cloaked_pkey, delta))
     }
 
     /// Create a new monetary transaction.
@@ -128,14 +167,13 @@ impl Output {
         pkey: &PublicKey,
     ) -> Result<EncryptedPayload, CryptoError> {
         // Convert amount to BE vector.
-
         let amount_bytes: [u8; 8] = unsafe { transmute(amount.to_be()) };
 
         let gamma_bytes: [u8; 32] = gamma.to_lev_u8();
         let delta_bytes: [u8; 32] = delta.to_lev_u8();
 
         let payload: Vec<u8> = [
-            &PAYLOAD_MAGIC[..],
+            &MONETARY_PAYLOAD_MAGIC[..],
             &amount_bytes[..],
             &delta_bytes[..],
             &gamma_bytes[..],
@@ -143,7 +181,7 @@ impl Output {
             .concat();
 
         // Ensure that the total length of package is 76 bytes.
-        assert_eq!(payload.len(), PAYLOAD_LEN);
+        assert_eq!(payload.len(), MONETARY_PAYLOAD_LEN);
 
         // String together a gamma, delta, and Amount (i64) all in one long vector and encrypt it.
         aes_encrypt(&payload, &pkey)
@@ -153,7 +191,7 @@ impl Output {
     pub fn decrypt_payload(&self, skey: &SecretKey) -> Result<(Fr, Fr, i64), Error> {
         let payload: Vec<u8> = aes_decrypt(&self.payload, &skey)?;
 
-        if payload.len() != PAYLOAD_LEN {
+        if payload.len() != MONETARY_PAYLOAD_LEN {
             // Invalid payload or invalid secret key supplied.
             return Err(OutputError::PayloadDecryptionError.into());
         }
@@ -167,7 +205,7 @@ impl Output {
         delta_bytes.copy_from_slice(&payload[12..44]);
         gamma_bytes.copy_from_slice(&payload[44..76]);
 
-        if magic != PAYLOAD_MAGIC {
+        if magic != MONETARY_PAYLOAD_MAGIC {
             // Invalid payload or invalid secret key supplied.
             return Err(OutputError::PayloadDecryptionError.into());
         }
@@ -180,20 +218,159 @@ impl Output {
     }
 }
 
+impl DataOutput {
+    /// Constructor for data UTXO.
+    pub fn new(
+        timestamp: u64,
+        sender_skey: &SecretKey,
+        recipient_pkey: &PublicKey,
+        ttl: u64,
+        data: &[u8],
+    ) -> Result<(Self, Fr), Error> {
+        assert!(ttl > 0);
+        assert!(data.len() > 0);
+
+        // Clock recipient public key
+        let (cloaked_pkey, delta) = cloak_key(sender_skey, recipient_pkey, timestamp)?;
+
+        // Create pedersen commitment
+        let (vcmt, gamma) = pedersen_commitment(0);
+        let vcmt = vcmt.compress();
+
+        // NOTE: real public key should be used to encrypt payload
+        let payload = Self::encrypt_payload(delta, gamma, data, recipient_pkey)?;
+
+        let output = DataOutput {
+            recipient: cloaked_pkey,
+            ttl,
+            vcmt,
+            payload,
+        };
+
+        Ok((output, gamma))
+    }
+
+    /// Encrypt data payload.
+    fn encrypt_payload(
+        delta: Fr,
+        gamma: Fr,
+        data: &[u8],
+        pkey: &PublicKey,
+    ) -> Result<EncryptedPayload, CryptoError> {
+        let gamma_bytes: [u8; 32] = gamma.to_lev_u8();
+        let delta_bytes: [u8; 32] = delta.to_lev_u8();
+
+        let payload: Vec<u8> = [
+            &DATA_PAYLOAD_MAGIC[..],
+            &delta_bytes[..],
+            &gamma_bytes[..],
+            &data[..],
+        ]
+            .concat();
+
+        // Ensure that the total length of package is 68 bytes + data.len().
+        assert_eq!(payload.len(), DATA_PAYLOAD_LEN + data.len());
+
+        // Encrypt the payload.
+        aes_encrypt(&payload, &pkey)
+    }
+
+    /// Decrypt data payload.
+    pub fn decrypt_payload(&self, skey: &SecretKey) -> Result<(Fr, Fr, Vec<u8>), Error> {
+        let payload: Vec<u8> = aes_decrypt(&self.payload, &skey)?;
+
+        if payload.len() < DATA_PAYLOAD_LEN {
+            // Invalid payload or invalid secret key supplied.
+            return Err(OutputError::PayloadDecryptionError.into());
+        }
+
+        let mut magic: [u8; 4] = [0u8; 4];
+        let mut delta_bytes: [u8; 32] = [0u8; 32];
+        let mut gamma_bytes: [u8; 32] = [0u8; 32];
+        magic.copy_from_slice(&payload[0..4]);
+        delta_bytes.copy_from_slice(&payload[4..36]);
+        gamma_bytes.copy_from_slice(&payload[36..68]);
+        let data = payload[68..].to_vec(); // the rest is data
+
+        if magic != DATA_PAYLOAD_MAGIC {
+            // Invalid payload or invalid secret key supplied.
+            return Err(OutputError::PayloadDecryptionError.into());
+        }
+
+        let gamma: Fr = Fr::from_lev_u8(gamma_bytes);
+        let delta: Fr = Fr::from_lev_u8(delta_bytes);
+
+        Ok((delta, gamma, data))
+    }
+}
+
+impl Output {
+    /// Create a new monetary transaction.
+    pub fn new_monetary(
+        timestamp: u64,
+        sender_skey: &SecretKey,
+        recipient_pkey: &PublicKey,
+        amount: i64,
+    ) -> Result<(Self, Fr), Error> {
+        let (output, delta) = MonetaryOutput::new(timestamp, sender_skey, recipient_pkey, amount)?;
+        Ok((Output::MonetaryOutput(output), delta))
+    }
+
+    /// Create a new data transaction.
+    pub fn new_data(
+        timestamp: u64,
+        sender_skey: &SecretKey,
+        recipient_pkey: &PublicKey,
+        ttl: u64,
+        data: &[u8],
+    ) -> Result<(Self, Fr), Error> {
+        let (output, delta) = DataOutput::new(timestamp, sender_skey, recipient_pkey, ttl, data)?;
+        Ok((Output::DataOutput(output), delta))
+    }
+
+    pub fn decrypt_payload(&self, skey: &SecretKey) -> Result<(Fr, Fr), Error> {
+        match self {
+            Output::MonetaryOutput(monetary) => {
+                let (delta, gamma, _amount) = monetary.decrypt_payload(skey)?;
+                Ok((delta, gamma))
+            }
+            Output::DataOutput(data) => {
+                let (delta, gamma, _data) = data.decrypt_payload(skey)?;
+                Ok((delta, gamma))
+            }
+        }
+    }
+}
+
 impl fmt::Display for Output {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Output({})", Hash::digest(self))
     }
 }
 
-impl Hashable for Output {
-    /// Unique identifier of the output.
-    /// Formed by hashing all fields of this structure.
-    /// H_r(P_{M, δ},B_p, E_M(x, γ, δ)).
+impl Hashable for MonetaryOutput {
     fn hash(&self, state: &mut Hasher) {
         self.recipient.hash(state);
         self.proof.hash(state);
         self.payload.hash(state);
+    }
+}
+
+impl Hashable for DataOutput {
+    fn hash(&self, state: &mut Hasher) {
+        self.recipient.hash(state);
+        self.vcmt.hash(state);
+        self.ttl.hash(state);
+        self.payload.hash(state);
+    }
+}
+
+impl Hashable for Output {
+    fn hash(&self, state: &mut Hasher) {
+        match self {
+            Output::MonetaryOutput(monetary) => monetary.hash(state),
+            Output::DataOutput(data) => data.hash(state),
+        }
     }
 }
 
@@ -212,7 +389,7 @@ pub mod tests {
     use stegos_crypto::curve1174::cpt::make_random_keys;
 
     #[test]
-    pub fn encrypt_decrypt() {
+    pub fn monetary_encrypt_decrypt() {
         let (skey1, _pkey1, _sig1) = make_random_keys();
         let (skey2, pkey2, _sig2) = make_random_keys();
 
@@ -220,12 +397,41 @@ pub mod tests {
         let amount: i64 = 100500;
 
         let (output, gamma) =
-            Output::new(timestamp, &skey1, &pkey2, amount).expect("encryption successful");
+            MonetaryOutput::new(timestamp, &skey1, &pkey2, amount).expect("encryption successful");
         let (_delta2, gamma2, amount2) = output
             .decrypt_payload(&skey2)
             .expect("decryption successful");
 
         assert_eq!(amount, amount2);
+        assert_eq!(gamma, gamma2);
+
+        // Error handling
+        if let Err(e) = output.decrypt_payload(&skey1) {
+            match e.downcast::<OutputError>() {
+                Ok(OutputError::PayloadDecryptionError) => (),
+                _ => assert!(false),
+            };
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    pub fn data_encrypt_decrypt() {
+        let (skey1, _pkey1, _sig1) = make_random_keys();
+        let (skey2, pkey2, _sig2) = make_random_keys();
+
+        let timestamp = Utc::now().timestamp() as u64;
+        let data = b"hello";
+        let ttl = 5;
+
+        let (output, gamma) =
+            DataOutput::new(timestamp, &skey1, &pkey2, ttl, data).expect("encryption successful");
+        let (_delta2, gamma2, data2) = output
+            .decrypt_payload(&skey2)
+            .expect("decryption successful");
+
+        assert_eq!(data.to_vec(), data2);
         assert_eq!(gamma, gamma2);
 
         // Error handling

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -39,6 +39,11 @@ pub const HASH_SIZE: usize = 32;
 pub struct Hash([u8; HASH_SIZE]);
 
 impl Hash {
+    /// Return a hash with all zeros.
+    pub fn zero() -> Self {
+        Hash([0u8; HASH_SIZE])
+    }
+
     pub fn base_vector(&self) -> &[u8] {
         &self.0
     }

--- a/node/protos/node.proto
+++ b/node/protos/node.proto
@@ -68,6 +68,8 @@ message BulletProof {
 message Output {
     PublicKey recipient = 1;
     BulletProof proof = 2;
+    Pt vcmt = 4;
+    uint64 ttl = 5;
     EncryptedPayload payload = 3;
 }
 

--- a/node/src/protos/node.rs
+++ b/node/src/protos/node.rs
@@ -3041,6 +3041,8 @@ pub struct Output {
     // message fields
     pub recipient: ::protobuf::SingularPtrField<PublicKey>,
     pub proof: ::protobuf::SingularPtrField<BulletProof>,
+    pub vcmt: ::protobuf::SingularPtrField<Pt>,
+    pub ttl: u64,
     pub payload: ::protobuf::SingularPtrField<EncryptedPayload>,
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
@@ -3118,6 +3120,54 @@ impl Output {
         self.proof.as_ref().unwrap_or_else(|| BulletProof::default_instance())
     }
 
+    // .protobuf.pb.Pt vcmt = 4;
+
+    pub fn clear_vcmt(&mut self) {
+        self.vcmt.clear();
+    }
+
+    pub fn has_vcmt(&self) -> bool {
+        self.vcmt.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_vcmt(&mut self, v: Pt) {
+        self.vcmt = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_vcmt(&mut self) -> &mut Pt {
+        if self.vcmt.is_none() {
+            self.vcmt.set_default();
+        }
+        self.vcmt.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_vcmt(&mut self) -> Pt {
+        self.vcmt.take().unwrap_or_else(|| Pt::new())
+    }
+
+    pub fn get_vcmt(&self) -> &Pt {
+        self.vcmt.as_ref().unwrap_or_else(|| Pt::default_instance())
+    }
+
+    // uint64 ttl = 5;
+
+    pub fn clear_ttl(&mut self) {
+        self.ttl = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ttl(&mut self, v: u64) {
+        self.ttl = v;
+    }
+
+    pub fn get_ttl(&self) -> u64 {
+        self.ttl
+    }
+
     // .protobuf.pb.EncryptedPayload payload = 3;
 
     pub fn clear_payload(&mut self) {
@@ -3164,6 +3214,11 @@ impl ::protobuf::Message for Output {
                 return false;
             }
         };
+        for v in &self.vcmt {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
         for v in &self.payload {
             if !v.is_initialized() {
                 return false;
@@ -3181,6 +3236,16 @@ impl ::protobuf::Message for Output {
                 },
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.proof)?;
+                },
+                4 => {
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.vcmt)?;
+                },
+                5 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_uint64()?;
+                    self.ttl = tmp;
                 },
                 3 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.payload)?;
@@ -3205,6 +3270,13 @@ impl ::protobuf::Message for Output {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         }
+        if let Some(ref v) = self.vcmt.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        }
+        if self.ttl != 0 {
+            my_size += ::protobuf::rt::value_size(5, self.ttl, ::protobuf::wire_format::WireTypeVarint);
+        }
         if let Some(ref v) = self.payload.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -3224,6 +3296,14 @@ impl ::protobuf::Message for Output {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
+        }
+        if let Some(ref v) = self.vcmt.as_ref() {
+            os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        }
+        if self.ttl != 0 {
+            os.write_uint64(5, self.ttl)?;
         }
         if let Some(ref v) = self.payload.as_ref() {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
@@ -3282,6 +3362,16 @@ impl ::protobuf::Message for Output {
                     |m: &Output| { &m.proof },
                     |m: &mut Output| { &mut m.proof },
                 ));
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Pt>>(
+                    "vcmt",
+                    |m: &Output| { &m.vcmt },
+                    |m: &mut Output| { &mut m.vcmt },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
+                    "ttl",
+                    |m: &Output| { &m.ttl },
+                    |m: &mut Output| { &mut m.ttl },
+                ));
                 fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<EncryptedPayload>>(
                     "payload",
                     |m: &Output| { &m.payload },
@@ -3311,6 +3401,8 @@ impl ::protobuf::Clear for Output {
     fn clear(&mut self) {
         self.clear_recipient();
         self.clear_proof();
+        self.clear_vcmt();
+        self.clear_ttl();
         self.clear_payload();
         self.unknown_fields.clear();
     }
@@ -5867,41 +5959,43 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     f\x18\t\x20\x01(\x0b2\x15.protobuf.pb.DotProofB\x02\x18\0\x12\x1e\n\x01x\
     \x18\n\x20\x01(\x0b2\x0f.protobuf.pb.FrB\x02\x18\0\x12\x1e\n\x01y\x18\
     \x0b\x20\x01(\x0b2\x0f.protobuf.pb.FrB\x02\x18\0\x12\x1e\n\x01z\x18\x0c\
-    \x20\x01(\x0b2\x0f.protobuf.pb.FrB\x02\x18\0\"\x98\x01\n\x06Output\x12-\
+    \x20\x01(\x0b2\x0f.protobuf.pb.FrB\x02\x18\0\"\xcc\x01\n\x06Output\x12-\
     \n\trecipient\x18\x01\x20\x01(\x0b2\x16.protobuf.pb.PublicKeyB\x02\x18\0\
     \x12+\n\x05proof\x18\x02\x20\x01(\x0b2\x18.protobuf.pb.BulletProofB\x02\
-    \x18\0\x122\n\x07payload\x18\x03\x20\x01(\x0b2\x1d.protobuf.pb.Encrypted\
-    PayloadB\x02\x18\0\"\xbb\x01\n\x0bTransaction\x12$\n\x05txins\x18\x01\
-    \x20\x03(\x0b2\x11.protobuf.pb.HashB\x02\x18\0\x12'\n\x06txouts\x18\x02\
-    \x20\x03(\x0b2\x13.protobuf.pb.OutputB\x02\x18\0\x12\"\n\x05gamma\x18\
-    \x03\x20\x01(\x0b2\x0f.protobuf.pb.FrB\x02\x18\0\x12\x0f\n\x03fee\x18\
-    \x04\x20\x01(\x03B\x02\x18\0\x12(\n\x03sig\x18\x05\x20\x01(\x0b2\x17.pro\
-    tobuf.pb.SchnorrSigB\x02\x18\0\"y\n\x0fBaseBlockHeader\x12\x13\n\x07vers\
-    ion\x18\x01\x20\x01(\x04B\x02\x18\0\x12'\n\x08previous\x18\x02\x20\x01(\
-    \x0b2\x11.protobuf.pb.HashB\x02\x18\0\x12\x11\n\x05epoch\x18\x03\x20\x01\
-    (\x04B\x02\x18\0\x12\x15\n\ttimestamp\x18\x04\x20\x01(\x04B\x02\x18\0\"\
-    \xce\x01\n\x13MonetaryBlockHeader\x12.\n\x04base\x18\x01\x20\x01(\x0b2\
-    \x1c.protobuf.pb.BaseBlockHeaderB\x02\x18\0\x12\"\n\x05gamma\x18\x02\x20\
-    \x01(\x0b2\x0f.protobuf.pb.FrB\x02\x18\0\x120\n\x11inputs_range_hash\x18\
-    \x03\x20\x01(\x0b2\x11.protobuf.pb.HashB\x02\x18\0\x121\n\x12outputs_ran\
-    ge_hash\x18\x04\x20\x01(\x0b2\x11.protobuf.pb.HashB\x02\x18\0\"~\n\nMerk\
-    leNode\x12#\n\x04hash\x18\x01\x20\x01(\x0b2\x11.protobuf.pb.HashB\x02\
-    \x18\0\x12\x10\n\x04left\x18\x02\x20\x01(\x04B\x02\x18\0\x12\x11\n\x05ri\
-    ght\x18\x03\x20\x01(\x04B\x02\x18\0\x12&\n\x05value\x18\x04\x20\x01(\x0b\
-    2\x13.protobuf.pb.OutputB\x02\x18\0\"h\n\x11MonetaryBlockBody\x12%\n\x06\
-    inputs\x18\x01\x20\x03(\x0b2\x11.protobuf.pb.HashB\x02\x18\0\x12,\n\x07o\
-    utputs\x18\x02\x20\x03(\x0b2\x17.protobuf.pb.MerkleNodeB\x02\x18\0\"w\n\
-    \rMonetaryBlock\x124\n\x06header\x18\x01\x20\x01(\x0b2\x20.protobuf.pb.M\
-    onetaryBlockHeaderB\x02\x18\0\x120\n\x04body\x18\x02\x20\x01(\x0b2\x1e.p\
-    rotobuf.pb.MonetaryBlockBodyB\x02\x18\0\"\xa7\x01\n\x0eKeyBlockHeader\
-    \x12.\n\x04base\x18\x01\x20\x01(\x0b2\x1c.protobuf.pb.BaseBlockHeaderB\
-    \x02\x18\0\x120\n\x06leader\x18\x02\x20\x01(\x0b2\x1c.protobuf.pb.Secure\
-    PublicKeyB\x02\x18\0\x123\n\twitnesses\x18\x03\x20\x03(\x0b2\x1c.protobu\
-    f.pb.SecurePublicKeyB\x02\x18\0\";\n\x08KeyBlock\x12/\n\x06header\x18\
-    \x01\x20\x01(\x0b2\x1b.protobuf.pb.KeyBlockHeaderB\x02\x18\0\"z\n\x05Blo\
-    ck\x12.\n\tkey_block\x18\x01\x20\x01(\x0b2\x15.protobuf.pb.KeyBlockH\0B\
-    \x02\x18\0\x128\n\x0emonetary_block\x18\x02\x20\x01(\x0b2\x1a.protobuf.p\
-    b.MonetaryBlockH\0B\x02\x18\0B\x07\n\x05blockB\0b\x06proto3\
+    \x18\0\x12!\n\x04vcmt\x18\x04\x20\x01(\x0b2\x0f.protobuf.pb.PtB\x02\x18\
+    \0\x12\x0f\n\x03ttl\x18\x05\x20\x01(\x04B\x02\x18\0\x122\n\x07payload\
+    \x18\x03\x20\x01(\x0b2\x1d.protobuf.pb.EncryptedPayloadB\x02\x18\0\"\xbb\
+    \x01\n\x0bTransaction\x12$\n\x05txins\x18\x01\x20\x03(\x0b2\x11.protobuf\
+    .pb.HashB\x02\x18\0\x12'\n\x06txouts\x18\x02\x20\x03(\x0b2\x13.protobuf.\
+    pb.OutputB\x02\x18\0\x12\"\n\x05gamma\x18\x03\x20\x01(\x0b2\x0f.protobuf\
+    .pb.FrB\x02\x18\0\x12\x0f\n\x03fee\x18\x04\x20\x01(\x03B\x02\x18\0\x12(\
+    \n\x03sig\x18\x05\x20\x01(\x0b2\x17.protobuf.pb.SchnorrSigB\x02\x18\0\"y\
+    \n\x0fBaseBlockHeader\x12\x13\n\x07version\x18\x01\x20\x01(\x04B\x02\x18\
+    \0\x12'\n\x08previous\x18\x02\x20\x01(\x0b2\x11.protobuf.pb.HashB\x02\
+    \x18\0\x12\x11\n\x05epoch\x18\x03\x20\x01(\x04B\x02\x18\0\x12\x15\n\ttim\
+    estamp\x18\x04\x20\x01(\x04B\x02\x18\0\"\xce\x01\n\x13MonetaryBlockHeade\
+    r\x12.\n\x04base\x18\x01\x20\x01(\x0b2\x1c.protobuf.pb.BaseBlockHeaderB\
+    \x02\x18\0\x12\"\n\x05gamma\x18\x02\x20\x01(\x0b2\x0f.protobuf.pb.FrB\
+    \x02\x18\0\x120\n\x11inputs_range_hash\x18\x03\x20\x01(\x0b2\x11.protobu\
+    f.pb.HashB\x02\x18\0\x121\n\x12outputs_range_hash\x18\x04\x20\x01(\x0b2\
+    \x11.protobuf.pb.HashB\x02\x18\0\"~\n\nMerkleNode\x12#\n\x04hash\x18\x01\
+    \x20\x01(\x0b2\x11.protobuf.pb.HashB\x02\x18\0\x12\x10\n\x04left\x18\x02\
+    \x20\x01(\x04B\x02\x18\0\x12\x11\n\x05right\x18\x03\x20\x01(\x04B\x02\
+    \x18\0\x12&\n\x05value\x18\x04\x20\x01(\x0b2\x13.protobuf.pb.OutputB\x02\
+    \x18\0\"h\n\x11MonetaryBlockBody\x12%\n\x06inputs\x18\x01\x20\x03(\x0b2\
+    \x11.protobuf.pb.HashB\x02\x18\0\x12,\n\x07outputs\x18\x02\x20\x03(\x0b2\
+    \x17.protobuf.pb.MerkleNodeB\x02\x18\0\"w\n\rMonetaryBlock\x124\n\x06hea\
+    der\x18\x01\x20\x01(\x0b2\x20.protobuf.pb.MonetaryBlockHeaderB\x02\x18\0\
+    \x120\n\x04body\x18\x02\x20\x01(\x0b2\x1e.protobuf.pb.MonetaryBlockBodyB\
+    \x02\x18\0\"\xa7\x01\n\x0eKeyBlockHeader\x12.\n\x04base\x18\x01\x20\x01(\
+    \x0b2\x1c.protobuf.pb.BaseBlockHeaderB\x02\x18\0\x120\n\x06leader\x18\
+    \x02\x20\x01(\x0b2\x1c.protobuf.pb.SecurePublicKeyB\x02\x18\0\x123\n\twi\
+    tnesses\x18\x03\x20\x03(\x0b2\x1c.protobuf.pb.SecurePublicKeyB\x02\x18\0\
+    \";\n\x08KeyBlock\x12/\n\x06header\x18\x01\x20\x01(\x0b2\x1b.protobuf.pb\
+    .KeyBlockHeaderB\x02\x18\0\"z\n\x05Block\x12.\n\tkey_block\x18\x01\x20\
+    \x01(\x0b2\x15.protobuf.pb.KeyBlockH\0B\x02\x18\0\x128\n\x0emonetary_blo\
+    ck\x18\x02\x20\x01(\x0b2\x1a.protobuf.pb.MonetaryBlockH\0B\x02\x18\0B\
+    \x07\n\x05blockB\0b\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {


### PR DESCRIPTION
- Split Output into MonetaryOutput and DataOutput
- Allow empty merkle tree and blocks without outputs
- Add "msg" command to CLI

Other changes:

- Fix error handling in CLI
- Print epoch changing notifications in CLI

Closes #165