### PR TITLE
Switch to Rust 2018 edition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ before_script:
 
 build:linux:
   extends: .build
-  image: rust:1.30
+  image: rust:1.31
   tags:
     - linux
 
@@ -36,7 +36,7 @@ build:linux:
 
 test:linux:
   extends: .test
-  image: rust:1.30
+  image: rust:1.31
   dependencies:
     - build:linux
   tags:
@@ -44,7 +44,7 @@ test:linux:
 
 code_coverage:
   stage: code_coverage
-  image: rust:1.30
+  image: rust:1.31
   script:
     - ci-scripts/coverage.sh
   dependencies:
@@ -70,7 +70,7 @@ code_coverage:
 
 release:linux:
   extends: .release
-  image: rust:1.30
+  image: rust:1.31
   tags:
     - linux
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* `Stegos` requires **Rust version 1.30.x or higher** to build.
+* `Stegos` requires **Rust version 1.31.x or higher** to build.
 
     The recommended way to install Rust it to use [rustup](https://www.rustup.rs/).
     If you don't already have `rustup`, you can install it like this:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,6 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=e179951c74cb0c8916d27329f2dfd78917dddfb2)",
@@ -2278,7 +2277,6 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2308,7 +2306,6 @@ name = "stegos_crypto"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2326,7 +2323,6 @@ version = "0.1.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2341,7 +2337,6 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2371,7 +2366,6 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2393,7 +2387,6 @@ name = "stegos_randhound"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [[bin]]
 name = "stegos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ tokio = "0.1"
 log = "0.4"
 log4rs = { version = "0.8", features = ["all_components", "gzip", "file", "toml_format"]}
 failure = "0.1"
-failure_derive = "0.1"
 rustyline = "2.1"
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "e179951c74cb0c8916d27329f2dfd78917dddfb2" }
 parking_lot = "0.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use multi-stage build to reduce image size
-FROM rust:1.30-slim-stretch AS builder
+FROM rust:1.31-slim-stretch AS builder
 LABEL maintainer="Stegos AG <info@stegos.cc>"
 
 ADD . /usr/src/stegos

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_api"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 log = "0.4"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -11,7 +11,6 @@ chrono = "0.4"
 rand = "0.6"
 log = "0.4"
 failure = "0.1"
-failure_derive = "0.1"
 
 [dev-dependencies]
 simple_logger = "1.0"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_blockchain"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 stegos_keychain = { path = "../keychain" }

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -21,13 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::collections::HashMap;
-use std::vec::Vec;
-
 use crate::block::*;
 use crate::error::*;
 use crate::merkle::*;
 use crate::output::*;
+use log::*;
+use std::collections::HashMap;
+use std::vec::Vec;
 use stegos_crypto::hash::*;
 
 type BlockId = usize;
@@ -322,7 +322,7 @@ pub mod tests {
 
     #[test]
     fn basic() {
-        extern crate simple_logger;
+        use simple_logger;
         simple_logger::init_with_level(log::Level::Debug).unwrap_or_default();
 
         let keychains = [

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use failure::Fail;
 use stegos_crypto::hash::Hash;
 
 #[derive(Debug, Fail)]

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -37,12 +37,4 @@ pub use crate::merkle::*;
 pub use crate::output::*;
 pub use crate::transaction::*;
 
-extern crate chrono;
-#[macro_use]
-extern crate log;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-extern crate rand;
-extern crate stegos_crypto;
-extern crate stegos_keychain;
+use log;

--- a/blockchain/src/merkle.rs
+++ b/blockchain/src/merkle.rs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use failure::Fail;
 use std::fmt;
 use std::vec::Vec;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
@@ -637,7 +638,7 @@ impl<T: Hashable + Clone + fmt::Debug + fmt::Display> Merkle<T> {
     }
 
     /// A recursive helper for fmt().
-    fn fmt_r(f: &mut fmt::Formatter, node: &Node<T>, h: usize) -> fmt::Result {
+    fn fmt_r(f: &mut fmt::Formatter<'_>, node: &Node<T>, h: usize) -> fmt::Result {
         match node {
             Node {
                 left: Some(ref left),
@@ -687,14 +688,14 @@ impl<T: Hashable + Clone + fmt::Debug + fmt::Display> Merkle<T> {
     }
 
     /// Debug formatting.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\n")?;
         Merkle::fmt_r(f, &self.root, 0)
     }
 }
 
 impl<T: Hashable + Clone + fmt::Debug + fmt::Display> fmt::Debug for Merkle<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt(f)
     }
 }
@@ -709,10 +710,10 @@ impl<T: Hashable + Clone + fmt::Debug + fmt::Display> Clone for Merkle<T> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use log::*;
     use rand::prelude::*;
     use rand::seq::SliceRandom;
-
-    extern crate simple_logger;
+    use simple_logger;
 
     /// Reverse the order of bits in a byte
     fn reverse_u32(mut n: u32) -> u32 {

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use failure::Error;
+use failure::{Error, Fail};
 use std::fmt;
 use std::mem::transmute;
 use stegos_crypto::bulletproofs::{make_range_proof, BulletProof};
@@ -181,7 +181,7 @@ impl Output {
 }
 
 impl fmt::Display for Output {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Output({})", Hash::digest(self))
     }
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_config"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 toml = "0.4"

--- a/config/src/error.rs
+++ b/config/src/error.rs
@@ -37,7 +37,7 @@ pub enum ConfigError {
 
 /// Display implementation for ConfigError.
 impl fmt::Display for ConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConfigError::NotFoundError => write!(f, "Configuration file not found"),
             ConfigError::IOError(e) => write!(f, "Failed to read configuration file: {}", e),
@@ -48,7 +48,7 @@ impl fmt::Display for ConfigError {
 
 /// Error implementation for ConfigError.
 impl error::Error for ConfigError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ConfigError::IOError(ref e) => Some(e),
             ConfigError::ParseError(ref e) => Some(e),

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -24,21 +24,18 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(warnings)]
 
-#[macro_use]
-extern crate serde_derive;
-extern crate rand;
-extern crate toml;
-
 mod error;
 mod types;
+
 pub use crate::error::*;
 pub use crate::types::*;
-
+use serde_derive;
 use std::fs::File;
 use std::io::ErrorKind;
 use std::io::Read;
 use std::path::Path;
 use std::result::Result;
+use toml;
 
 ///
 /// Load configuration file

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -21,6 +21,7 @@
 
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+use serde_derive::{Deserialize, Serialize};
 
 ///! Configuration Structures.
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_consensus"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 log = "0.4"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,6 @@ rust-libpbc = { git = "https://github.com/stegos/rust-pbcintf.git" }
 sha3 = "0.8"
 log = "0.4"
 failure = "0.1"
-failure_derive = "0.1"
 
 [[example]]
 name = "bulletproofs"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "stegos_crypto"
 version = "0.1.0"
+edition = "2018"
 authors = ["Stegos AG <info@stegos.cc>"]
 
 [dependencies]

--- a/crypto/examples/bulletproofs.rs
+++ b/crypto/examples/bulletproofs.rs
@@ -21,8 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-extern crate stegos_crypto;
-
 use stegos_crypto::bulletproofs::*;
 
 // -------------------------------------------------------------------------------

--- a/crypto/examples/curve1174.rs
+++ b/crypto/examples/curve1174.rs
@@ -37,9 +37,6 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 
-extern crate rand;
-extern crate stegos_crypto;
-
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;

--- a/crypto/examples/pbc.rs
+++ b/crypto/examples/pbc.rs
@@ -21,12 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-extern crate rust_libpbc;
-extern crate stegos_crypto;
-
 use stegos_crypto::pbc::*;
-
-extern crate hex;
 
 // ------------------------------------------------------------------------
 

--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -25,23 +25,23 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 
-use crate::CryptoError;
-use rand::prelude::*;
-use std::fmt;
-use std::fmt::Debug;
-use std::mem;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use std::time::{Duration, SystemTime};
-
 use crate::curve1174::cpt::*;
 use crate::curve1174::ecpt::*;
 use crate::curve1174::fields::*;
 use crate::curve1174::*;
 use crate::hash::*;
 use crate::utils::*;
-use std::cmp::Ordering;
+use crate::CryptoError;
 
-use lazy_static::*;
+use lazy_static::lazy_static;
+use log::*;
+use rand::prelude::*;
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::Debug;
+use std::mem;
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::time::{Duration, SystemTime};
 
 // ----------------------------------------------------------------
 
@@ -329,13 +329,13 @@ pub struct LR {
 // --------------------------------------------------------
 
 impl Debug for BulletProof {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "BP(vcmt: {}, ...)", self.vcmt)
     }
 }
 
 impl fmt::Display for BulletProof {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }

--- a/crypto/src/curve1174/cpt.rs
+++ b/crypto/src/curve1174/cpt.rs
@@ -24,6 +24,7 @@
 
 use super::*;
 use crate::CryptoError;
+
 use crypto::aes;
 use crypto::aes::KeySize::KeySize128;
 use crypto::aesni;
@@ -89,13 +90,13 @@ impl Pt {
 }
 
 impl fmt::Display for Pt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Pt({})", self.into_hex())
     }
 }
 
 impl fmt::Debug for Pt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Pt({})", self.into_hex())
     }
 }
