### PR TITLE
Add new REPL commands

### DIFF
--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -139,9 +139,6 @@ impl KeyChain {
 
         let (cosi_skey, cosi_pkey, cosi_sig) = wallet_to_cosi_keys(&wallet_skey);
 
-        info!("My wallet key: {}", &wallet_pkey.into_hex());
-        debug!("My secure key: {}", &cosi_pkey.into_hex());
-
         let keychain = KeyChain {
             wallet_skey,
             wallet_pkey,

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -25,6 +25,8 @@ use futures::sync::mpsc::unbounded;
 use futures::sync::mpsc::UnboundedReceiver;
 use futures::sync::mpsc::UnboundedSender;
 use stegos_crypto::curve1174::cpt::PublicKey;
+use stegos_crypto::hash::Hash;
+use stegos_crypto::pbc::secure;
 use stegos_node::OutputsNotification;
 
 //
@@ -33,9 +35,27 @@ use stegos_node::OutputsNotification;
 
 #[derive(Debug, Clone)]
 pub enum WalletNotification {
-    BalanceChanged { balance: i64 },
-    PaymentReceived { amount: i64, comment: String },
-    Error { error: String },
+    BalanceChanged {
+        balance: i64,
+    },
+    PaymentReceived {
+        amount: i64,
+        comment: String,
+    },
+    BalanceInfo {
+        balance: i64,
+    },
+    KeysInfo {
+        wallet_pkey: PublicKey,
+        cosi_pkey: secure::PublicKey,
+    },
+    UnspentInfo {
+        unspent: Vec<(Hash, i64)>,
+        unspent_stakes: Vec<(Hash, i64)>,
+    },
+    Error {
+        error: String,
+    },
 }
 
 //
@@ -66,6 +86,10 @@ pub(crate) enum WalletEvent {
         amount: i64,
     },
     UnstakeAll {},
+
+    KeysInfo,
+    BalanceInfo,
+    UnspentInfo,
 
     //
     // Internal events.
@@ -117,6 +141,21 @@ impl Wallet {
 
     pub fn unstake_all(&self) {
         let msg = WalletEvent::UnstakeAll {};
+        self.outbox.unbounded_send(msg).expect("connected")
+    }
+
+    pub fn balance_info(&self) {
+        let msg = WalletEvent::BalanceInfo;
+        self.outbox.unbounded_send(msg).expect("connected")
+    }
+
+    pub fn keys_info(&self) {
+        let msg = WalletEvent::KeysInfo;
+        self.outbox.unbounded_send(msg).expect("connected")
+    }
+
+    pub fn unspent_info(&self) {
+        let msg = WalletEvent::UnspentInfo;
         self.outbox.unbounded_send(msg).expect("connected")
     }
 }


### PR DESCRIPTION
- Add `show version` to display current version.
- Add `show balance` to display actual balance.
- Add `show utxo` to display unspent outputs.
- Add `show keys` to display keys.
- Rename `send` to `net send`.
- Rename `publish` to `net publish`.
- Remove `connect`.
- Improve readline's thread parking/unparking.
- Use Self:: instead of ConsoleService::

Closes #305
Closes #306