### PR TITLE
Store decrypted shares, even when randmoness was calculated

### DIFF
--- a/randhound/src/randhound.rs
+++ b/randhound/src/randhound.rs
@@ -1427,7 +1427,6 @@ impl GlobalState {
                                         if newsess.rands.len() >= thresh {
                                             // If the output pending vector now has a threshold number of decoded
                                             // randomness, then send the batch to our group leader.
-                                            self.send_randomness_to_group_leader(&newsess.rands);
                                             done = true; // don't bother accepting any more decryptions.
                                         }
                                     }
@@ -1450,9 +1449,11 @@ impl GlobalState {
                         }
                     }
                 }
-                if !done {
-                    newsess.grptbl = sess.grptbl.clone();
-                    self.session_info = newsess;
+                newsess.grptbl = sess.grptbl.clone();
+                let new_rands = newsess.rands.clone();
+                self.session_info = newsess.clone();
+                if done {
+                    self.send_randomness_to_group_leader(&new_rands);
                 }
             }
             _ => {


### PR DESCRIPTION
In previous fix, I was discarding calculated values after collecting BFT of randomness
Now, values are stored in internal state, as it was in original code

Closes #276 