@@ -145,13 +146,13 @@ impl SecretKey {
 }
 
 impl fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SKey({})", self.into_hex())
     }
 }
 
 impl fmt::Debug for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SKey({})", self.into_hex())
     }
 }
@@ -207,13 +208,13 @@ impl PublicKey {
 }
 
 impl fmt::Display for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PKey({})", self.into_hex())
     }
 }
 
 impl fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PKey({})", self.into_hex())
     }
 }
@@ -350,7 +351,7 @@ pub struct EncryptedPayload {
 }
 
 impl fmt::Debug for EncryptedPayload {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "apkg={} ag={} cmsg={}",
@@ -362,7 +363,7 @@ impl fmt::Debug for EncryptedPayload {
 }
 
 impl fmt::Display for EncryptedPayload {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }

--- a/crypto/src/curve1174/ecpt.rs
+++ b/crypto/src/curve1174/ecpt.rs
@@ -184,7 +184,7 @@ impl From<Hash> for ECp {
 }
 
 impl fmt::Display for ECp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "ECp {{\n x: {},\n y: {},\n z: {},\n t: {} }}",

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -172,7 +172,7 @@ macro_rules! field_impl {
                 mk
             }
 
-            pub fn synthetic_random(pref: &str, uniq: &Hashable, h: &Hash) -> Self {
+            pub fn synthetic_random(pref: &str, uniq: &dyn Hashable, h: &Hash) -> Self {
                 // Construct a pseudo random field value without using the PRNG
                 // This generates so-called "deterministic randomness" and assures
                 // random-appearing values that will always be the same for the same
@@ -227,7 +227,7 @@ macro_rules! field_impl {
         // -------------------------------------------
 
         impl fmt::Display for $name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 let tmp = (*self).unscaled_bits();
                 write!(f, $fmt, tmp.nbr_str())
             }

--- a/crypto/src/curve1174/fq51.rs
+++ b/crypto/src/curve1174/fq51.rs
@@ -96,7 +96,7 @@ impl From<Fq51> for Fq {
 }
 
 impl fmt::Debug for Fq51 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "Fq51([{:016x}, {:016x}, {:016x}, {:016x}, {:016x}])",
@@ -110,7 +110,7 @@ impl fmt::Debug for Fq51 {
 }
 
 impl fmt::Display for Fq51 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Fq51({})", self.nbr_str())
     }
 }

--- a/crypto/src/curve1174/lev32.rs
+++ b/crypto/src/curve1174/lev32.rs
@@ -84,7 +84,7 @@ impl Lev32 {
 }
 
 impl fmt::Display for Lev32 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Lev32({})", self.nbr_str())
     }
 }

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -25,17 +25,15 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 
+use lazy_static::lazy_static;
 use rand::prelude::*;
-
+use std::cmp::Ordering;
 use std::fmt;
 use std::mem;
-
-use hex;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::hash::*;
 use crate::utils::*;
-use std::cmp::Ordering;
 
 mod winvec; // window vectors for point multiplication
 use self::winvec::*;
@@ -57,8 +55,6 @@ use self::ecpt::*;
 
 pub mod cpt; // compressed point representation
 use self::cpt::*;
-
-use lazy_static::*;
 
 // -------------------------------------------------------------------
 // Signature Public Key - for checking curve constants validity

--- a/crypto/src/curve1174/u256.rs
+++ b/crypto/src/curve1174/u256.rs
@@ -23,6 +23,7 @@
 
 use super::*;
 use crate::CryptoError;
