### PR TITLE
Refactor NodeService::poll()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-stream-select-all-send 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,6 +14,7 @@ stegos_keychain = { path = "../keychain" }
 log = "0.4"
 failure = "0.1"
 futures = "0.1"
+futures-stream-select-all-send = "0.1"
 tokio-timer = "0.2"
 chrono = "0.4"
 protobuf = "2.2"


### PR DESCRIPTION
Merge all event streams into one in order to simplify the code.
Re-use pattern introduced by 3e35c24d "Initial RandHound bootstrap"

Needed to introduce more network streams for #47