### PR TITLE
Actualize copyright information

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 STEGOS CODE OF CONDUCT
 =======================
 
-Contact: [info@stegos.cc](mailto:info@stegos.cc)
+Contact: [info@stegos.com](mailto:info@stegos.com)
 
 We are committed to providing a friendly, safe and welcoming environment for
 all, regardless of level of experience, gender, gender identity and expression,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 edition = "2018"
 build = "build.rs"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use multi-stage build to reduce image size
 FROM rust:1.32-slim-stretch AS builder
-LABEL maintainer="Stegos AG <info@stegos.cc>"
+LABEL maintainer="Stegos AG <info@stegos.com>"
 
 RUN apt-get update && apt-get install -y git-core
 ADD . /usr/src/stegos

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Stegos
+Copyright (c) 2018-2019 Stegos AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ We encourage you to contribute in any way you can!
 Please see our [CONTRIBUTING GUIDE](https://github.com/stegos/stegos/blob/dev/CONTRIBUTING.md) and [CODE OF CONDUCT](https://github.com/stegos/stegos/blob/readme/CODE_OF_CONDUCT.md) for more information on contributing.
 
 
-Copyright (c) 2018 Stegos AG
+Copyright (c) 2018-2019 Stegos AG

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_blockchain"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 edition = "2018"
 links = "stegos_blockchain"
 build = "build.rs"

--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -1,7 +1,7 @@
 //! Block Definition.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -1,7 +1,7 @@
 //! Blockchain definition.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -1,7 +1,7 @@
 //! Blockchain Errors.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/escrow.rs
+++ b/blockchain/src/escrow.rs
@@ -3,7 +3,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -1,7 +1,7 @@
 //! Genesis Block.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -1,7 +1,7 @@
 //! Blockchain Implementation.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/merkle.rs
+++ b/blockchain/src/merkle.rs
@@ -1,7 +1,7 @@
 //! A Merkle Tree.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -1,7 +1,7 @@
 //! Transaction output.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/protos.rs
+++ b/blockchain/src/protos.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/storage.rs
+++ b/blockchain/src/storage.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/blockchain/src/transaction.rs
+++ b/blockchain/src/transaction.rs
@@ -1,7 +1,7 @@
 //! Transactions.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_consensus"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 edition = "2018"
 links = "stegos_consensus"
 build = "build.rs"

--- a/consensus/src/blockchain.rs
+++ b/consensus/src/blockchain.rs
@@ -1,7 +1,7 @@
 //! Blockchain Integration.
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -1,7 +1,7 @@
 //! pBFT Consensus - Errors.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,7 +1,7 @@
 //! pBFT Consensus.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/src/message.rs
+++ b/consensus/src/message.rs
@@ -1,7 +1,7 @@
 //! pBFT Consensus - Network Messages.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/src/multisignature.rs
+++ b/consensus/src/multisignature.rs
@@ -1,7 +1,7 @@
 //! pBFT Consensus - BLS Multisignature.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/src/protos.rs
+++ b/consensus/src/protos.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/consensus/src/state.rs
+++ b/consensus/src/state.rs
@@ -1,7 +1,7 @@
 //! pBFT Consensus - States and Transitions.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stegos_crypto"
 version = "0.1.0"
 edition = "2018"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 links = "stegos_crypto"
 build = "build.rs"
 

--- a/crypto/examples/bulletproofs.rs
+++ b/crypto/examples/bulletproofs.rs
@@ -1,7 +1,7 @@
 //! Test Fast Implementation of Bulletproofs on Curve1174
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/examples/curve1174.rs
+++ b/crypto/examples/curve1174.rs
@@ -1,7 +1,7 @@
 //! Test Fast Implementation of Edwards Curve Curve1174
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/examples/pbc.rs
+++ b/crypto/examples/pbc.rs
@@ -1,7 +1,7 @@
 //! Test PBC Crypto for Rust, atop Ben Lynn's PBCliib
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -1,7 +1,7 @@
 //! mod.rs - Bulletproofs on Curve1174
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/cpt.rs
+++ b/crypto/src/curve1174/cpt.rs
@@ -1,7 +1,7 @@
 //! cpt.rs - Compressed Points & main API
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/ecpt.rs
+++ b/crypto/src/curve1174/ecpt.rs
@@ -1,7 +1,7 @@
 //! ecpt.rs - Bernstein algorithm for elliptic curve arithmetic
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -1,7 +1,7 @@
 //! fq.rs - Field arithmetic in curve embedding field
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/fq51.rs
+++ b/crypto/src/curve1174/fq51.rs
@@ -1,7 +1,7 @@
 //! fq51.rs - Bernstein encoding of arithmetic on Fq embedding field.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/lev32.rs
+++ b/crypto/src/curve1174/lev32.rs
@@ -1,7 +1,7 @@
 //! lev32.rs - 32-byte little-endian vectors
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -1,7 +1,7 @@
 //! mod.rs - Single-curve ECC on Curve1174
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/u256.rs
+++ b/crypto/src/curve1174/u256.rs
@@ -1,7 +1,7 @@
 //! u256.rs - Little endian data vectors of [i64; 4] used by Fr and Fq
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/curve1174/winvec.rs
+++ b/crypto/src/curve1174/winvec.rs
@@ -1,7 +1,7 @@
 //! winvec.rs - 4-bit window vectors for curve multipliers in fixed-width windowed multiplication
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/dicemix/mod.rs
+++ b/crypto/src/dicemix/mod.rs
@@ -1,7 +1,7 @@
 //! mod.rs - DiceMix for secure and anonymous info exchange
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -1,7 +1,7 @@
 //! Hashing with SHA3
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/keying/mod.rs
+++ b/crypto/src/keying/mod.rs
@@ -1,7 +1,7 @@
 //! Keying - Key Generation from Word Lists
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/pbc/fast.rs
+++ b/crypto/src/pbc/fast.rs
@@ -2,7 +2,7 @@
 //! (intended for eRandHound ephemeral secrets)
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -1,7 +1,7 @@
 //! PBC Crypto for Rust, atop Ben Lynn's PBCliib
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -1,7 +1,7 @@
 //! Secure Pairings using BN Curve FR256 (type F, r approx 256 bits)
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/protos.rs
+++ b/crypto/src/protos.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crypto/src/utils/mod.rs
+++ b/crypto/src/utils/mod.rs
@@ -1,7 +1,7 @@
 //! mod.rs - general utility functions for vector handling
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_keychain"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 edition = "2018"
 
 [dependencies]

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/keychain/src/pem.rs
+++ b/keychain/src/pem.rs
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2016-2017 Jonathan Creekmore
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Based on https://github.com/jcreekmore/pem-rs
 //

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_network"
 version = "0.3.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 links = "stegos_network"
 edition = "2018"
 build = "build.rs"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_node"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 links = "stegos_node"
 build = "build.rs"
 edition = "2018"

--- a/node/src/bootstrap.rs
+++ b/node/src/bootstrap.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,7 @@ fn main() {
 
     let args = App::new("Stegos Bootstrap Utility")
         .version(crate_version!())
-        .author("Stegos AG <info@stegos.cc>")
+        .author("Stegos AG <info@stegos.com>")
         .about("A tool to generate initial keys and genesis block.")
         .arg(
             Arg::with_name("keys")

--- a/node/src/consensus.rs
+++ b/node/src/consensus.rs
@@ -1,7 +1,7 @@
 //! Consensus Integration.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/election.rs
+++ b/node/src/election.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -3,7 +3,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,7 +1,7 @@
 //! Blockchain Node.
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/loader.rs
+++ b/node/src/loader.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -1,7 +1,7 @@
 //! Memory Pool of Transactions.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/protos/mod.rs
+++ b/node/src/protos/mod.rs
@@ -1,7 +1,7 @@
 //! Protobuf Definitions.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/test/mod.rs
+++ b/node/src/test/mod.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/test/simple_tests.rs
+++ b/node/src/test/simple_tests.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/test/time.rs
+++ b/node/src/test/time.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/src/tickets.rs
+++ b/node/src/tickets.rs
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/serialization/Cargo.toml
+++ b/serialization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_serialization"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 edition = "2018"
 
 [dependencies]

--- a/serialization/src/build_script.rs
+++ b/serialization/src/build_script.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/serialization/src/lib.rs
+++ b/serialization/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/serialization/src/traits.rs
+++ b/serialization/src/traits.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration Handling.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,6 +1,6 @@
 ///! Console - command-line interface.
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -187,7 +187,7 @@ fn run() -> Result<(), Error> {
 
     let args = App::new(name)
         .version(&version[..])
-        .author("Stegos AG <info@stegos.cc>")
+        .author("Stegos AG <info@stegos.com>")
         .about("Stegos is a completely anonymous and confidential cryptocurrency.")
         .arg(
             Arg::with_name("config")

--- a/txpool/Cargo.toml
+++ b/txpool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_txpool"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 build = "build.rs"
 edition = "2018"
 

--- a/txpool/src/messages.rs
+++ b/txpool/src/messages.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/txpool/src/protos.rs
+++ b/txpool/src/protos.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stegos_wallet"
 version = "0.1.0"
-authors = ["Stegos AG <info@stegos.cc>"]
+authors = ["Stegos AG <info@stegos.com>"]
 edition = "2018"
 build = "build.rs"
 

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -1,7 +1,7 @@
 //! Wallet - API.
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/change.rs
+++ b/wallet/src/change.rs
@@ -1,7 +1,7 @@
 //! Wallet - Change Calculation.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -1,7 +1,7 @@
 //! Wallet - Errors.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,7 +1,7 @@
 //! Wallet.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/transaction.rs
+++ b/wallet/src/transaction.rs
@@ -1,7 +1,7 @@
 //! Wallet - Transactions.
 
 //
-// Copyright (c) 2018 Stegos
+// Copyright (c) 2018 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/valueshuffle/error.rs
+++ b/wallet/src/valueshuffle/error.rs
@@ -1,7 +1,7 @@
 //! error.rs - ValueShuffle Errors.
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/valueshuffle/message.rs
+++ b/wallet/src/valueshuffle/message.rs
@@ -1,7 +1,7 @@
 //! message.rs - ValueShuffle Messages.
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/valueshuffle/mod.rs
+++ b/wallet/src/valueshuffle/mod.rs
@@ -1,7 +1,7 @@
 //! lib.rs - DiceMix for secure and anonymous info exchange
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/wallet/src/valueshuffle/protos.rs
+++ b/wallet/src/valueshuffle/protos.rs
@@ -1,7 +1,7 @@
 //! message.rs - ValueShuffle Protobuf Encoding.
 
 //
-// Copyright (c) 2019 Stegos
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Company name is "Stegos AG", not just "Stegos".
- Add 2019 year to template and README.md.

Please use the following convention:

- "Copyright (c) 2019 Stegos AG" for all new files.
- "Copyright (C) 2018-2019 Stegos AG" on major changes in existing files.

See https://www.gnu.org/prep/maintain/html_node/Copyright-Notices.html
for details.

Closes #431