+
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;
@@ -245,7 +246,7 @@ impl U256 {
 // -------------------------------------------
 
 impl fmt::Debug for U256 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "U256([{:016x}, {:016x}, {:016x}, {:016x}])",
@@ -255,7 +256,7 @@ impl fmt::Debug for U256 {
 }
 
 impl fmt::Display for U256 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "U256({})", self.nbr_str())
     }
 }

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -23,6 +23,7 @@
 
 use crate::utils::*;
 use crate::CryptoError;
+
 use sha3::{Digest, Sha3_256};
 use std::fmt;
 use std::hash as stdhash;
@@ -72,14 +73,14 @@ impl Hash {
         hasher.result()
     }
 
-    pub fn digest(msg: &Hashable) -> Hash {
+    pub fn digest(msg: &dyn Hashable) -> Hash {
         // produce a Hash from a single Hashable
         let mut hasher = Hasher::new();
         msg.hash(&mut hasher);
         hasher.result()
     }
 
-    pub fn digest_chain(msgs: &[&Hashable]) -> Hash {
+    pub fn digest_chain(msgs: &[&dyn Hashable]) -> Hash {
         // produce a Hash from a list of Hashable items
         let mut state = Hasher::new();
         for x in msgs.iter() {
@@ -103,13 +104,13 @@ impl Hash {
 }
 
 impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "H({})", self.into_hex())
     }
 }
 
 impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }
@@ -309,7 +310,6 @@ pub mod tests {
     #[test]
     fn check_empty_hash() {
         // assure that we get correct Sha3-256 hash of empty vector
-        extern crate hex;
         let h = Hash::from_vector(b"");
         let chk = hex::decode("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a")
             .unwrap();

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -19,26 +19,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-extern crate crypto;
-extern crate gmp;
-extern crate hex;
-extern crate lazy_static;
-extern crate parking_lot;
-extern crate rand;
-extern crate rust_libpbc;
-extern crate sha3;
-#[macro_use]
-extern crate log;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-
 pub mod bulletproofs;
 pub mod curve1174;
 pub mod hash;
 pub mod keying;
 pub mod pbc;
 pub mod utils;
+
+use crypto;
+use failure::Fail;
+use gmp;
+use hex;
+use lazy_static;
+use log;
+use parking_lot;
+use rand;
+use rust_libpbc;
+use sha3;
 
 #[derive(Debug, Fail)]
 pub enum CryptoError {

--- a/crypto/src/pbc/fast.rs
+++ b/crypto/src/pbc/fast.rs
@@ -41,6 +41,7 @@
 
 use super::*;
 use crate::CryptoError;
+
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;
@@ -111,7 +112,7 @@ impl Zr {
         zx
     }
 
-    pub fn synthetic_random(pref: &str, uniq: &Hashable, h: &Hash) -> Self {
+    pub fn synthetic_random(pref: &str, uniq: &dyn Hashable, h: &Hash) -> Self {
         // Construct a pseudo random field value without using the PRNG
         // This generates so-called "deterministic randomness" and assures
         // random-appearing values that will always be the same for the same
@@ -173,13 +174,13 @@ impl From<i64> for Zr {
 }
 
 impl fmt::Debug for Zr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastZr({})", self.into_hex())
     }
 }
 
 impl fmt::Display for Zr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastZr({})", self.into_hex())
     }
 }
@@ -436,13 +437,13 @@ impl PartialEq for G1 {
 }
 
 impl fmt::Debug for G1 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastG1({})", self.into_hex())
     }
 }
 
 impl fmt::Display for G1 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastG1({})", self.into_hex())
     }
 }
@@ -650,13 +651,13 @@ impl PartialEq for G2 {
 }
 
 impl fmt::Debug for G2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastG2({})", self.into_hex())
     }
 }
 
 impl fmt::Display for G2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastG2({})", self.into_hex())
     }
 }
@@ -813,7 +814,7 @@ impl GT {
 }
 
 impl fmt::Display for GT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastGT({})", self.into_hex())
     }
 }
@@ -874,7 +875,7 @@ impl SecretKey {
 }
 
 impl fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastSKey({})", self.into_hex())
     }
 }
@@ -930,13 +931,13 @@ impl PartialEq for PublicKey {
 }
 
 impl fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastPKey({})", self.into_hex())
     }
 }
 
 impl fmt::Display for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastPKey({})", self.into_hex())
     }
 }
@@ -980,7 +981,7 @@ impl Signature {
 }
 
 impl fmt::Display for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FastSig({})", self.into_hex())
     }
 }

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -24,15 +24,15 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
+pub mod fast;
+pub mod secure;
 use crate::hash::*;
 use crate::utils::*;
-use lazy_static::*;
+
+use lazy_static::lazy_static;
 use rust_libpbc;
 use std::fmt;
 use std::vec::*;
-
-pub mod fast;
-pub mod secure;
 
 // -------------------------------------------------------------------
 // Signature Public Key - for checking curve constants validity

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -32,6 +32,7 @@
 
 use super::*;
 use crate::CryptoError;
+
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;
@@ -96,7 +97,7 @@ impl Zr {
         zx
     }
 
-    pub fn synthetic_random(pref: &str, uniq: &Hashable, h: &Hash) -> Self {
+    pub fn synthetic_random(pref: &str, uniq: &dyn Hashable, h: &Hash) -> Self {
         // Construct a pseudo random field value without using the PRNG
         // This generates so-called "deterministic randomness" and assures
         // random-appearing values that will always be the same for the same
@@ -155,7 +156,7 @@ impl PartialOrd for Zr {
 }
 
 impl fmt::Display for Zr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureZr({})", self.into_hex())
     }
 }
@@ -235,7 +236,7 @@ impl G1 {
 
 impl fmt::Display for G1 {
     // for display of signatures
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureG1({})", self.into_hex())
     }
 }
@@ -316,13 +317,13 @@ impl G2 {
 }
 
 impl fmt::Debug for G2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureG2({})", self.into_hex())
     }
 }
 
 impl fmt::Display for G2 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureG2({})", self.into_hex())
     }
 }
@@ -380,7 +381,7 @@ impl GT {
 }
 
 impl fmt::Display for GT {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureGT({})", self.into_hex())
     }
 }
@@ -421,13 +422,13 @@ impl SecretKey {
 }
 
 impl fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureSKey({})", self.into_hex())
     }
 }
 
 impl fmt::Debug for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureSKey({})", self.into_hex())
     }
 }
@@ -483,13 +484,13 @@ impl PublicKey {
 }
 
 impl fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecurePKey({})", self.into_hex())
     }
 }
 
 impl fmt::Display for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecurePKey({})", self.into_hex())
     }
 }
