### PR TITLE
Fix async consensus behaviour

### DIFF
--- a/consensus/src/message.rs
+++ b/consensus/src/message.rs
@@ -64,6 +64,8 @@ impl<Request: Hashable, Proof: Hashable> Hashable for ConsensusMessageBody<Reque
 pub struct ConsensusMessage<Request, Proof> {
     /// Current height.
     pub height: u64,
+    /// Current epoch.
+    pub epoch: u64,
     /// Hash of proposed request.
     pub request_hash: Hash,
     /// Message Body.
@@ -90,6 +92,7 @@ impl<Request: Hashable, Proof: Hashable> ConsensusMessage<Request, Proof> {
     ///
     pub fn new(
         height: u64,
+        epoch: u64,
         request_hash: Hash,
         skey: &SecureSecretKey,
         pkey: &SecurePublicKey,
@@ -97,12 +100,14 @@ impl<Request: Hashable, Proof: Hashable> ConsensusMessage<Request, Proof> {
     ) -> ConsensusMessage<Request, Proof> {
         let mut hasher = Hasher::new();
         height.hash(&mut hasher);
+        epoch.hash(&mut hasher);
         request_hash.hash(&mut hasher);
         body.hash(&mut hasher);
         let hash = hasher.result();
         let sig = secure_sign_hash(&hash, skey);
         ConsensusMessage {
             height,
+            epoch,
             request_hash,
             body,
             pkey: pkey.clone(),
@@ -116,6 +121,7 @@ impl<Request: Hashable, Proof: Hashable> ConsensusMessage<Request, Proof> {
     pub fn validate(&self) -> Result<(), ConsensusError> {
         let mut hasher = Hasher::new();
         self.height.hash(&mut hasher);
+        self.epoch.hash(&mut hasher);
         self.request_hash.hash(&mut hasher);
         self.body.hash(&mut hasher);
         let hash = hasher.result();
@@ -130,6 +136,7 @@ impl<Request: Hashable, Proof: Hashable> ConsensusMessage<Request, Proof> {
 impl<Request: Hashable, Proof: Hashable> Hashable for ConsensusMessage<Request, Proof> {
     fn hash(&self, state: &mut Hasher) {
         self.height.hash(state);
+        self.epoch.hash(state);
         self.request_hash.hash(state);
         self.body.hash(state);
         self.pkey.hash(state);

--- a/node/protos/node.proto
+++ b/node/protos/node.proto
@@ -168,10 +168,11 @@ message ConsensusMessageBody {
 
 message ConsensusMessage {
     uint64 height = 1;
-    Hash request_hash = 2;
-    ConsensusMessageBody body = 3;
-    SecurePublicKey pkey = 4;
-    SecureSignature sig = 5;
+    uint64 epoch = 2;
+    Hash request_hash = 3;
+    ConsensusMessageBody body = 4;
+    SecurePublicKey pkey = 5;
+    SecureSignature sig = 6;
 }
 
 message SealedBlockMessage {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -279,6 +279,11 @@ struct NodeService {
     /// And allow to change validators in case of epoch change.
     vrf_system: TicketsSystem,
 
+    /// A queue of consensus message from the future epoch.
+    // TODO: Add orphan SealedBlock to the queue.
+    // TODO: Resolve unknown blocks using requests-responses.
+    future_consensus_messages: Vec<Vec<u8>>,
+
     //
     // Consensus
     //
@@ -326,6 +331,7 @@ impl NodeService {
 
         let leader: SecurePublicKey = G2::generator().into(); // some fake key
         let validators = BTreeMap::<SecurePublicKey, i64>::new();
+        let future_consensus_messages = Vec::new();
         //TODO: Calculate viewchange on node restart by timeout since last known block.
         let vrf_system = TicketsSystem::new(WITNESSES_MAX, 0, 0, keys.cosi_pkey, keys.cosi_skey);
 
@@ -355,10 +361,10 @@ impl NodeService {
         streams.push(Box::new(consensus_rx));
 
         // VRF Requests
-        let consensus_rx = broker
+        let ticket_system_rx = broker
             .subscribe(&tickets::VRF_TICKETS_TOPIC.to_string())?
             .map(|m| NodeMessage::VRFMessage(m));
-        streams.push(Box::new(consensus_rx));
+        streams.push(Box::new(ticket_system_rx));
 
         // Block Requests
         let block_rx = broker
@@ -383,6 +389,7 @@ impl NodeService {
         let events = select_all(streams);
 
         let service = NodeService {
+            future_consensus_messages,
             sealed_block_num,
             vrf_system,
             chain,
@@ -644,6 +651,7 @@ impl NodeService {
             // Check previous hash.
             let previous_hash = Hash::digest(self.chain.last_block());
             if previous_hash != header.previous {
+                //TODO: Add orphan blocks to the self.future_consensus_messages;
                 error!("Invalid or out-of-order block received: hash={}, expected_previous={}, got_previous={}",
                        &block_hash, &previous_hash, &header.previous);
                 return Ok(());
@@ -822,6 +830,7 @@ impl NodeService {
             // Promote to Validator role
             let consensus = BlockConsensus::new(
                 self.chain.height() as u64,
+                self.epoch,
                 self.keys.cosi_skey.clone(),
                 self.keys.cosi_pkey.clone(),
                 self.leader.clone(),
@@ -835,11 +844,14 @@ impl NodeService {
             }
 
             self.consensus = Some(consensus);
+            self.on_new_consensus();
         } else {
             // Resign from Validator role.
             info!("I'm regular node");
             self.consensus = None;
         }
+        // clear consensus messages when new epoch starts
+        self.future_consensus_messages.clear();
 
         Ok(())
     }
@@ -1299,17 +1311,18 @@ impl NodeService {
         if self.validators.contains_key(&self.keys.cosi_pkey) {
             let consensus = BlockConsensus::new(
                 self.chain.height() as u64,
+                self.epoch + 1,
                 self.keys.cosi_skey.clone(),
                 self.keys.cosi_pkey.clone(),
                 self.leader.clone(),
                 self.validators.clone(),
             );
             self.consensus = Some(consensus);
-
             let consensus = self.consensus.as_ref().unwrap();
             if consensus.is_leader() {
                 self.on_create_new_epoch()?;
             }
+            self.on_new_consensus();
         } else {
             self.consensus = None;
         }
@@ -1319,6 +1332,18 @@ impl NodeService {
     //----------------------------------------------------------------------------------------------
     // Consensus
     //----------------------------------------------------------------------------------------------
+
+    ///
+    /// Try to process messages with new consensus.
+    ///
+    fn on_new_consensus(&mut self) {
+        let outbox = std::mem::replace(&mut self.future_consensus_messages, Vec::new());
+        for msg in outbox {
+            if let Err(e) = self.handle_consensus_message(msg) {
+                debug!("Error in future consensus message: {}", e);
+            }
+        }
+    }
 
     ///
     /// Try to commit a new block if consensus is in an appropriate state.
@@ -1340,15 +1365,18 @@ impl NodeService {
     ///
     /// Handles incoming consensus requests received from network.
     ///
-    fn handle_consensus_message(&mut self, msg: Vec<u8>) -> Result<(), Error> {
-        if self.consensus.is_none() {
+    fn handle_consensus_message(&mut self, buffer: Vec<u8>) -> Result<(), Error> {
+        // Process incoming message.
+        let msg: protos::node::ConsensusMessage = protobuf::parse_from_bytes(&buffer)?;
+        let msg = BlockConsensusMessage::from_proto(&msg)?;
+
+        // if our consensus state is outdated, push message to future_consensus_messages.
+        // TODO: remove queue and use request-responses to get message from other nodes.
+        if self.consensus.is_none() || self.consensus.as_ref().unwrap().epoch() == msg.epoch + 1 {
+            self.future_consensus_messages.push(buffer);
             return Ok(());
         }
-
-        // Process incoming message.
         let consensus = self.consensus.as_mut().unwrap();
-        let msg: protos::node::ConsensusMessage = protobuf::parse_from_bytes(&msg)?;
-        let msg = BlockConsensusMessage::from_proto(&msg)?;
         consensus.feed_message(msg)?;
         // Flush pending messages.
         NodeService::flush_consensus_messages(consensus, &mut self.broker)?;
@@ -1751,7 +1779,7 @@ pub mod tests {
         assert_eq!(node.balance, 0);
         assert_eq!(node.unspent.len(), 0);
         assert_eq!(node.mempool.len(), 0);
-        assert_eq!(node.epoch, 1);
+        assert_eq!(node.epoch, 0);
         assert_ne!(node.leader, keys.cosi_pkey);
         assert!(node.validators.is_empty());
 
@@ -1763,7 +1791,7 @@ pub mod tests {
         assert_eq!(node.balance, amount);
         assert_eq!(node.unspent.len(), 1);
         assert_eq!(node.mempool.len(), 0);
-        assert_eq!(node.epoch, 2);
+        assert_eq!(node.epoch, 1);
         assert_eq!(node.leader, keys.cosi_pkey);
         assert_eq!(node.validators.len(), 1);
         assert_eq!(node.validators.keys().next().unwrap(), &node.leader);

--- a/node/src/protos/mod.rs
+++ b/node/src/protos/mod.rs
@@ -841,6 +841,7 @@ impl IntoProto<node::ConsensusMessage> for ConsensusMessage<Block, BlockProof> {
     fn into_proto(&self) -> node::ConsensusMessage {
         let mut proto = node::ConsensusMessage::new();
         proto.set_height(self.height);
+        proto.set_epoch(self.epoch);
         proto.set_request_hash(self.request_hash.into_proto());
         proto.set_body(self.body.into_proto());
         proto.set_sig(self.sig.into_proto());
@@ -852,12 +853,14 @@ impl IntoProto<node::ConsensusMessage> for ConsensusMessage<Block, BlockProof> {
 impl FromProto<node::ConsensusMessage> for ConsensusMessage<Block, BlockProof> {
     fn from_proto(proto: &node::ConsensusMessage) -> Result<Self, Error> {
         let height = proto.get_height();
+        let epoch = proto.get_epoch();
         let request_hash = Hash::from_proto(proto.get_request_hash())?;
         let body = ConsensusMessageBody::from_proto(proto.get_body())?;
         let sig = SecureSignature::from_proto(proto.get_sig())?;
         let pkey = SecurePublicKey::from_proto(proto.get_pkey())?;
         Ok(ConsensusMessage {
             height,
+            epoch,
             request_hash,
             body,
             sig,
@@ -1061,13 +1064,13 @@ mod tests {
         let (cosi_skey, cosi_pkey, cosi_sig) = make_secure_random_keys();
 
         let body = ConsensusMessageBody::Prevote {};
-        let msg = ConsensusMessage::new(1, Hash::digest(&1u64), &cosi_skey, &cosi_pkey, body);
+        let msg = ConsensusMessage::new(1, 1, Hash::digest(&1u64), &cosi_skey, &cosi_pkey, body);
         roundtrip(&msg);
 
         let body = ConsensusMessageBody::Precommit {
             request_hash_sig: cosi_sig,
         };
-        let msg = ConsensusMessage::new(1, Hash::digest(&1u64), &cosi_skey, &cosi_pkey, body);
+        let msg = ConsensusMessage::new(1, 1, Hash::digest(&1u64), &cosi_skey, &cosi_pkey, body);
         roundtrip(&msg);
     }
 


### PR DESCRIPTION
Duplicate of https://github.com/stegos/stegos/pull/325 (it was originally merged into other branch)
Closes #312

1) Now keyblock is first block in new epoch, rather then last block in old.
2) Introduce a epoch check in consensus, and push messages from future epoch into queue.
