### PR TITLE
Link libstdc++ statically

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,4 +9,10 @@ fn main() {
 
     // Generate the 'cargo:' key output
     generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate the cargo keys!");
+
+    // Link libstdc++ statically on Linux.
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=static=stdc++");
+    }
 }


### PR DESCRIPTION
I haven't found solution for `libgcc_s`. `println!("cargo:rustc-link-lib=static=gcc_s")` doesn't work.
Let's try with shared libgcc_s first, it should work.