### PR TITLE
Implement VRF in module pbc::secure

### DIFF
--- a/crypto/examples/pbc.rs
+++ b/crypto/examples/pbc.rs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use stegos_crypto::hash::*;
 use stegos_crypto::pbc::*;
 
 // ------------------------------------------------------------------------
@@ -64,4 +65,14 @@ fn main() {
     println!("skey = {}", skey);
     println!("pkey = {}", pkey);
     println!("sig = {}", sig);
+
+    // -----------------------------------------
+    let (skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
+    assert!(secure::check_keying(&pkey, &sig));
+    let hseed = Hash::from_str("VRF_Seed");
+    let vrf = secure::make_VRF(&skey, &hseed);
+    println!("VRF Rand: {:}", vrf.rand);
+    println!("VRF Proof: {:}", vrf.proof);
+    assert!(secure::validate_VRF_randomness(&vrf));
+    assert!(secure::validate_VRF_source(&vrf, &pkey, &hseed));
 }

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -266,6 +266,16 @@ pub mod tests {
         assert!(secure::check_keying(&pkey, &sig), "Invalid keying");
         fast::G2::generator();
     }
+
+    #[test]
+    fn check_vrf() {
+        let (skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
+        assert!(secure::check_keying(&pkey, &sig));
+        let hseed = Hash::from_str("VRF_Seed");
+        let vrf = secure::make_VRF(&skey, &hseed);
+        assert!(secure::validate_VRF_randomness(&vrf));
+        assert!(secure::validate_VRF_source(&vrf, &pkey, &hseed));
+    }
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
tests would not run from cargo, so I put the test at the end of examples/pbc.rs - runs just fine

pub struct pbc::secure::VRF;
pub fun  pbc::secure::make_VRF(&pbc::secure::SecretKey, &Hash) -> pbc::secure::VRF;
pub fun pbc::secure::validate_VRF_randomness(&pbc::secure::VRF) -> bool;
pub fun pbc::secure::validate_VRF_source(&pbc::secure::VRF, &pbc::secure:PublicKey, &Hash) -> bool;