### PR TITLE
Fix one-off error in SubGroupRandomness collection

### DIFF
--- a/randhound/src/randhound.rs
+++ b/randhound/src/randhound.rs
@@ -1450,8 +1450,10 @@ impl GlobalState {
                         }
                     }
                 }
-                newsess.grptbl = sess.grptbl.clone(); // is this really necessary?
-                self.session_info = newsess; // is this really necessary?
+                if !done {
+                    newsess.grptbl = sess.grptbl.clone();
+                    self.session_info = newsess;
+                }
             }
             _ => {
                 // latecomers... just ignore the message


### PR DESCRIPTION
On the leader, send_randomness_to_leader mutates internal state, which afterwards was overwritten by stash_decrypted_shares