### PR TITLE
Add unit tests for blockchain node

### DIFF
--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -327,7 +327,7 @@ impl Hashable for MonetaryBlock {
 }
 
 /// Types of blocks supported by this blockchain.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Block {
     KeyBlock(KeyBlock),
     MonetaryBlock(MonetaryBlock),

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -328,11 +328,17 @@ pub mod tests {
             KeyChain::new_mem(),
         ];
 
-        let (key_block, monetary_block) = genesis(&keychains);
+        let blocks = genesis(&keychains, 1_000_000);
 
         let mut blockchain = Blockchain::new();
-        blockchain.register_key_block(key_block).unwrap();
-        blockchain.register_monetary_block(monetary_block).unwrap();
+        for block in blocks {
+            match block {
+                Block::KeyBlock(block) => blockchain.register_key_block(block).unwrap(),
+                Block::MonetaryBlock(block) => {
+                    blockchain.register_monetary_block(block).unwrap();
+                }
+            }
+        }
 
         assert!(blockchain.blocks().len() > 0);
         iterate(&mut blockchain).unwrap();

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -29,7 +29,9 @@ use stegos_crypto::pbc::secure as cosi_keys;
 use stegos_keychain::KeyChain;
 
 /// Genesis blocks.
-pub fn genesis(keychains: &[KeyChain]) -> (KeyBlock, MonetaryBlock) {
+pub fn genesis(keychains: &[KeyChain], amount: i64) -> Vec<Block> {
+    let mut blocks = Vec::with_capacity(2);
+
     // Both block are created at the same time in the same epoch.
     let version: u64 = 1;
     let epoch: u64 = 1;
@@ -57,7 +59,6 @@ pub fn genesis(keychains: &[KeyChain]) -> (KeyBlock, MonetaryBlock) {
     let block2 = {
         let previous = Hash::digest(&block1);
         let base = BaseBlockHeader::new(version, previous, epoch, timestamp);
-        let amount: i64 = 1_000_000;
 
         // Genesis doesn't have inputs
         let inputs = Vec::<Hash>::new();
@@ -75,5 +76,8 @@ pub fn genesis(keychains: &[KeyChain]) -> (KeyBlock, MonetaryBlock) {
         MonetaryBlock::new(base, gamma, &inputs, &outputs)
     };
 
-    (block1, block2)
+    blocks.push(Block::KeyBlock(block1));
+    blocks.push(Block::MonetaryBlock(block2));
+
+    blocks
 }

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -305,9 +305,9 @@ impl DataOutput {
         Ok((delta, gamma, data))
     }
 
-    pub fn data_size(&self) -> u64 {
+    pub fn data_size(&self) -> usize {
         assert!(self.payload.ctxt.len() > DATA_PAYLOAD_LEN);
-        (self.payload.ctxt.len() - DATA_PAYLOAD_LEN) as u64
+        (self.payload.ctxt.len() - DATA_PAYLOAD_LEN)
     }
 }
 

--- a/network/src/node/broker.rs
+++ b/network/src/node/broker.rs
@@ -40,7 +40,7 @@ use log::*;
 ///
 #[derive(Clone, Debug)]
 pub struct Broker {
-    upstream: mpsc::UnboundedSender<PubsubMessage>,
+    pub upstream: mpsc::UnboundedSender<PubsubMessage>,
 }
 
 impl Broker {
@@ -62,7 +62,6 @@ impl Broker {
         S: Into<String> + Clone,
     {
         let topic: String = topic.clone().into();
-        debug!("net: *Subscribed to topic '{}'*", &topic);
         let (tx, rx) = mpsc::unbounded();
         let msg = PubsubMessage::Subscribe { topic, handler: tx };
         self.upstream.unbounded_send(msg)?;
@@ -74,7 +73,6 @@ impl Broker {
         S: Into<String> + Clone,
     {
         let topic: String = topic.clone().into();
-        debug!("net: *Publishing message to topic '{}'*", &topic);
         let msg = PubsubMessage::Publish {
             topic: topic.clone().into(),
             data,
@@ -89,7 +87,7 @@ impl Broker {
 // ----------------------------------------------------------------
 
 #[derive(Clone, Debug)]
-enum PubsubMessage {
+pub enum PubsubMessage {
     Subscribe {
         topic: String,
         handler: mpsc::UnboundedSender<Vec<u8>>,
@@ -145,6 +143,7 @@ impl Future for BrokerService {
                 Ok(Async::Ready(msg)) => match msg {
                     Some(Message::Pubsub(m)) => match m {
                         PubsubMessage::Subscribe { topic, handler } => {
+                            debug!("Subscribed to topic '{}'*", &topic);
                             let new_topic = floodsub::TopicBuilder::new(topic).build();
                             let topic_hash = new_topic.hash();
                             self.consumers

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -40,7 +40,7 @@ use stegos_config;
 use stegos_config::{Config, ConfigError};
 use stegos_keychain::*;
 use stegos_network::Network;
-use stegos_node::Node;
+use stegos_node::{genesis_dev, Node};
 use stegos_randhound::*;
 use tokio::runtime::Runtime;
 
@@ -123,7 +123,8 @@ fn run() -> Result<(), Box<dyn Error>> {
     let (network, network_service, broker) = Network::new(&cfg.network, &keychain)?;
 
     // Initialize node
-    let (node_service, node) = Node::new(keychain.clone(), broker.clone())?;
+    let genesis = genesis_dev().expect("failed to load genesis block");
+    let (node_service, node) = Node::new(keychain.clone(), genesis, broker.clone())?;
     rt.spawn(node_service);
 
     // Don't initialize REPL if stdin is not a TTY device


### PR DESCRIPTION
- Pass genesis blocks to node's constructor explicitly
- Don't include extra MONETARY_FEE for data transactions
- Add basic unit tests for NodeService
- Allow to specify the total number of coins in bootstrap utility
- Use usize instead of u64 for DATA_UNIT
- Improve debug output in Broker
- Remove NodeService::outbox (an artifact)

See #190