@@ -564,7 +565,7 @@ impl SecretSubKey {
 }
 
 impl fmt::Display for SecretSubKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureSSubKey({})", self.into_hex())
     }
 }
@@ -605,7 +606,7 @@ impl PublicSubKey {
 }
 
 impl fmt::Display for PublicSubKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecurePSubKey({})", self.into_hex())
     }
 }
@@ -655,13 +656,13 @@ impl Signature {
 }
 
 impl fmt::Debug for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureSig({})", self.into_hex())
     }
 }
 
 impl fmt::Display for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureSig({})", self.into_hex())
     }
 }
@@ -820,7 +821,7 @@ impl RVal {
 }
 
 impl fmt::Display for RVal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureRVal({})", self.into_hex())
     }
 }

--- a/crypto/src/utils/mod.rs
+++ b/crypto/src/utils/mod.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use crate::CryptoError;
+
 use hex;
 use std::cmp::Ordering;
 

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 failure = "0.1"
-failure_derive = "0.1"
 base64 = "0.9"
 lazy_static = "1.1"
 regex = "1.0"

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_keychain"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 log = "0.4"

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -21,21 +21,11 @@
 
 #![deny(warnings)]
 
-extern crate stegos_config;
-extern crate stegos_crypto;
-#[macro_use]
-extern crate log;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-extern crate base64;
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
-
 pub mod pem;
 
-use failure::Error;
+use failure::{Error, Fail};
+use lazy_static;
+use log::*;
 use std::fs;
 use std::path::Path;
 use stegos_config::ConfigKeyChain;

--- a/keychain/src/pem.rs
+++ b/keychain/src/pem.rs
@@ -40,6 +40,8 @@
     unused_qualifications
 )]
 
+use failure::Fail;
+use lazy_static::lazy_static;
 use regex::bytes::{Captures, Regex};
 
 /// Erros caused by PEM decoder
