### PR TITLE
Change transaction formation logic for unstaking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_blockchain 0.1.0",
  "stegos_config 0.1.0",
  "stegos_crypto 0.1.0",

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -173,6 +173,8 @@ impl PaymentOutput {
         recipient_pkey: &PublicKey,
         amount: i64,
     ) -> Result<(Self, Fr), Error> {
+        assert!(amount > 0);
+
         // Create range proofs.
         let (proof, gamma) = make_range_proof(amount);
 
@@ -352,6 +354,8 @@ impl EscrowOutput {
         validator_pkey: &secure::PublicKey,
         amount: i64,
     ) -> Result<Self, Error> {
+        assert!(amount > 0);
+
         // Cloak recipient public key.
         let gamma = Fr::zero();
         let (cloaked_pkey, delta) = cloak_key(sender_skey, recipient_pkey, &gamma, timestamp)?;

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -11,3 +11,6 @@ stegos_config = { path = "../config" }
 log = "0.4"
 failure = "0.1"
 chrono = "0.4"
+
+[dev-dependencies]
+simple_logger = "1.0"

--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -28,4 +28,6 @@ pub enum WalletError {
     NotEnoughMoney,
     #[fail(display = "Amount should be greater than zero.")]
     ZeroOrNegativeAmount,
+    #[fail(display = "Insufficient stake: min={}, got={}.", _0, _1)]
+    InsufficientStake(i64, i64),
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -109,6 +109,7 @@ impl Wallet {
     }
 
     /// Unstake money from the escrow.
+    /// NOTE: amount must include PAYMENT_FEE.
     pub fn unstake(
         &self,
         validator_pkey: &secure::PublicKey,


### PR DESCRIPTION
This patch changes transaction formation logic for `unstake` REPL command.

Before this patch `1 x PAYMENT_FEE` was charged OVER the amount specified
by `unstake` command in REPL.

With this patch `1 x PAYMENT_FEE` is charged FROM the amount specified
by `unstake` command in REPL.

Let's take look on an example. Assume that 100 tokens have been staked
into the escrow using the single UTXO.

Before this patch:

  * `unstake 100` raised an error, because it actually required
     `100 + PAYMENT_FEE` in the escrow.
  * `unstake 100 - PAYMENT_FEE` withdrew `100 - PAYMENT_FEE`.
  * `unstake 20` withdrew `20` and staked `80 - PAYMENT_FEE - ESCROW_FEE`
    back to the escrow.

With this patch:

  * `unstake 100` withdraw `100 - PAYMENT_FEE`.
  * `unstake 20` withdraw `20 - PAYMENT_FEE` and stake `80 - ESCROW_FEE`
     back to the escrow.

In other words, now `1 x PAYMENT_FEE` is always charged from unstaked amount.
Motivation is to allow `unstake x` after `stake x` without making troubles
for the end user.

This patch doesn't change the transaction validation logic on Node.
Both options are completely valid in terms of monetary balance, but
now Wallet prepares transactions different way.

Closes #349