### PR TITLE
Refactor transaction validation

### DIFF
--- a/node/protos/node.proto
+++ b/node/protos/node.proto
@@ -167,7 +167,6 @@ message KeyBlockProposal {
 message MonetaryBlockProposal {
     MonetaryBlock block = 1;
     Output fee_output = 2;
-    Fr gamma = 3;
     repeated Hash tx_hashes = 4;
 }
 

--- a/node/src/consensus.rs
+++ b/node/src/consensus.rs
@@ -23,7 +23,6 @@
 
 use stegos_blockchain::*;
 use stegos_consensus::{Consensus, ConsensusError, ConsensusMessage};
-use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
 use stegos_crypto::pbc::secure::check_hash as secure_check_hash;
 use stegos_crypto::pbc::secure::sign_hash as secure_sign_hash;
@@ -35,7 +34,6 @@ use stegos_crypto::pbc::secure::Signature as SecureSignature;
 #[derive(Clone, Debug)]
 pub struct MonetaryBlockProof {
     pub fee_output: Option<Output>,
-    pub gamma: Fr,
     pub tx_hashes: Vec<Hash>,
 }
 
@@ -50,7 +48,6 @@ impl Hashable for MonetaryBlockProof {
     fn hash(&self, state: &mut Hasher) {
         "MonetaryBlockProof".hash(state);
         self.fee_output.hash(state);
-        self.gamma.hash(state);
         let txs_count: u64 = self.tx_hashes.len() as u64;
         txs_count.hash(state);
         for tx_hashes in &self.tx_hashes {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -970,7 +970,7 @@ where
         };
 
         let base = BaseBlockHeader::new(VERSION, previous, epoch, timestamp);
-        let block = MonetaryBlock::new(base, gamma.clone(), &inputs_hashes, &outputs);
+        let block = MonetaryBlock::new(base, gamma, &inputs_hashes, &outputs);
 
         // Double-check the monetary balance of created block.
         let inputs = chain
@@ -989,7 +989,6 @@ where
 
         let proof = MonetaryBlockProof {
             fee_output: output_fee,
-            gamma,
             tx_hashes,
         };
         let proof = BlockProof::MonetaryBlockProof(proof);
@@ -1230,7 +1229,6 @@ where
                     block_hash,
                     &block,
                     &proof.fee_output,
-                    &proof.gamma,
                     &proof.tx_hashes,
                 )
             }
@@ -1257,7 +1255,6 @@ where
         block_hash: Hash,
         block: &MonetaryBlock,
         fee_output: &Option<Output>,
-        gamma: &Fr,
         tx_hashes: &Vec<Hash>,
     ) -> Result<(), Error> {
         // Check transactions.
@@ -1335,7 +1332,12 @@ where
         let inputs_hashes: Vec<Hash> = inputs_hashes.into_iter().collect();
 
         let base_header = block.header.base.clone();
-        let block = MonetaryBlock::new(base_header, gamma.clone(), &inputs_hashes, &outputs);
+        let block = MonetaryBlock::new(
+            base_header,
+            block.header.gamma.clone(),
+            &inputs_hashes,
+            &outputs,
+        );
         let inputs = chain
             .outputs_by_hashes(&block.body.inputs)
             .expect("check above");

--- a/node/src/protos/mod.rs
+++ b/node/src/protos/mod.rs
@@ -815,7 +815,6 @@ impl IntoProto<node::ConsensusMessageBody> for ConsensusMessageBody<Block, Block
                     if let Some(ref fee_output) = proof.fee_output {
                         proposal.set_fee_output(fee_output.into_proto());
                     }
-                    proposal.set_gamma(proof.gamma.into_proto());
                     proto.set_monetary_block_proposal(proposal);
                 }
                 _ => unreachable!(),
@@ -843,14 +842,12 @@ impl FromProto<node::ConsensusMessageBody> for ConsensusMessageBody<Block, Block
                 } else {
                     None
                 };
-                let gamma = Fr::from_proto(msg.get_gamma())?;
                 let mut tx_hashes = Vec::with_capacity(msg.tx_hashes.len());
                 for tx_hash in msg.tx_hashes.iter() {
                     tx_hashes.push(Hash::from_proto(tx_hash)?);
                 }
                 let proof = MonetaryBlockProof {
                     fee_output,
-                    gamma,
                     tx_hashes,
                 };
                 let proof = BlockProof::MonetaryBlockProof(proof);
@@ -1235,7 +1232,7 @@ mod tests {
         assert_eq!(base.multisig, base2.multisig);
         assert_eq!(base.multisigmap, base2.multisigmap);
 
-        let block = MonetaryBlock::new(base, gamma.clone(), &inputs1, &outputs1);
+        let block = MonetaryBlock::new(base, gamma, &inputs1, &outputs1);
         roundtrip(&block.header);
         roundtrip(&block.body);
         roundtrip(&block);
@@ -1253,7 +1250,6 @@ mod tests {
         tx_hashes.push(Hash::digest(&1u64));
         let proof = MonetaryBlockProof {
             fee_output: Some(fee_output),
-            gamma: gamma.clone(),
             tx_hashes,
         };
         let proof = BlockProof::MonetaryBlockProof(proof);
@@ -1266,7 +1262,6 @@ mod tests {
 
         let proof = MonetaryBlockProof {
             fee_output: None,
-            gamma: gamma.clone(),
             tx_hashes: Vec::new(),
         };
         let proof = BlockProof::MonetaryBlockProof(proof);


### PR DESCRIPTION
Before this patch transaction was validated twice:
    
1. In handle_transaction() before accepting into the mempool.
2. In process_mempool() before creating a new block.
    
Initial idea was that transaction can be received out of order,
therefore handle_transaction() should only perform basic checks,
whereas process_mempool() should peform the full check of inputs.
    
Actually, we can't check anything without having resolved inputs.
Even signature can't be checked without inputs. For this reason
transactions from the future can't be checked at all. Let's ignore
out-of-order transactions for now and focus on security.
    
This patch integrates all checks into handle_transaction().
Mempool now contains only fully validated transactions. Nothing can
fail during creation of a block. For security reason created block is
double-checked before sending it to the network.
    
Needed for #318
Needed for #299
Needed for #304
Closes #356
Closes #371
