### PR TITLE
Add test cases for transaction validation

### DIFF
--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -600,7 +600,7 @@ pub mod tests {
         ];
 
         let current_timestamp = Utc::now().timestamp() as u64;
-        let blocks = genesis(&keychains, 100, 1_000_000);
+        let blocks = genesis(&keychains, 100, 1_000_000, current_timestamp);
         let mut blockchain = Blockchain::testing();
         for block in blocks {
             match block {

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -23,20 +23,18 @@
 
 use crate::block::*;
 use crate::output::*;
-use chrono::prelude::Utc;
 use std::collections::BTreeSet;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::pbc::secure as cosi_keys;
 use stegos_keychain::KeyChain;
 
 /// Genesis blocks.
-pub fn genesis(keychains: &[KeyChain], stake: i64, coins: i64) -> Vec<Block> {
+pub fn genesis(keychains: &[KeyChain], stake: i64, coins: i64, timestamp: u64) -> Vec<Block> {
     let mut blocks = Vec::with_capacity(2);
 
     // Both block are created at the same time in the same epoch.
     let version: u64 = 1;
     let epoch: u64 = 1;
-    let timestamp = Utc::now().timestamp() as u64;
 
     //
     // Create initial Monetary Block.

--- a/blockchain/src/protos.rs
+++ b/blockchain/src/protos.rs
@@ -446,6 +446,10 @@ mod tests {
         let output = Output::new_stake(timestamp, &skey1, &pkey1, &secure_pkey1, amount)
             .expect("keys are valid");
         roundtrip(&output);
+
+        let mut buf = output.into_buffer().unwrap();
+        buf.pop();
+        Output::from_buffer(&buf).expect_err("error");
     }
 
     fn mktransaction() -> Transaction {
@@ -483,7 +487,12 @@ mod tests {
 
     #[test]
     fn transactions() {
-        mktransaction();
+        let tx = mktransaction();
+        roundtrip(&tx);
+
+        let mut buf = tx.into_buffer().unwrap();
+        buf.pop();
+        Transaction::from_buffer(&buf).expect_err("error");
     }
 
     #[test]

--- a/node/src/bootstrap.rs
+++ b/node/src/bootstrap.rs
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use chrono::Utc;
 use clap::{crate_version, App, Arg};
 use log::*;
 use protobuf::Message;
@@ -137,7 +138,8 @@ fn main() {
     }
 
     info!("Generating genesis blocks...");
-    let blocks = genesis(&keychains, stake, coins);
+    let timestamp = Utc::now().timestamp() as u64;
+    let blocks = genesis(&keychains, stake, coins, timestamp);
     for (i, block) in blocks.iter().enumerate() {
         let block_data = block.into_proto();
         let block_data = block_data.write_to_bytes().unwrap();

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -115,7 +115,7 @@ impl Node {
         self.network.publish(&TX_TOPIC, data.clone())?;
         info!(
             "Sent transaction to the network: hash={}",
-            Hash::digest(&tx.body)
+            Hash::digest(&tx)
         );
         let msg = NodeMessage::Transaction(data);
         self.outbox.unbounded_send(msg)?;
@@ -498,7 +498,7 @@ impl NodeService {
     }
     /// Handle incoming transactions received from network.
     fn handle_transaction(&mut self, tx: Transaction) -> Result<(), Error> {
-        let tx_hash = Hash::digest(&tx.body);
+        let tx_hash = Hash::digest(&tx);
         info!(
             "Received transaction from the network: hash={}, inputs={}, outputs={}, fee={}",
             &tx_hash,

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -86,7 +86,7 @@ impl Mempool {
     /// Queues a transaction to the mempool.
     ///
     pub fn push_tx(&mut self, tx_hash: Hash, tx: Transaction) {
-        assert_eq!(&tx_hash, &Hash::digest(&tx.body));
+        debug_assert_eq!(&tx_hash, &Hash::digest(&tx));
         for input_hash in &tx.body.txins {
             let exists = self.inputs.insert(input_hash.clone(), tx_hash.clone());
             assert!(exists.is_none());
@@ -174,7 +174,7 @@ impl Mempool {
         for entry in self.pool.entries() {
             let tx_hash = entry.key();
             let tx = entry.get();
-            assert_eq!(tx_hash, &Hash::digest(&tx.body));
+            debug_assert_eq!(tx_hash, &Hash::digest(&tx));
 
             debug!("Processing transaction: hash={}", &tx_hash);
             tx_hashes.push(tx_hash.clone());
@@ -228,8 +228,8 @@ mod test {
 
         let (tx1, inputs1, outputs1) = Transaction::new_test(&skey, &pkey, 100, 2, 200, 1, 0);
         let (tx2, inputs2, outputs2) = Transaction::new_test(&skey, &pkey, 300, 1, 100, 3, 0);
-        let tx_hash1 = Hash::digest(&tx1.body);
-        let tx_hash2 = Hash::digest(&tx2.body);
+        let tx_hash1 = Hash::digest(&tx1);
+        let tx_hash2 = Hash::digest(&tx2);
 
         mempool.push_tx(tx_hash1.clone(), tx1.clone());
         mempool.push_tx(tx_hash2.clone(), tx2.clone());
@@ -291,7 +291,7 @@ mod test {
         let mut mempool = Mempool::new();
 
         let (tx, inputs, _outputs) = Transaction::new_test(&skey, &pkey, 100, 1, 100, 1, 0);
-        let tx_hash = Hash::digest(&tx.body);
+        let tx_hash = Hash::digest(&tx);
         mempool.push_tx(tx_hash.clone(), tx.clone());
         mempool.prune(&vec![Hash::digest(&inputs[0])], &vec![]);
     }
@@ -303,7 +303,7 @@ mod test {
         let mut mempool = Mempool::new();
 
         let (tx, _inputs, outputs) = Transaction::new_test(&skey, &pkey, 100, 1, 100, 1, 0);
-        let tx_hash = Hash::digest(&tx.body);
+        let tx_hash = Hash::digest(&tx);
         mempool.push_tx(tx_hash.clone(), tx.clone());
         mempool.prune(&vec![], &vec![Hash::digest(&outputs[0])]);
     }
@@ -318,8 +318,8 @@ mod test {
         let (tx2, inputs2, _outputs2) = Transaction::new_test(&skey, &pkey, 6, 1, 2, 2, 2);
         tx2.validate(&inputs2).expect("transaction is valid");
 
-        let tx_hash1 = Hash::digest(&tx1.body);
-        let tx_hash2 = Hash::digest(&tx2.body);
+        let tx_hash1 = Hash::digest(&tx1);
+        let tx_hash2 = Hash::digest(&tx2);
         mempool.push_tx(tx_hash1.clone(), tx1.clone());
         mempool.push_tx(tx_hash2.clone(), tx2.clone());
 

--- a/node/src/test/simple_tests.rs
+++ b/node/src/test/simple_tests.rs
@@ -21,6 +21,7 @@
 
 use super::Loopback;
 use crate::*;
+use chrono::Utc;
 use std::collections::HashMap;
 use stegos_crypto::pbc::secure::sign_hash as secure_sign_hash;
 use stegos_wallet::create_payment_transaction;
@@ -40,7 +41,8 @@ pub fn init() {
     assert_ne!(node.chain.leader, keys.cosi_pkey);
     assert!(node.chain.validators.is_empty());
 
-    let genesis = genesis(&[keys.clone()], 100, 3_000_000);
+    let current_timestamp = Utc::now().timestamp() as u64;
+    let genesis = genesis(&[keys.clone()], 100, 3_000_000, current_timestamp);
     let genesis_count = genesis.len();
     node.handle_init(genesis).unwrap();
     assert_eq!(node.chain.blocks().len(), genesis_count);
@@ -110,7 +112,8 @@ pub fn monetary_requests() {
 
     let total: i64 = 3_000_000;
     let stake: i64 = 100;
-    let genesis = genesis(&[keys.clone()], stake, total);
+    let current_timestamp = Utc::now().timestamp() as u64;
+    let genesis = genesis(&[keys.clone()], stake, total, current_timestamp);
     node.handle_init(genesis).unwrap();
     let mut block_count = node.chain.blocks().len();
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -264,7 +264,7 @@ impl WalletService {
                 }
             }
             Output::StakeOutput(o) => {
-                if let Ok(_delta) = o.decrypt_payload(&self.skey) {
+                if let Ok(_payload) = o.decrypt_payload(&self.skey) {
                     info!("Staked money to escrow: hash={}, amount={}", hash, o.amount);
                     let missing = self.unspent_stakes.insert(hash, o);
                     assert!(missing.is_none());
@@ -290,7 +290,7 @@ impl WalletService {
                 }
             }
             Output::StakeOutput(o) => {
-                if let Ok(_delta) = o.decrypt_payload(&self.skey) {
+                if let Ok(_payload) = o.decrypt_payload(&self.skey) {
                     info!(
                         "Unstaked money from escrow: hash={}, amount={}",
                         hash, o.amount

--- a/wallet/src/transaction.rs
+++ b/wallet/src/transaction.rs
@@ -49,6 +49,8 @@ pub fn create_payment_transaction(
         return Err(WalletError::NegativeAmount(amount).into());
     }
 
+    data.validate()?;
+
     debug!(
         "Creating a payment transaction: recipient={}, amount={}",
         recipient, amount
@@ -67,6 +69,7 @@ pub fn create_payment_transaction(
         .into_iter()
         .map(|o| Output::PaymentOutput(o.clone()))
         .collect();
+    assert!(!inputs.is_empty());
 
     debug!(
         "Transaction preview: recipient={}, amount={}, withdrawn={}, change={}, fee={}",
@@ -161,6 +164,7 @@ pub fn create_staking_transaction(
         .into_iter()
         .map(|o| Output::PaymentOutput(o.clone()))
         .collect();
+    assert!(!inputs.is_empty());
 
     debug!(
         "Transaction preview: recipient={}, validator={}, stake={}, withdrawn={}, change={}, fee={}",


### PR DESCRIPTION
- Add test cases for transaction validation.
- Refactor payload encoding/decoding for StakeUTXO.
- Use Hash::digest(&tx) instead of Hash::digest(&tx.body) as
  a transaction identifier in mempool.

Closes #391