### PR TITLE
Use secure::PublicKey prefix instead of SecurePublicKey

### DIFF
--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -34,8 +34,7 @@ use stegos_crypto::curve1174::ecpt::ECp;
 use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::curve1174::G;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
-use stegos_crypto::pbc::secure::Signature as SecureSignature;
+use stegos_crypto::pbc::secure;
 
 /// The maximum number of nodes in multi-signature.
 pub const WITNESSES_MAX: usize = 512;
@@ -57,7 +56,7 @@ pub struct BaseBlockHeader {
     pub timestamp: u64,
 
     /// BLS multi-signature
-    pub multisig: SecureSignature,
+    pub multisig: secure::Signature,
 
     /// Bitmap of signers in the multi-signature.
     pub multisigmap: BitVector,
@@ -65,7 +64,7 @@ pub struct BaseBlockHeader {
 
 impl BaseBlockHeader {
     pub fn new(version: u64, previous: Hash, epoch: u64, timestamp: u64) -> Self {
-        let multisig = SecureSignature::zero();
+        let multisig = secure::Signature::zero();
         let multisigmap = BitVector::new(WITNESSES_MAX);
         BaseBlockHeader {
             version,
@@ -94,13 +93,13 @@ pub struct KeyBlockHeader {
     pub base: BaseBlockHeader,
 
     /// Leader public key.
-    pub leader: SecurePublicKey,
+    pub leader: secure::PublicKey,
 
     /// Facilitator of Transaction Pool.
-    pub facilitator: SecurePublicKey,
+    pub facilitator: secure::PublicKey,
 
     /// Ordered list of witnesses public keys.
-    pub witnesses: BTreeSet<SecurePublicKey>,
+    pub witnesses: BTreeSet<secure::PublicKey>,
 }
 
 impl Hashable for KeyBlockHeader {
@@ -189,9 +188,9 @@ pub struct KeyBlock {
 impl KeyBlock {
     pub fn new(
         base: BaseBlockHeader,
-        leader: SecurePublicKey,
-        facilitator: SecurePublicKey,
-        witnesses: BTreeSet<SecurePublicKey>,
+        leader: secure::PublicKey,
+        facilitator: secure::PublicKey,
+        witnesses: BTreeSet<secure::PublicKey>,
     ) -> Self {
         assert!(!witnesses.is_empty(), "witnesses is not empty");
         assert!(
@@ -460,7 +459,7 @@ pub mod tests {
 
         let base = BaseBlockHeader::new(version, previous, epoch, timestamp);
 
-        let witnesses: BTreeSet<SecurePublicKey> = [pkey0].iter().cloned().collect();
+        let witnesses: BTreeSet<secure::PublicKey> = [pkey0].iter().cloned().collect();
         let leader = pkey0.clone();
         let facilitator = pkey0.clone();
 

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -657,9 +657,9 @@ pub mod tests {
                 let base = BaseBlockHeader::new(version, previous, epoch, 0);
 
                 let witnesses: BTreeSet<SecurePublicKey> =
-                    keychains.iter().map(|p| p.cosi_pkey.clone()).collect();
-                let leader = keychains[0].cosi_pkey.clone();
-                let facilitator = keychains[0].cosi_pkey.clone();
+                    keychains.iter().map(|p| p.network_pkey.clone()).collect();
+                let leader = keychains[0].network_pkey.clone();
+                let facilitator = keychains[0].network_pkey.clone();
 
                 KeyBlock::new(base, leader, facilitator, witnesses)
             };

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -40,7 +40,7 @@ use stegos_crypto::curve1174::ecpt::ECp;
 use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::curve1174::G;
 use stegos_crypto::hash::*;
-use stegos_crypto::pbc::secure::{PublicKey as SecurePublicKey, G2};
+use stegos_crypto::pbc::secure;
 use tokio_timer::clock;
 
 type BlockId = usize;
@@ -78,11 +78,11 @@ pub struct Blockchain {
     /// Escrow
     pub escrow: Escrow,
     /// Snapshot of selected leader from the latest key block.
-    pub leader: SecurePublicKey,
+    pub leader: secure::PublicKey,
     /// Snapshot of selected facilitator from the latest key block.
-    pub facilitator: SecurePublicKey,
+    pub facilitator: secure::PublicKey,
     /// Snapshot of validators with stakes from the latest key block.
-    pub validators: BTreeMap<SecurePublicKey, i64>,
+    pub validators: BTreeMap<secure::PublicKey, i64>,
     /// A timestamp when the last sealed block was received.
     pub last_block_timestamp: Instant,
     /// A monotonically increasing value that represents the epoch of the blockchain,
@@ -123,9 +123,9 @@ impl Blockchain {
         let output_by_hash = HashMap::<Hash, OutputKey>::new();
         let epoch: u64 = 0;
         let escrow = Escrow::new();
-        let leader: SecurePublicKey = G2::generator().into(); // some fake key
-        let facilitator: SecurePublicKey = G2::generator().into(); // some fake key
-        let validators = BTreeMap::<SecurePublicKey, i64>::new();
+        let leader: secure::PublicKey = secure::G2::generator().into(); // some fake key
+        let facilitator: secure::PublicKey = secure::G2::generator().into(); // some fake key
+        let validators = BTreeMap::<secure::PublicKey, i64>::new();
         let last_block_timestamp = clock::now();
 
         let created = ECp::inf();
@@ -282,9 +282,9 @@ impl Blockchain {
     /// Force consensus group changes.
     pub fn change_group(
         &mut self,
-        leader: SecurePublicKey,
-        facilitator: SecurePublicKey,
-        validators: BTreeMap<SecurePublicKey, i64>,
+        leader: secure::PublicKey,
+        facilitator: secure::PublicKey,
+        validators: BTreeMap<secure::PublicKey, i64>,
     ) {
         self.leader = leader;
         self.facilitator = facilitator;
@@ -656,7 +656,7 @@ pub mod tests {
                 let previous = Hash::digest(&blockchain.last_block());
                 let base = BaseBlockHeader::new(version, previous, epoch, 0);
 
-                let witnesses: BTreeSet<SecurePublicKey> =
+                let witnesses: BTreeSet<secure::PublicKey> =
                     keychains.iter().map(|p| p.network_pkey.clone()).collect();
                 let leader = keychains[0].network_pkey.clone();
                 let facilitator = keychains[0].network_pkey.clone();

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -25,7 +25,7 @@ use crate::block::*;
 use crate::output::*;
 use std::collections::BTreeSet;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure as cosi_keys;
+use stegos_crypto::pbc::secure;
 use stegos_keychain::KeyChain;
 
 /// Genesis blocks.
@@ -66,7 +66,7 @@ pub fn genesis(keychains: &[KeyChain], stake: i64, coins: i64, timestamp: u64) -
                 timestamp,
                 &keys.wallet_skey,
                 &keys.wallet_pkey,
-                &keys.cosi_pkey,
+                &keys.network_pkey,
                 stake,
             )
             .expect("genesis has valid public keys");
@@ -87,10 +87,10 @@ pub fn genesis(keychains: &[KeyChain], stake: i64, coins: i64, timestamp: u64) -
         let previous = Hash::digest(&block1);
         let base = BaseBlockHeader::new(version, previous, epoch, timestamp);
 
-        let witnesses: BTreeSet<cosi_keys::PublicKey> =
-            keychains.iter().map(|p| p.cosi_pkey.clone()).collect();
-        let leader = keychains[0].cosi_pkey.clone();
-        let facilitator = keychains[0].cosi_pkey.clone();
+        let witnesses: BTreeSet<secure::PublicKey> =
+            keychains.iter().map(|p| p.network_pkey.clone()).collect();
+        let leader = keychains[0].network_pkey.clone();
+        let facilitator = keychains[0].network_pkey.clone();
 
         KeyBlock::new(base, leader, facilitator, witnesses)
     };

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -102,7 +102,7 @@ pub struct StakeOutput {
     /// Cloaked wallet key of validator.
     pub recipient: PublicKey,
 
-    /// Uncloaked secure key of validator.
+    /// Uncloaked network key of validator.
     pub validator: secure::PublicKey,
 
     /// Amount to stake.

--- a/blockchain/src/storage.rs
+++ b/blockchain/src/storage.rs
@@ -105,7 +105,7 @@ mod test {
     use crate::block::{BaseBlockHeader, KeyBlock};
     use std::collections::BTreeSet;
     use stegos_crypto::hash::Hash;
-    use stegos_crypto::pbc::secure::{self, PublicKey as SecurePublicKey};
+    use stegos_crypto::pbc::secure;
 
     fn create_block(previous: Hash) -> Block {
         let (_skey0, pkey0, _sig0) = secure::make_random_keys();
@@ -115,7 +115,7 @@ mod test {
 
         let base = BaseBlockHeader::new(version, previous, epoch, timestamp);
 
-        let witnesses: BTreeSet<SecurePublicKey> = [pkey0].iter().cloned().collect();
+        let witnesses: BTreeSet<secure::PublicKey> = [pkey0].iter().cloned().collect();
         let leader = pkey0.clone();
         let facilitator = pkey0.clone();
 

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -23,26 +23,26 @@
 
 use failure::Fail;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
+use stegos_crypto::pbc::secure;
 
 #[derive(Debug, Fail)]
 pub enum ConsensusError {
     #[fail(display = "Unknown peer: pkey={}", _0)]
-    UnknownMessagePeer(SecurePublicKey),
+    UnknownMessagePeer(secure::PublicKey),
     #[fail(display = "Invalid message signature.")]
     InvalidMessageSignature,
     #[fail(
         display = "Invalid request hash: expected={}, got={}, pkey={}.",
         _0, _1, _2
     )]
-    InvalidRequestHash(Hash, Hash, SecurePublicKey),
+    InvalidRequestHash(Hash, Hash, secure::PublicKey),
     #[fail(display = "Invalid message: state={} msg={}.", _0, _1)]
     InvalidMessage(&'static str, &'static str),
     #[fail(
         display = "Proposal from non-leader: request_hash={}, expected={}, got={}",
         _0, _1, _2
     )]
-    ProposalFromNonLeader(Hash, SecurePublicKey, SecurePublicKey),
+    ProposalFromNonLeader(Hash, secure::PublicKey, secure::PublicKey),
     #[fail(display = "Invalid BLS multisignature for request: request={}", _0)]
     InvalidRequestSignature(Hash),
 }

--- a/consensus/src/protos.rs
+++ b/consensus/src/protos.rs
@@ -27,8 +27,7 @@ use crate::message::*;
 
 use stegos_blockchain::*;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
-use stegos_crypto::pbc::secure::Signature as SecureSignature;
+use stegos_crypto::pbc::secure;
 
 // link protobuf dependencies
 use stegos_blockchain::protos::*;
@@ -100,7 +99,7 @@ impl ProtoConvert for ConsensusMessageBody<Block, BlockProof> {
                 ConsensusMessageBody::Prevote {}
             }
             Some(consensus::ConsensusMessageBody_oneof_body::precommit(ref msg)) => {
-                let request_hash_sig = SecureSignature::from_proto(msg.get_request_hash_sig())?;
+                let request_hash_sig = secure::Signature::from_proto(msg.get_request_hash_sig())?;
                 ConsensusMessageBody::Precommit { request_hash_sig }
             }
             None => {
@@ -128,8 +127,8 @@ impl ProtoConvert for ConsensusMessage<Block, BlockProof> {
         let epoch = proto.get_epoch();
         let request_hash = Hash::from_proto(proto.get_request_hash())?;
         let body = ConsensusMessageBody::from_proto(proto.get_body())?;
-        let sig = SecureSignature::from_proto(proto.get_sig())?;
-        let pkey = SecurePublicKey::from_proto(proto.get_pkey())?;
+        let sig = secure::Signature::from_proto(proto.get_sig())?;
+        let pkey = secure::PublicKey::from_proto(proto.get_pkey())?;
         Ok(ConsensusMessage {
             height,
             epoch,
@@ -198,7 +197,7 @@ mod tests {
         let previous = Hash::digest(&"test".to_string());
 
         let base = BaseBlockHeader::new(version, previous, epoch, timestamp);
-        let witnesses: BTreeSet<SecurePublicKey> = [pkey0].iter().cloned().collect();
+        let witnesses: BTreeSet<secure::PublicKey> = [pkey0].iter().cloned().collect();
         let leader = pkey0.clone();
         let facilitator = pkey0.clone();
 

--- a/consensus/src/protos.rs
+++ b/consensus/src/protos.rs
@@ -161,16 +161,30 @@ mod tests {
 
     #[test]
     fn consensus() {
-        let (cosi_skey, cosi_pkey, cosi_sig) = make_secure_random_keys();
+        let (network_skey, network_pkey, network_sig) = make_secure_random_keys();
 
         let body = ConsensusMessageBody::Prevote {};
-        let msg = ConsensusMessage::new(1, 1, Hash::digest(&1u64), &cosi_skey, &cosi_pkey, body);
+        let msg = ConsensusMessage::new(
+            1,
+            1,
+            Hash::digest(&1u64),
+            &network_skey,
+            &network_pkey,
+            body,
+        );
         roundtrip(&msg);
 
         let body = ConsensusMessageBody::Precommit {
-            request_hash_sig: cosi_sig,
+            request_hash_sig: network_sig,
         };
-        let msg = ConsensusMessage::new(1, 1, Hash::digest(&1u64), &cosi_skey, &cosi_pkey, body);
+        let msg = ConsensusMessage::new(
+            1,
+            1,
+            Hash::digest(&1u64),
+            &network_skey,
+            &network_pkey,
+            body,
+        );
         roundtrip(&msg);
     }
 

--- a/crypto/src/protos.rs
+++ b/crypto/src/protos.rs
@@ -27,8 +27,7 @@ use crate::curve1174::cpt::Pt;
 use crate::curve1174::cpt::{EncryptedPayload, PublicKey, SchnorrSig};
 use crate::curve1174::fields::Fr;
 use crate::hash::Hash;
-use crate::pbc::secure::PublicKey as SecurePublicKey;
-use crate::pbc::secure::Signature as SecureSignature;
+use crate::pbc::secure;
 use crate::pbc::secure::G1;
 use crate::pbc::secure::G2;
 use crate::pbc::secure::VRF;
@@ -125,7 +124,7 @@ impl ProtoConvert for SchnorrSig {
     }
 }
 
-impl ProtoConvert for SecurePublicKey {
+impl ProtoConvert for secure::PublicKey {
     type Proto = crypto::SecurePublicKey;
     fn into_proto(&self) -> Self::Proto {
         let mut proto = crypto::SecurePublicKey::new();
@@ -135,11 +134,11 @@ impl ProtoConvert for SecurePublicKey {
     }
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
         let g: G2 = G2::from_proto(proto.get_point())?;
-        Ok(SecurePublicKey::from(g))
+        Ok(secure::PublicKey::from(g))
     }
 }
 
-impl ProtoConvert for SecureSignature {
+impl ProtoConvert for secure::Signature {
     type Proto = crypto::SecureSignature;
     fn into_proto(&self) -> Self::Proto {
         let mut proto = crypto::SecureSignature::new();
@@ -149,7 +148,7 @@ impl ProtoConvert for SecureSignature {
     }
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
         let g: G1 = G1::from_proto(proto.get_point())?;
-        Ok(SecureSignature::from(g))
+        Ok(secure::Signature::from(g))
     }
 }
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -56,7 +56,7 @@ where
         protocol_id: &str,
     ) -> Result<mpsc::UnboundedReceiver<UnicastMessage>, Error>;
 
-    /// Send unicast message to peer identified by cosi public key
+    /// Send unicast message to peer identified by network public key
     fn send(&self, dest: secure::PublicKey, protocol_id: &str, data: Vec<u8>) -> Result<(), Error>;
 
     /// Helper for cloning boxed object

--- a/network/src/libp2p_network/mod.rs
+++ b/network/src/libp2p_network/mod.rs
@@ -207,14 +207,14 @@ where
 {
     pub fn new(config: &NetworkConfig, keychain: &KeyChain, peer_id: PeerId) -> Self {
         let mut kad = kad_discovery::KadBehaviour::new(peer_id.clone());
-        kad.add_providing(cosi_pkey2peer_id(&keychain.cosi_pkey));
+        kad.add_providing(network_pkey_to_peer_id(&keychain.network_pkey));
         let mut behaviour = Libp2pBehaviour {
             floodsub: floodsub::Floodsub::new(peer_id.clone()),
             ncp: ncp::layer::Ncp::new(config),
             kad,
             consumers: HashMap::new(),
             unicast_consumers: HashMap::new(),
-            my_pkey: keychain.cosi_pkey.clone(),
+            my_pkey: keychain.network_pkey.clone(),
         };
         let unicast_topic = floodsub::TopicBuilder::new(UNICAST_TOPIC).build();
         behaviour.floodsub.subscribe(unicast_topic);
@@ -400,7 +400,7 @@ pub enum ControlMessage {
     },
 }
 
-fn cosi_pkey2peer_id(key: &secure::PublicKey) -> PeerId {
+fn network_pkey_to_peer_id(key: &secure::PublicKey) -> PeerId {
     let hash = multihash::encode(multihash::Hash::SHA2256, &key.clone().into_bytes())
         .expect("should never fail");
     PeerId::from_multihash(hash).expect("hash is properly formed on prev step")
@@ -449,12 +449,12 @@ fn new_peerstore(
 
     debug!("My adverised addresses: {:#?}", my_addresses);
     peerstore.add_local_external_addrs(my_addresses.into_iter());
-    let cosi_pkey_hash = multihash::encode(
+    let network_pkey_hash = multihash::encode(
         multihash::Hash::SHA2256,
-        &keychain.cosi_pkey.clone().into_bytes(),
+        &keychain.network_pkey.clone().into_bytes(),
     )
     .expect("hashing with SHA2256 never fails");
-    peerstore.add_provider(cosi_pkey_hash, peer_id);
+    peerstore.add_provider(network_pkey_hash, peer_id);
     peerstore
 }
 

--- a/network/src/unicast_send/behavior.rs
+++ b/network/src/unicast_send/behavior.rs
@@ -115,8 +115,8 @@ impl<TSubstream> UnicastSend<TSubstream> {
             dialouts: PeersQueue::new(Duration::from_secs(DIAL_OUT_TIMEOUT)),
             sending_queues: HashMap::new(),
             peers_pkeys: HashMap::new(),
-            local_pkey: keychain.cosi_pkey.clone(),
-            local_skey: keychain.cosi_skey.clone(),
+            local_pkey: keychain.network_pkey.clone(),
+            local_skey: keychain.network_skey.clone(),
             marker: PhantomData,
         }
     }
@@ -354,8 +354,8 @@ mod tests {
         };
 
         let msg = UnicastDataMessage {
-            to: keychain1.cosi_pkey.clone(),
-            from: keychain2.cosi_pkey.clone(),
+            to: keychain1.network_pkey.clone(),
+            from: keychain2.network_pkey.clone(),
             protocol_id: "testing".to_string(),
             data: b"Sunt est voluptate mollit duis elit excepteur do ad minim et exercitation. Duis nostrud veniam commodo labore ut. Voluptate magna laboris Lorem ullamco. Et irure consectetur qui quis aliquip excepteur. Aute elit commodo in laboris proident eu adipisicing pariatur do velit excepteur duis irure. Consectetur pariatur cillum et sit aliquip sit pariatur minim sint et duis.".to_vec(),
         };

--- a/node/src/consensus.rs
+++ b/node/src/consensus.rs
@@ -25,11 +25,7 @@ use stegos_blockchain::*;
 
 use stegos_consensus::ConsensusError;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
-use stegos_crypto::pbc::secure::check_hash as secure_check_hash;
-use stegos_crypto::pbc::secure::sign_hash as secure_sign_hash;
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
-use stegos_crypto::pbc::secure::SecretKey as SecureSecretKey;
-use stegos_crypto::pbc::secure::Signature as SecureSignature;
+use stegos_crypto::pbc::secure;
 
 /// Sealed Block with multi-signature.
 #[derive(Clone, Debug)]
@@ -37,18 +33,18 @@ pub struct SealedBlockMessage {
     /// Block.
     pub block: Block,
     /// Secure Public Key used to sign this message.
-    pub pkey: SecurePublicKey,
+    pub pkey: secure::PublicKey,
     /// Secure Signature.
-    pub sig: SecureSignature,
+    pub sig: secure::Signature,
 }
 
 impl SealedBlockMessage {
     ///
     /// Create and sign a new SealedBlock message.
     ///
-    pub fn new(skey: &SecureSecretKey, pkey: &SecurePublicKey, block: Block) -> Self {
+    pub fn new(skey: &secure::SecretKey, pkey: &secure::PublicKey, block: Block) -> Self {
         let hash = Hasher::digest(&block);
-        let sig = secure_sign_hash(&hash, skey);
+        let sig = secure::sign_hash(&hash, skey);
         Self {
             block,
             pkey: pkey.clone(),
@@ -61,7 +57,7 @@ impl SealedBlockMessage {
     ///
     pub fn validate(&self) -> Result<(), ConsensusError> {
         let hash = Hash::digest(&self.block);
-        if !secure_check_hash(&hash, &self.sig, &self.pkey) {
+        if !secure::check_hash(&hash, &self.sig, &self.pkey) {
             return Err(ConsensusError::InvalidMessageSignature);
         }
         Ok(())

--- a/node/src/election.rs
+++ b/node/src/election.rs
@@ -27,18 +27,18 @@ use stegos_crypto::hash::Hash;
 use rand::{Rng, SeedableRng};
 use rand_isaac::IsaacRng;
 
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
+use stegos_crypto::pbc::secure;
 
-pub type StakersGroup = Vec<(SecurePublicKey, i64)>;
+pub type StakersGroup = Vec<(secure::PublicKey, i64)>;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct ConsensusGroup {
     /// List of Validators
     pub validators: StakersGroup,
     /// Leader public key
-    pub leader: SecurePublicKey,
+    pub leader: secure::PublicKey,
     /// Facilitator of the transaction pool
-    pub facilitator: SecurePublicKey,
+    pub facilitator: secure::PublicKey,
 }
 
 /// Choose random validator, based on `random_number`.
@@ -156,7 +156,7 @@ mod test {
     use std::collections::{HashMap, HashSet};
 
     use stegos_crypto::hash::Hash;
-    use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
+    use stegos_crypto::pbc::secure;
 
     fn broken_random(nums: i64) -> impl Iterator<Item = i64> {
         (0..nums).into_iter()
@@ -254,7 +254,7 @@ mod test {
     fn test_group_size() {
         const PUBLIC_KEY_SIZE: usize = 65;
 
-        let key = SecurePublicKey::try_from_bytes(&[0; PUBLIC_KEY_SIZE]).unwrap();
+        let key = secure::PublicKey::try_from_bytes(&[0; PUBLIC_KEY_SIZE]).unwrap();
         let keys = vec![(key, 1), (key, 2), (key, 3), (key, 4)];
         for i in 1..5 {
             assert_eq!(

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -25,7 +25,7 @@
 
 use failure::Fail;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
+use stegos_crypto::pbc::secure;
 
 #[derive(Debug, Fail, PartialEq, Eq)]
 pub enum NodeError {
@@ -59,7 +59,7 @@ pub enum NodeError {
         display = "Sealed Block from non-leader: block={}, expected={}, got={}",
         _0, _1, _2
     )]
-    SealedBlockFromNonLeader(Hash, SecurePublicKey, SecurePublicKey),
+    SealedBlockFromNonLeader(Hash, secure::PublicKey, secure::PublicKey),
     #[fail(display = "Invalid fee UTXO: hash={}", _0)]
     InvalidFeeUTXO(Hash),
     #[fail(display = "Invalid block BLS multisignature: block={}", _0)]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -55,8 +55,7 @@ use std::time::{Duration, Instant};
 use stegos_blockchain::*;
 use stegos_consensus::{BlockConsensus, BlockConsensusMessage, BlockProof, MonetaryBlockProof};
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
-use stegos_crypto::pbc::secure::Signature as SecureSignature;
+use stegos_crypto::pbc::secure;
 use stegos_keychain::KeyChain;
 use stegos_network::Network;
 use stegos_network::UnicastMessage;
@@ -138,9 +137,9 @@ impl Node {
 #[derive(Clone, Debug)]
 pub struct EpochNotification {
     pub epoch: u64,
-    pub leader: SecurePublicKey,
-    pub facilitator: SecurePublicKey,
-    pub validators: BTreeMap<SecurePublicKey, i64>,
+    pub leader: secure::PublicKey,
+    pub facilitator: secure::PublicKey,
+    pub validators: BTreeMap<secure::PublicKey, i64>,
 }
 
 /// Send when outputs created and/or pruned.
@@ -669,7 +668,7 @@ impl NodeService {
     /// Handler for new epoch creation procedure.
     /// This method called only on leader side, and when consensus is active.
     /// Leader should create a KeyBlock based on last random provided by VRF.
-    fn create_new_epoch(&mut self, facilitator: SecurePublicKey) -> Result<(), Error> {
+    fn create_new_epoch(&mut self, facilitator: secure::PublicKey) -> Result<(), Error> {
         let consensus = self.consensus.as_mut().unwrap();
         let last = self.chain.last_block();
         let previous = Hash::digest(last);
@@ -1025,7 +1024,7 @@ impl NodeService {
     fn commit_proposed_block(
         &mut self,
         block: Block,
-        multisig: SecureSignature,
+        multisig: secure::Signature,
         multisigmap: BitVector,
     ) {
         let current_timestamp = Utc::now().timestamp() as u64;

--- a/node/src/loader.rs
+++ b/node/src/loader.rs
@@ -155,7 +155,7 @@ impl NodeService {
             debug!("Chain loading already in progress, skipping request from validator.");
         }
         let validators = self.chain.validators.iter().map(|(k, _)| k);
-        let validators = validators.filter(|key| &self.keys.cosi_pkey != *key);
+        let validators = validators.filter(|key| &self.keys.network_pkey != *key);
 
         let mut rng = rand::thread_rng();
         let pkey = if let Some(pkey) = validators.choose(&mut rng) {

--- a/node/src/protos/mod.rs
+++ b/node/src/protos/mod.rs
@@ -34,8 +34,7 @@ use crate::VRFTicket;
 use failure::{format_err, Error};
 use protobuf::RepeatedField;
 use stegos_blockchain::*;
-use stegos_crypto::pbc::secure::PublicKey as SecurePublicKey;
-use stegos_crypto::pbc::secure::Signature as SecureSignature;
+use stegos_crypto::pbc::secure;
 use stegos_crypto::pbc::secure::VRF;
 
 impl ProtoConvert for SealedBlockMessage {
@@ -49,8 +48,8 @@ impl ProtoConvert for SealedBlockMessage {
     }
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
         let block = Block::from_proto(proto.get_block())?;
-        let sig = SecureSignature::from_proto(proto.get_sig())?;
-        let pkey = SecurePublicKey::from_proto(proto.get_pkey())?;
+        let sig = secure::Signature::from_proto(proto.get_sig())?;
+        let pkey = secure::PublicKey::from_proto(proto.get_pkey())?;
         Ok(SealedBlockMessage { block, sig, pkey })
     }
 }
@@ -68,8 +67,8 @@ impl ProtoConvert for VRFTicket {
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
         let random = VRF::from_proto(proto.get_random())?;
         let height = proto.get_height();
-        let pkey = SecurePublicKey::from_proto(proto.get_pkey())?;
-        let sig = SecureSignature::from_proto(proto.get_sig())?;
+        let pkey = secure::PublicKey::from_proto(proto.get_pkey())?;
+        let sig = secure::Signature::from_proto(proto.get_sig())?;
         Ok(VRFTicket {
             random,
             height,
@@ -168,7 +167,7 @@ mod tests {
         let previous = Hash::digest("test");
         let base = BaseBlockHeader::new(version, previous, epoch, timestamp);
 
-        let witnesses: BTreeSet<SecurePublicKey> = [pkey0].iter().cloned().collect();
+        let witnesses: BTreeSet<secure::PublicKey> = [pkey0].iter().cloned().collect();
         let leader = pkey0.clone();
         let facilitator = pkey0.clone();
 

--- a/node/src/test/simple_tests.rs
+++ b/node/src/test/simple_tests.rs
@@ -38,7 +38,7 @@ pub fn init() {
     assert_eq!(node.chain.blocks().len(), 0);
     assert_eq!(node.mempool.len(), 0);
     assert_eq!(node.chain.epoch, 0);
-    assert_ne!(node.chain.leader, keys.cosi_pkey);
+    assert_ne!(node.chain.leader, keys.network_pkey);
     assert!(node.chain.validators.is_empty());
 
     let current_timestamp = Utc::now().timestamp() as u64;
@@ -48,7 +48,7 @@ pub fn init() {
     assert_eq!(node.chain.blocks().len(), genesis_count);
     assert_eq!(node.mempool.len(), 0);
     assert_eq!(node.chain.epoch, 1);
-    assert_eq!(node.chain.leader, keys.cosi_pkey);
+    assert_eq!(node.chain.leader, keys.network_pkey);
     assert_eq!(node.chain.validators.len(), 1);
     assert_eq!(
         node.chain.validators.keys().next().unwrap(),
@@ -69,7 +69,7 @@ fn simulate_consensus(node: &mut NodeService) {
 
     let block = Block::MonetaryBlock(block);
     let block_hash = Hash::digest(&block);
-    let multisig = secure_sign_hash(&block_hash, &node.keys.cosi_skey);
+    let multisig = secure_sign_hash(&block_hash, &node.keys.network_skey);
     let mut multisigmap = BitVector::new(1);
     multisigmap.insert(0);
     node.commit_proposed_block(block, multisig, multisigmap);

--- a/node/src/test/simple_tests.rs
+++ b/node/src/test/simple_tests.rs
@@ -24,7 +24,7 @@ use crate::*;
 use chrono::Utc;
 use stegos_blockchain::*;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::sign_hash as secure_sign_hash;
+use stegos_crypto::pbc::secure;
 
 #[test]
 pub fn init() {
@@ -69,7 +69,7 @@ fn simulate_consensus(node: &mut NodeService) {
 
     let block = Block::MonetaryBlock(block);
     let block_hash = Hash::digest(&block);
-    let multisig = secure_sign_hash(&block_hash, &node.keys.network_skey);
+    let multisig = secure::sign_hash(&block_hash, &node.keys.network_skey);
     let mut multisigmap = BitVector::new(1);
     multisigmap.insert(0);
     node.commit_proposed_block(block, multisig, multisigmap);

--- a/node/src/test/vrf_tickets.rs
+++ b/node/src/test/vrf_tickets.rs
@@ -49,8 +49,8 @@ impl VRFHelper {
             result.push(Self::node_ticket(
                 height,
                 seed,
-                keys.cosi_pkey,
-                &keys.cosi_skey,
+                keys.network_pkey,
+                &keys.network_skey,
             ));
         }
         result

--- a/node/src/tickets.rs
+++ b/node/src/tickets.rs
@@ -300,7 +300,7 @@ impl TicketsSystem {
 ///Node service extension for VrfTicketSystem
 impl NodeService {
     pub(crate) fn broadcast_vrf_ticket(&mut self, ticket: VRFTicket) -> Result<(), Error> {
-        if self.chain.escrow.get(&self.keys.cosi_pkey) < stegos_blockchain::MIN_STAKE_AMOUNT {
+        if self.chain.escrow.get(&self.keys.network_pkey) < stegos_blockchain::MIN_STAKE_AMOUNT {
             debug!("Trying to broadcast ticket but our node is not staker.");
             return Ok(());
         }

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -130,7 +130,9 @@ pub(crate) fn validate_transaction(
     Ok(())
 }
 
-/// Process MonetaryBlockProposal CoSi message.
+///
+/// Validate proposed key block.
+///
 pub(crate) fn validate_proposed_key_block(
     consensus: &BlockConsensus,
     block_hash: Hash,
@@ -199,7 +201,7 @@ pub(crate) fn validate_sealed_key_block(
 }
 
 ///
-/// Process MonetaryBlockProposal CoSi message.
+/// Validate proposed monetary block.
 ///
 pub(crate) fn validate_proposed_monetary_block(
     mempool: &Mempool,
@@ -421,7 +423,7 @@ mod test {
 
         let skey = &keychain.wallet_skey;
         let pkey = &keychain.wallet_pkey;
-        let validator_pkey = &keychain.cosi_pkey;
+        let validator_pkey = &keychain.network_pkey;
 
         //
         // Valid transaction.

--- a/src/console.rs
+++ b/src/console.rs
@@ -156,7 +156,7 @@ impl ConsoleService {
         println!("show balance - print balance");
         println!("show utxo - print unspent outputs");
         println!("net publish TOPIC MESSAGE - publish a network message via floodsub");
-        println!("net send SECURE_PUBKEY MESSAGE - send a network message via unicast");
+        println!("net send NETWORK_PUBKEY MESSAGE - send a network message via unicast");
         println!();
     }
 
@@ -168,23 +168,23 @@ impl ConsoleService {
     }
 
     fn help_send() {
-        println!("Usage: net send SECUREKEY MESSAGE");
-        println!(" - SECUREKEY recipient's secure public key in HEX format");
+        println!("Usage: net send NETWORK_PUBKEY MESSAGE");
+        println!(" - NETWORK_PUBKEY recipient's network public key in HEX format");
         println!(" - MESSAGE some message");
         println!();
     }
 
     fn help_pay() {
-        println!("Usage: pay PUBLICKEY AMOUNT [COMMENT]");
-        println!(" - WALLETKEY recipient's wallet public key in HEX format");
+        println!("Usage: pay WALLET_PUBKEY AMOUNT [COMMENT]");
+        println!(" - WALLET_PUBKEY recipient's wallet public key in HEX format");
         println!(" - AMOUNT amount in tokens");
         println!(" - COMMENT purpose of payment");
         println!();
     }
 
     fn help_spay() {
-        println!("Usage: spay PUBLICKEY AMOUNT [COMMENT]");
-        println!(" - WALLETKEY recipient's wallet public key in HEX format");
+        println!("Usage: spay WALLET_PUBKEY AMOUNT [COMMENT]");
+        println!(" - WALLET_PUBKEY recipient's wallet public key in HEX format");
         println!(" - AMOUNT amount in tokens");
         println!(" - COMMENT purpose of payment");
         println!();
@@ -204,8 +204,8 @@ impl ConsoleService {
     }
 
     fn help_msg() {
-        println!("Usage: msg PUBLICKEY MESSAGE");
-        println!(" - PUBLICKEY recipient's public key in HEX format");
+        println!("Usage: msg WALLET_PUBKEY MESSAGE");
+        println!(" - WALLET_PUBKEY recipient's public key in HEX format");
         println!(" - MESSAGE some message");
         println!();
     }
@@ -240,7 +240,7 @@ impl ConsoleService {
             let recipient = match secure::PublicKey::try_from_hex(recipient) {
                 Ok(r) => r,
                 Err(e) => {
-                    println!("Invalid public key '{}': {}", recipient, e);
+                    println!("Invalid network public key '{}': {}", recipient, e);
                     Self::help_send();
                     return true;
                 }
@@ -263,7 +263,7 @@ impl ConsoleService {
             let recipient = match PublicKey::try_from_hex(recipient) {
                 Ok(r) => r,
                 Err(e) => {
-                    println!("Invalid public key '{}': {}", recipient, e);
+                    println!("Invalid wallet public key '{}': {}", recipient, e);
                     Self::help_pay();
                     return true;
                 }
@@ -291,7 +291,7 @@ impl ConsoleService {
             let recipient = match PublicKey::try_from_hex(recipient) {
                 Ok(r) => r,
                 Err(e) => {
-                    println!("Invalid public key '{}': {}", recipient, e);
+                    println!("Invalid wallet public key '{}': {}", recipient, e);
                     Self::help_pay();
                     return true;
                 }
@@ -323,7 +323,7 @@ impl ConsoleService {
             let recipient = match PublicKey::try_from_hex(recipient) {
                 Ok(r) => r,
                 Err(e) => {
-                    println!("Invalid public key '{}': {}", recipient, e);
+                    println!("Invalid wallet public key '{}': {}", recipient, e);
                     Self::help_msg();
                     return true;
                 }
@@ -407,10 +407,10 @@ impl ConsoleService {
             }
             WalletNotification::KeysInfo {
                 wallet_pkey,
-                cosi_pkey,
+                network_pkey,
             } => {
                 println!("My wallet key: {}", &wallet_pkey.into_hex());
-                println!("My secure key: {}", &cosi_pkey.into_hex());
+                println!("My network key: {}", &network_pkey.into_hex());
                 self.stdin_th.thread().unpark();
             }
             WalletNotification::UnspentInfo {

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -254,7 +254,7 @@ fn run() -> Result<(), Error> {
         let (wallet_service, wallet) = WalletService::new(
             keychain.wallet_skey.clone(),
             keychain.wallet_pkey.clone(),
-            keychain.cosi_pkey.clone(),
+            keychain.network_pkey.clone(),
             network.clone(),
             node.clone(),
         );

--- a/txpool/src/lib.rs
+++ b/txpool/src/lib.rs
@@ -75,7 +75,7 @@ pub struct TransactionPoolService {
 impl TransactionPoolService {
     /// Crates new TransactionPool.
     pub fn new(keychain: &KeyChain, network: Network, node: Node) -> TransactionPoolService {
-        let pkey = keychain.cosi_pkey.clone();
+        let pkey = keychain.network_pkey.clone();
         let facilitator_pkey: secure::PublicKey = G2::generator().into(); // some fake key
 
         let events = || -> Result<_, Error> {

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -47,7 +47,7 @@ pub enum WalletNotification {
     },
     KeysInfo {
         wallet_pkey: PublicKey,
-        cosi_pkey: secure::PublicKey,
+        network_pkey: secure::PublicKey,
     },
     UnspentInfo {
         unspent: Vec<(Hash, i64)>,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -87,7 +87,7 @@ impl WalletService {
         node: Node,
     ) -> (Self, Wallet) {
         info!("My wallet key: {}", &pkey.into_hex());
-        debug!("My secure key: {}", &validator_pkey.into_hex());
+        debug!("My network key: {}", &validator_pkey.into_hex());
 
         //
         // State.
@@ -340,7 +340,7 @@ impl Future for WalletService {
                         WalletEvent::KeysInfo => {
                             let notification = WalletNotification::KeysInfo {
                                 wallet_pkey: self.pkey,
-                                cosi_pkey: self.validator_pkey,
+                                network_pkey: self.validator_pkey,
                             };
                             self.subscribers
                                 .retain(move |tx| tx.unbounded_send(notification.clone()).is_ok());


### PR DESCRIPTION
Unify secure:: usage across the code.

Follow up #542