@@ -85,7 +87,7 @@ pub struct Pem {
 }
 
 impl Pem {
-    fn new_from_captures(caps: Captures) -> Result<Pem, ErrorKind> {
+    fn new_from_captures(caps: Captures<'_>) -> Result<Pem, ErrorKind> {
         fn as_utf8<'a>(bytes: &'a [u8]) -> Result<&'a str, ErrorKind> {
             std::str::from_utf8(bytes).map_err(|e| ErrorKind::NotUtf8(e).into())
         }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -8,7 +8,6 @@ build = "build.rs"
 [dependencies]
 bytes = "0.4"
 failure = "0.1"
-failure_derive = "0.1"
 fnv = "1.0"
 futures = "0.1"
 ipnetwork = "^0.12"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_network"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 build = "build.rs"
 
 [dependencies]

--- a/network/build.rs
+++ b/network/build.rs
@@ -1,5 +1,3 @@
-extern crate protobuf_codegen_pure;
-
 use protobuf_codegen_pure::{Args, Customize};
 use std::fs;
 

--- a/network/examples/echo-dialer.rs
+++ b/network/examples/echo-dialer.rs
@@ -18,23 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate bytes;
-extern crate env_logger;
-extern crate futures;
-extern crate libp2p;
-extern crate stegos_network;
-extern crate tokio_codec;
-extern crate tokio_current_thread;
-extern crate unsigned_varint;
-
+use env_logger;
 use futures::sync::oneshot;
 use futures::{Future, Sink, Stream};
+use libp2p;
 use libp2p::core::Transport;
 use libp2p::core::{either::EitherOutput, upgrade};
 use libp2p::tcp::TcpConfig;
 use libp2p::websocket::WsConfig;
 use std::env;
 use stegos_network::EchoUpgrade;
+use tokio_current_thread;
 
 fn main() {
     env_logger::init();

--- a/network/examples/floodsub.rs
+++ b/network/examples/floodsub.rs
@@ -22,27 +22,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-extern crate bytes;
-extern crate env_logger;
-extern crate futures;
-extern crate libp2p;
-extern crate rand;
-extern crate tokio;
-extern crate tokio_current_thread;
-extern crate tokio_io;
-extern crate tokio_stdin;
-
+use env_logger;
 use futures::future::Future;
 use futures::sync::mpsc;
 use futures::{Sink, Stream};
+use libp2p;
 use libp2p::core::upgrade;
 use libp2p::core::{Multiaddr, PublicKey, Transport};
 use libp2p::peerstore::PeerId;
 use libp2p::secio::SecioOutput;
 use libp2p::tcp::TcpConfig;
 use libp2p::websocket::WsConfig;
+use rand;
 use std::{env, mem};
 use tokio::runtime::Runtime;
+use tokio_stdin;
 
 pub struct FloodSubHandler {
     pub rx: mpsc::Receiver<String>,

--- a/network/examples/ncp-ping.rs
+++ b/network/examples/ncp-ping.rs
@@ -18,23 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate bytes;
-extern crate env_logger;
-extern crate futures;
-extern crate libp2p;
-extern crate stegos_network;
-extern crate tokio_codec;
-extern crate tokio_current_thread;
-extern crate unsigned_varint;
-
+use env_logger;
 use futures::sync::oneshot;
 use futures::{Future, Sink, Stream};
+use libp2p;
 use libp2p::core::Transport;
 use libp2p::core::{either::EitherOutput, upgrade};
 use libp2p::tcp::TcpConfig;
 use libp2p::websocket::WsConfig;
 use std::env;
 use stegos_network::protocol::{NcpMsg, NcpProtocolConfig};
+use tokio_current_thread;
 
 fn main() {
     env_logger::init();

--- a/network/src/echo/protocol.rs
+++ b/network/src/echo/protocol.rs
@@ -41,7 +41,7 @@ where
 {
     type Output = (Endpoint, EchoMiddleware<S>);
     type MultiaddrFuture = Maf;
-    type Future = Box<Future<Item = (Self::Output, Maf), Error = IoError> + Send>;
+    type Future = Box<dyn Future<Item = (Self::Output, Maf), Error = IoError> + Send>;
     type NamesIter = iter::Once<(Bytes, ())>;
     type UpgradeIdentifier = ();
 
@@ -77,7 +77,9 @@ where
     S: AsyncRead + AsyncWrite + Send,
 {
     /// Wraps stream in Framing proto
-    pub fn new<'a>(socket: S) -> Box<Future<Item = EchoMiddleware<S>, Error = IoError> + Send + 'a>
+    pub fn new<'a>(
+        socket: S,
+    ) -> Box<dyn Future<Item = EchoMiddleware<S>, Error = IoError> + Send + 'a>
     where
         S: 'a,
     {

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -21,30 +21,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// #![deny(warnings)]
+#![deny(warnings)]
 
-#[macro_use]
-extern crate log;
-extern crate bytes;
-// #[macro_use]
-// extern crate failure_derive;
-#[macro_use]
-extern crate failure;
-extern crate fnv;
-extern crate futures;
-extern crate ipnetwork;
-extern crate libp2p;
-extern crate parking_lot;
-extern crate pnet;
-extern crate protobuf;
-extern crate rand;
-extern crate stegos_config;
-extern crate stegos_crypto;
-extern crate stegos_keychain;
-extern crate tokio;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate unsigned_varint;
+use log;
+use protobuf;
+use rand;
 
 mod echo;
 mod ncp;

--- a/network/src/ncp/handler.rs
+++ b/network/src/ncp/handler.rs
@@ -63,7 +63,7 @@ where
                         debug!("Received a message: {:?}", msg);
                         match msg {
                             NcpMsg::Ping { ping_data } => {
-                                let mut resp = NcpMsg::Pong { ping_data };
+                                let resp = NcpMsg::Pong { ping_data };
                                 Box::new(rest.send(resp).map(|m| Loop::Continue(m)))
                                     as Box<Future<Item = _, Error = _> + Send>
                             }

--- a/network/src/ncp/protocol.rs
+++ b/network/src/ncp/protocol.rs
@@ -206,17 +206,18 @@ fn proto_to_msg(mut message: ncp_proto::Message) -> Result<NcpMsg, IoError> {
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p;
-    extern crate simple_logger;
-    extern crate tokio_current_thread;
-
     use crate::ncp::protocol::{GetPeersResponse, NcpMsg, NcpProtocolConfig, PeerInfo};
+
     use futures::{Future, Sink, Stream};
+    use libp2p;
     use libp2p::core::{PeerId, PublicKey, Transport};
     use libp2p::tcp::TcpConfig;
+    use log::*;
     use rand;
+    use simple_logger;
     use std::sync::mpsc;
     use std::thread;
+    use tokio_current_thread;
 
     #[test]
     fn log_test() {

--- a/network/src/node/broker.rs
+++ b/network/src/node/broker.rs
@@ -30,6 +30,7 @@ use futures::sync::mpsc;
 use futures::Stream;
 use futures::{Async, Future, Poll};
 use libp2p::floodsub::{self, TopicHash};
+use log::*;
 
 // ----------------------------------------------------------------
 // Public API.
@@ -106,7 +107,7 @@ enum Message {
 
 struct BrokerService {
     consumers: FnvHashMap<TopicHash, Vec<mpsc::UnboundedSender<Vec<u8>>>>,
-    pubsub_rx: Box<Stream<Item = Message, Error = ()> + Send>,
+    pubsub_rx: Box<dyn Stream<Item = Message, Error = ()> + Send>,
     floodsub_ctl: floodsub::FloodSubController,
 }
 

--- a/network/src/node/heartbeat/mod.rs
+++ b/network/src/node/heartbeat/mod.rs
@@ -24,11 +24,13 @@
 #![allow(dead_code)]
 
 use super::{broker::Broker, Inner};
+use failure::format_err;
 use failure::Error;
 use futures::sync::mpsc;
 use futures::{Async, Future, Poll, Stream};
 use libp2p::peerstore::{PeerAccess, Peerstore};
 use libp2p::Multiaddr;
+use log::*;
 use parking_lot::RwLock;
 use protobuf::{self, Message};
 use std::cmp::{Eq, PartialEq};
@@ -138,7 +140,7 @@ struct HeartbeatService {
     me: NodeInfo,
     my_skey: NodeSecretKey,
     active_nodes: HashSet<NodeInfo>,
-    input: Box<Stream<Item = HeartbeatControlMsg, Error = ()> + Send>,
+    input: Box<dyn Stream<Item = HeartbeatControlMsg, Error = ()> + Send>,
     consumers: Vec<mpsc::UnboundedSender<HeartbeatUpdate>>,
     ttl: u64,
     broker: Broker,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,6 +3,7 @@ name = "stegos_node"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 stegos_config = { path = "../config" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -12,9 +12,8 @@ stegos_blockchain = { path = "../blockchain" }
 stegos_network = { path = "../network" }
 stegos_keychain = { path = "../keychain" }
 log = "0.4"
-failure = "0.1.2"
-failure_derive = "0.1.2"
-futures = "0.1.25"
+failure = "0.1"
+futures = "0.1"
 tokio-timer = "0.2"
 chrono = "0.4"
 protobuf = "2.2"

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,5 +1,3 @@
-extern crate protobuf_codegen_pure;
-
 use protobuf_codegen_pure::{Args, Customize};
 use std::fs;
 

--- a/node/src/bootstrap.rs
+++ b/node/src/bootstrap.rs
@@ -19,19 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-extern crate stegos_blockchain;
-extern crate stegos_config;
-extern crate stegos_keychain;
-extern crate stegos_node;
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate log;
-extern crate protobuf;
-extern crate simple_logger;
-
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
+use log::*;
 use protobuf::Message;
+use simple_logger;
 use std::fs;
 use std::process;
 use stegos_blockchain::genesis;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -39,11 +39,11 @@ extern crate stegos_network;
 pub mod protos;
 
 use chrono::Utc;
+use crate::protos::{FromProto, IntoProto};
 use failure::Error;
 use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::{Async, Future, Poll, Stream};
 use protobuf::Message;
-use protos::{FromProto, IntoProto};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -21,28 +21,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#[macro_use]
-extern crate log;
-extern crate failure;
-extern crate tokio_timer;
-#[macro_use]
-extern crate failure_derive;
-extern crate chrono;
-extern crate futures;
-extern crate protobuf;
-extern crate rand;
-extern crate stegos_blockchain;
-extern crate stegos_crypto;
-extern crate stegos_keychain;
-extern crate stegos_network;
-
 pub mod protos;
 
-use chrono::Utc;
 use crate::protos::{FromProto, IntoProto};
-use failure::Error;
+
+use chrono::Utc;
+use failure::{Error, Fail};
 use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::{Async, Future, Poll, Stream};
+use log::*;
+use protobuf;
 use protobuf::Message;
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/node/src/protos/mod.rs
+++ b/node/src/protos/mod.rs
@@ -23,7 +23,7 @@
 
 pub mod node;
 
-use failure::Error;
+use failure::{Error, Fail};
 use stegos_blockchain::*;
 use stegos_crypto::bulletproofs::{BulletProof, DotProof, L2_NBASIS, LR};
 use stegos_crypto::curve1174::cpt::Pt;

--- a/node/src/protos/node.rs
+++ b/node/src/protos/node.rs
@@ -67,7 +67,7 @@ impl ::protobuf::Message for Pt {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -94,7 +94,7 @@ impl ::protobuf::Message for Pt {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if !self.data.is_empty() {
             os.write_bytes(1, &self.data)?;
         }
@@ -114,13 +114,13 @@ impl ::protobuf::Message for Pt {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -173,13 +173,13 @@ impl ::protobuf::Clear for Pt {
 }
 
 impl ::std::fmt::Debug for Pt {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Pt {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -230,7 +230,7 @@ impl ::protobuf::Message for Fr {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -257,7 +257,7 @@ impl ::protobuf::Message for Fr {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if !self.data.is_empty() {
             os.write_bytes(1, &self.data)?;
         }
@@ -277,13 +277,13 @@ impl ::protobuf::Message for Fr {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -336,13 +336,13 @@ impl ::protobuf::Clear for Fr {
 }
 
 impl ::std::fmt::Debug for Fr {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Fr {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -393,7 +393,7 @@ impl ::protobuf::Message for G2 {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -420,7 +420,7 @@ impl ::protobuf::Message for G2 {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if !self.data.is_empty() {
             os.write_bytes(1, &self.data)?;
         }
@@ -440,13 +440,13 @@ impl ::protobuf::Message for G2 {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -499,13 +499,13 @@ impl ::protobuf::Clear for G2 {
 }
 
 impl ::std::fmt::Debug for G2 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for G2 {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -556,7 +556,7 @@ impl ::protobuf::Message for Hash {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -583,7 +583,7 @@ impl ::protobuf::Message for Hash {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if !self.data.is_empty() {
             os.write_bytes(1, &self.data)?;
         }
@@ -603,13 +603,13 @@ impl ::protobuf::Message for Hash {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -662,13 +662,13 @@ impl ::protobuf::Clear for Hash {
 }
 
 impl ::std::fmt::Debug for Hash {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Hash {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -731,7 +731,7 @@ impl ::protobuf::Message for PublicKey {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -759,7 +759,7 @@ impl ::protobuf::Message for PublicKey {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.point.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -781,13 +781,13 @@ impl ::protobuf::Message for PublicKey {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -840,13 +840,13 @@ impl ::protobuf::Clear for PublicKey {
 }
 
 impl ::std::fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for PublicKey {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -948,7 +948,7 @@ impl ::protobuf::Message for SchnorrSig {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -983,7 +983,7 @@ impl ::protobuf::Message for SchnorrSig {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.u.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1010,13 +1010,13 @@ impl ::protobuf::Message for SchnorrSig {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1075,13 +1075,13 @@ impl ::protobuf::Clear for SchnorrSig {
 }
 
 impl ::std::fmt::Debug for SchnorrSig {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for SchnorrSig {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1144,7 +1144,7 @@ impl ::protobuf::Message for SecurePublicKey {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1172,7 +1172,7 @@ impl ::protobuf::Message for SecurePublicKey {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.point.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1194,13 +1194,13 @@ impl ::protobuf::Message for SecurePublicKey {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1253,13 +1253,13 @@ impl ::protobuf::Clear for SecurePublicKey {
 }
 
 impl ::std::fmt::Debug for SecurePublicKey {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for SecurePublicKey {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1388,7 +1388,7 @@ impl ::protobuf::Message for EncryptedPayload {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1429,7 +1429,7 @@ impl ::protobuf::Message for EncryptedPayload {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.apkg.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1459,13 +1459,13 @@ impl ::protobuf::Message for EncryptedPayload {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1530,13 +1530,13 @@ impl ::protobuf::Clear for EncryptedPayload {
 }
 
 impl ::std::fmt::Debug for EncryptedPayload {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for EncryptedPayload {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1677,7 +1677,7 @@ impl ::protobuf::Message for LR {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1719,7 +1719,7 @@ impl ::protobuf::Message for LR {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.x.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1751,13 +1751,13 @@ impl ::protobuf::Message for LR {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1822,13 +1822,13 @@ impl ::protobuf::Clear for LR {
 }
 
 impl ::std::fmt::Debug for LR {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for LR {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -2039,7 +2039,7 @@ impl ::protobuf::Message for DotProof {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -2095,7 +2095,7 @@ impl ::protobuf::Message for DotProof {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.u.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2137,13 +2137,13 @@ impl ::protobuf::Message for DotProof {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -2220,13 +2220,13 @@ impl ::protobuf::Clear for DotProof {
 }
 
 impl ::std::fmt::Debug for DotProof {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for DotProof {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -2718,7 +2718,7 @@ impl ::protobuf::Message for BulletProof {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -2823,7 +2823,7 @@ impl ::protobuf::Message for BulletProof {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.vcmt.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2900,13 +2900,13 @@ impl ::protobuf::Message for BulletProof {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -3025,13 +3025,13 @@ impl ::protobuf::Clear for BulletProof {
 }
 
 impl ::std::fmt::Debug for BulletProof {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for BulletProof {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -3172,7 +3172,7 @@ impl ::protobuf::Message for Output {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -3214,7 +3214,7 @@ impl ::protobuf::Message for Output {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.recipient.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -3246,13 +3246,13 @@ impl ::protobuf::Message for Output {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -3317,13 +3317,13 @@ impl ::protobuf::Clear for Output {
 }
 
 impl ::std::fmt::Debug for Output {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Output {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -3503,7 +3503,7 @@ impl ::protobuf::Message for Transaction {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -3562,7 +3562,7 @@ impl ::protobuf::Message for Transaction {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         for v in &self.txins {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -3602,13 +3602,13 @@ impl ::protobuf::Message for Transaction {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -3685,13 +3685,13 @@ impl ::protobuf::Clear for Transaction {
 }
 
 impl ::std::fmt::Debug for Transaction {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Transaction {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -3802,7 +3802,7 @@ impl ::protobuf::Message for BaseBlockHeader {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -3860,7 +3860,7 @@ impl ::protobuf::Message for BaseBlockHeader {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if self.version != 0 {
             os.write_uint64(1, self.version)?;
         }
@@ -3891,13 +3891,13 @@ impl ::protobuf::Message for BaseBlockHeader {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -3968,13 +3968,13 @@ impl ::protobuf::Clear for BaseBlockHeader {
 }
 
 impl ::std::fmt::Debug for BaseBlockHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for BaseBlockHeader {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -4154,7 +4154,7 @@ impl ::protobuf::Message for MonetaryBlockHeader {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -4203,7 +4203,7 @@ impl ::protobuf::Message for MonetaryBlockHeader {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.base.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -4240,13 +4240,13 @@ impl ::protobuf::Message for MonetaryBlockHeader {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -4317,13 +4317,13 @@ impl ::protobuf::Clear for MonetaryBlockHeader {
 }
 
 impl ::std::fmt::Debug for MonetaryBlockHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for MonetaryBlockHeader {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -4457,7 +4457,7 @@ impl ::protobuf::Message for MerkleNode {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -4512,7 +4512,7 @@ impl ::protobuf::Message for MerkleNode {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.hash.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -4545,13 +4545,13 @@ impl ::protobuf::Message for MerkleNode {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -4622,13 +4622,13 @@ impl ::protobuf::Clear for MerkleNode {
 }
 
 impl ::std::fmt::Debug for MerkleNode {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for MerkleNode {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -4714,7 +4714,7 @@ impl ::protobuf::Message for MonetaryBlockBody {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -4749,7 +4749,7 @@ impl ::protobuf::Message for MonetaryBlockBody {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         for v in &self.inputs {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -4776,13 +4776,13 @@ impl ::protobuf::Message for MonetaryBlockBody {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -4841,13 +4841,13 @@ impl ::protobuf::Clear for MonetaryBlockBody {
 }
 
 impl ::std::fmt::Debug for MonetaryBlockBody {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for MonetaryBlockBody {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -4949,7 +4949,7 @@ impl ::protobuf::Message for MonetaryBlock {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -4984,7 +4984,7 @@ impl ::protobuf::Message for MonetaryBlock {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.header.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5011,13 +5011,13 @@ impl ::protobuf::Message for MonetaryBlock {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -5076,13 +5076,13 @@ impl ::protobuf::Clear for MonetaryBlock {
 }
 
 impl ::std::fmt::Debug for MonetaryBlock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for MonetaryBlock {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -5215,7 +5215,7 @@ impl ::protobuf::Message for KeyBlockHeader {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -5257,7 +5257,7 @@ impl ::protobuf::Message for KeyBlockHeader {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.base.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5289,13 +5289,13 @@ impl ::protobuf::Message for KeyBlockHeader {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -5360,13 +5360,13 @@ impl ::protobuf::Clear for KeyBlockHeader {
 }
 
 impl ::std::fmt::Debug for KeyBlockHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for KeyBlockHeader {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -5429,7 +5429,7 @@ impl ::protobuf::Message for KeyBlock {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -5457,7 +5457,7 @@ impl ::protobuf::Message for KeyBlock {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.header.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5479,13 +5479,13 @@ impl ::protobuf::Message for KeyBlock {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -5538,13 +5538,13 @@ impl ::protobuf::Clear for KeyBlock {
 }
 
 impl ::std::fmt::Debug for KeyBlock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for KeyBlock {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -5683,7 +5683,7 @@ impl ::protobuf::Message for Block {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -5728,7 +5728,7 @@ impl ::protobuf::Message for Block {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let ::std::option::Option::Some(ref v) = self.block {
             match v {
                 &Block_oneof_block::key_block(ref v) => {
@@ -5759,13 +5759,13 @@ impl ::protobuf::Message for Block {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -5824,13 +5824,13 @@ impl ::protobuf::Clear for Block {
 }
 
 impl ::std::fmt::Debug for Block {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Block {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }

--- a/randhound/Cargo.toml
+++ b/randhound/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_randhound"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 stegos_config = { path = "../config" }

--- a/randhound/Cargo.toml
+++ b/randhound/Cargo.toml
@@ -10,7 +10,6 @@ stegos_crypto = { path = "../crypto" }
 stegos_keychain = { path = "../keychain" }
 stegos_network = { path = "../network" }
 failure = "0.1"
-failure_derive = "0.1"
 futures = "0.1"
 hex = "0.3"
 lazy_static = "1.1"

--- a/randhound/build.rs
+++ b/randhound/build.rs
@@ -1,5 +1,3 @@
-extern crate protobuf_codegen_pure;
-
 use protobuf_codegen_pure::{Args, Customize};
 use std::fs;
 

--- a/randhound/src/lib.rs
+++ b/randhound/src/lib.rs
@@ -21,28 +21,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-extern crate failure;
-extern crate futures;
-// #[macro_use]
-// extern crate lazy_static;
-extern crate parking_lot;
-extern crate protobuf;
-extern crate rand;
-extern crate state;
-extern crate stegos_config;
-extern crate stegos_crypto;
-extern crate stegos_keychain;
-extern crate stegos_network;
-extern crate tokio;
-extern crate tokio_timer;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate failure_derive;
+mod randhound;
+mod randhound_proto;
+
+use crate::randhound::GlobalState;
 
 use failure::Error;
 use futures::sync::mpsc::UnboundedReceiver;
 use futures::{Async, Future, Poll, Stream};
+use log::*;
+use protobuf;
 use std::sync::Arc;
 use std::time::Duration;
 use stegos_config::Config;
@@ -50,11 +38,6 @@ use stegos_crypto::hash::{Hash, Hashable};
 use stegos_keychain::KeyChain;
 use stegos_network::Broker;
 use tokio::timer::Interval;
-
-mod randhound;
-mod randhound_proto;
-
-use crate::randhound::GlobalState;
 
 const TOPIC: &'static str = "randhound";
 
@@ -221,6 +204,6 @@ impl Future for RandHoundService {
 }
 
 #[inline]
-pub fn node_id_from_hashable(id: &Hashable) -> String {
+pub fn node_id_from_hashable(id: &dyn Hashable) -> String {
     Hash::digest(id).into_hex()
 }

--- a/randhound/src/lib.rs
+++ b/randhound/src/lib.rs
@@ -54,7 +54,7 @@ use tokio::timer::Interval;
 mod randhound;
 mod randhound_proto;
 
-use randhound::GlobalState;
+use crate::randhound::GlobalState;
 
 const TOPIC: &'static str = "randhound";
 
@@ -91,7 +91,7 @@ struct RandHoundService {
     /// Broadcast Input Messages.
     broadcast_rx: UnboundedReceiver<Vec<u8>>,
     /// Is Randhound started??
-    randhound_started: bool,
+    // randhound_started: bool,
     /// Randhound state
     state: Arc<GlobalState>,
 }
@@ -119,7 +119,7 @@ impl RandHoundService {
             timer,
             unicast_rx,
             broadcast_rx,
-            randhound_started: false,
+            // randhound_started: false,
             state: Arc::new(state),
         };
 

--- a/randhound/src/randhound.rs
+++ b/randhound/src/randhound.rs
@@ -102,26 +102,22 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 
-use failure::Error;
-use std::fs;
-use stegos_keychain::{pem, KeyChain, KeyChainError};
+use super::randhound_proto::{self, RandhoundMessage, RandhoundMessageTypes};
 
+use failure::{Error, Fail};
+use log::*;
 use parking_lot::RwLock;
+use protobuf::Message as ProtoMessage;
 use std::collections::hash_map::HashMap;
 use std::collections::hash_set::HashSet;
-
+use std::collections::VecDeque;
+use std::fs;
+use std::sync::Arc;
 use std::vec::Vec;
 use stegos_crypto::hash::*;
 use stegos_crypto::pbc::*;
-
-use std::collections::VecDeque;
-use std::sync::Arc;
-
+use stegos_keychain::{pem, KeyChain, KeyChainError};
 use stegos_network::Broker;
-
-use super::randhound_proto::{self, RandhoundMessage, RandhoundMessageTypes};
-
-use protobuf::Message as ProtoMessage;
 
 type Zr = fast::Zr;
 type G1 = fast::G1;
@@ -1821,7 +1817,7 @@ fn reduce_lagrange_interpolate(v: &HashMap<secure::PublicKey, DecrShare>) -> G2 
         .fold(G2::zero(), |ans, (x, y)| ans + *y * lagrange_wt(&xs, *x))
 }
 
-fn schedule_after(_dursec: f32, _skedfn: &Fn() -> ()) {
+fn schedule_after(_dursec: f32, _skedfn: &dyn Fn() -> ()) {
     // TODO: somehow pull this off...
     // Wait till dursec seconds have elapsed, then call the indicated function.
     //

--- a/randhound/src/randhound.rs
+++ b/randhound/src/randhound.rs
@@ -1900,7 +1900,7 @@ pub(crate) fn proto_to_msg(mut message: RandhoundMessage) -> Result<Message, Err
             let mut shares = vec![];
             for s in shares_msg.iter() {
                 let pkey = secure::PublicKey::try_from_bytes(&s.get_pkey().to_vec())?;
-                let mut decr_share_msg = s.get_decr_share();
+                let decr_share_msg = s.get_decr_share();
                 let kpt = G1::try_from_bytes(&decr_share_msg.get_kpt().to_vec())?;
                 let share = G2::try_from_bytes(&decr_share_msg.get_share().to_vec())?;
                 let proof = G1::try_from_bytes(&decr_share_msg.get_proof().to_vec())?;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stegos_runtime"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]
 log = "0.4"

--- a/src/console.rs
+++ b/src/console.rs
@@ -19,7 +19,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-use crate::consts;
 use dirs;
 use failure::Error;
 use futures::sync::mpsc::UnboundedReceiver;
@@ -27,6 +26,7 @@ use futures::sync::mpsc::{channel, Receiver, Sender};
 use futures::{Async, Future, Poll, Sink, Stream};
 use lazy_static::*;
 use libp2p::Multiaddr;
+use log::*;
 use regex::Regex;
 use rustyline as rl;
 use std::path::PathBuf;
@@ -35,6 +35,8 @@ use std::thread;
 use stegos_crypto::curve1174::cpt::PublicKey;
 use stegos_network::{Broker, Network};
 use stegos_node::Node;
+
+use crate::consts;
 
 // ----------------------------------------------------------------
 // Public API.

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -22,40 +22,21 @@
 mod console;
 mod consts;
 
-#[macro_use]
-extern crate log;
-extern crate log4rs;
-#[macro_use]
-extern crate clap;
-extern crate atty;
-extern crate dirs;
-extern crate failure;
-extern crate futures;
-extern crate lazy_static;
-extern crate libp2p;
-extern crate parking_lot;
-extern crate regex;
-extern crate rustyline;
-extern crate stegos_blockchain;
-extern crate stegos_config;
-extern crate stegos_crypto;
-extern crate stegos_keychain;
-extern crate stegos_network;
-extern crate stegos_node;
-extern crate stegos_randhound;
-extern crate tokio;
-extern crate tokio_timer;
-
+use atty;
+use clap;
+use clap::crate_version;
 use clap::{App, Arg, ArgMatches};
-use crate::console::*;
-use log::LevelFilter;
+use dirs;
+use log::*;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config as LogConfig, Logger, Root};
 use log4rs::encode::pattern::PatternEncoder;
 use log4rs::{Error as LogError, Handle as LogHandle};
+use rustyline;
 use std::error::Error;
 use std::path::PathBuf;
 use std::process;
+use stegos_config;
 use stegos_config::{Config, ConfigError};
 use stegos_keychain::*;
 use stegos_network::Network;
@@ -63,7 +44,9 @@ use stegos_node::Node;
 use stegos_randhound::*;
 use tokio::runtime::Runtime;
 
-fn load_configuration(args: &ArgMatches) -> Result<Config, Box<Error>> {
+use crate::console::*;
+
+fn load_configuration(args: &ArgMatches<'_>) -> Result<Config, Box<dyn Error>> {
     if let Some(cfg_path) = args.value_of_os("config") {
         // Use --config argument for configuration.
         return Ok(stegos_config::from_file(cfg_path)?);
@@ -110,7 +93,7 @@ fn initialize_logger(cfg: &Config) -> Result<LogHandle, LogError> {
     Ok(handle)
 }
 
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     let args = App::new("Stegos")
         .version(crate_version!())
         .author("Stegos AG <info@stegos.cc>")
@@ -169,7 +152,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    extern crate simple_logger;
+    use super::*;
+    use simple_logger;
 
     #[test]
     fn log_test() {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,5 +2,6 @@
 name = "stegos_storage"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]

--- a/txpool/Cargo.toml
+++ b/txpool/Cargo.toml
@@ -2,5 +2,6 @@
 name = "stegos_txpool"
 version = "0.1.0"
 authors = ["Stegos AG <info@stegos.cc>"]
+edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
- Add `edition = "2018"`  
- Remove "extern crate"
- Remove #[macro_use]
- Fix hidden lifetime parameters
- Add "dyn"

Closes #184