### PR TITLE
Implement super-transactions for ValueShuffle

### DIFF
--- a/crypto/protos/crypto.proto
+++ b/crypto/protos/crypto.proto
@@ -21,6 +21,10 @@ message Hash {
     bytes data = 1;
 }
 
+message SecretKey {
+    Fr skeyf = 1;
+}
+
 message PublicKey {
     Pt point = 1;
 }
@@ -39,9 +43,8 @@ message SecureSignature {
 }
 
 message EncryptedPayload {
-    Pt apkg = 1;
-    Pt ag = 2;
-    bytes ctxt = 3;
+    Pt ag = 1;
+    bytes ctxt = 2;
 }
 
 message LR {

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -188,6 +188,20 @@ macro_rules! field_impl {
                 Self::acceptable_random_rehash(x)
             }
 
+            /// Convert to positive i64 (if you can)
+            pub fn to_i64(self) -> Result<i64, CryptoError> {
+                let U256(uval) = U256::from(self.unscaled());
+                if uval[0] == 0
+                    && uval[1] == 0
+                    && uval[2] == 0
+                    && uval[3] < 0x8000_0000_0000_0000u64
+                {
+                    return Ok(uval[3] as i64);
+                } else {
+                    return Err(CryptoError::TooLarge);
+                }
+            }
+
             /// Convert into raw bytes.
             pub fn to_lev_u8(self) -> [u8; 32] {
                 self.bits().to_lev_u8()

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -150,6 +150,7 @@ fn check_prng() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::dbg;
 
     #[test]
     fn tst_hex() {
@@ -198,6 +199,7 @@ mod tests {
         let gen_x = Fq::try_from_hex(sx).unwrap();
         let gen_y = Fq::try_from_hex(sy).unwrap();
         let pt1 = ECp::try_from_xy(&gen_x, &gen_y).unwrap();
+        dbg!((gen_x, gen_y, pt1));
 
         let gx = Fq::try_from_hex(&sx).unwrap();
         let gy = Fq::try_from_hex(&sy).unwrap();

--- a/crypto/src/dicemix/mod.rs
+++ b/crypto/src/dicemix/mod.rs
@@ -557,7 +557,7 @@ pub fn dc_keys(
     out
 }
 
-pub type ValidatorFn<T> = fn(&ParticipantID, &Vec<Vec<u8>>, Fr, &T) -> bool;
+pub type ValidatorFn<T> = fn(&ParticipantID, &Vec<Vec<u8>>, Fr, Fr, &T) -> bool;
 
 pub fn dc_reconstruct<T>(
     participants: &Vec<ParticipantID>,
@@ -565,7 +565,8 @@ pub fn dc_reconstruct<T>(
     my_id: &ParticipantID,
     sess_skeys: &HashMap<ParticipantID, SecretKey>,
     dc: &HashMap<ParticipantID, DcMatrix>,
-    sum_dc: &HashMap<ParticipantID, Fr>,
+    sum_dc1: &HashMap<ParticipantID, Fr>, // table of cloaked gamma_adj
+    sum_dc2: &HashMap<ParticipantID, Fr>, // table of cloaked fees
     sess: &Hash,
     p_excl: &Vec<ParticipantID>,
     k_excl: &HashMap<ParticipantID, HashMap<ParticipantID, Hash>>,
@@ -641,10 +642,12 @@ where
 
             if !pkey_fail {
                 // recover component of shared sum and validate the payload
-                let seed_str = format!("sum").into_bytes();
-                let r_adj = *sum_dc.get(pkey).unwrap()
+                let seed_str = scalar_open_seed();
+                let r_adj = *sum_dc1.get(pkey).expect("Can't access sum_dc1")
                     - dc_slot_pad(participants, pkey, &cloaks, &seed_str);
-                pkey_fail = !vfn(&pkey, &msgs, r_adj, data);
+                let fee = *sum_dc2.get(pkey).expect("Can't access sum_dc2")
+                    - dc_slot_pad(participants, pkey, &cloaks, &seed_str);
+                pkey_fail = !vfn(&pkey, &msgs, r_adj, fee, data);
             }
 
             if !pkey_fail {
@@ -1276,6 +1279,7 @@ mod tests {
             pkey: &ParticipantID,
             msgs: &Vec<Vec<u8>>,
             r_adj: Fr,
+            fee: Fr,
             dum_data: &Vec<usize>,
         ) -> bool {
             // deserialize msgs and check the validity of the components.
@@ -1294,6 +1298,7 @@ mod tests {
             &my_id,
             &sess_skeys,
             &matrices,
+            &gamma_adjs,
             &gamma_adjs,
             &sess,
             &p_excl,
@@ -1327,7 +1332,7 @@ mod tests {
     }
 
     #[test]
-    fn tst_10_15() {
+    fn tst_10_5() {
         tst_end_to_end(10, 5, 1350);
     }
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -57,6 +57,11 @@ pub enum CryptoError {
     /// length.
     #[fail(display = "Invalid hex string length")]
     InvalidHexLength,
+
+    // If someone requests a field value, e.g., Fr::to_i64() and number
+    // is too large to allow that conversion...
+    #[fail(display = "Field value is too large for requested conversion")]
+    TooLarge,
 }
 
 impl From<hex::FromHexError> for CryptoError {

--- a/crypto/src/protos.rs
+++ b/crypto/src/protos.rs
@@ -24,7 +24,7 @@ use stegos_serialization::traits::*;
 
 use crate::bulletproofs::{BulletProof, DotProof, L2_NBASIS, LR};
 use crate::curve1174::cpt::Pt;
-use crate::curve1174::cpt::{EncryptedPayload, PublicKey, SchnorrSig};
+use crate::curve1174::cpt::{EncryptedPayload, PublicKey, SchnorrSig, SecretKey};
 use crate::curve1174::fields::Fr;
 use crate::hash::Hash;
 use crate::pbc::secure;
@@ -95,6 +95,20 @@ impl ProtoConvert for Hash {
     }
 }
 
+impl ProtoConvert for SecretKey {
+    type Proto = crypto::SecretKey;
+    fn into_proto(&self) -> Self::Proto {
+        let mut proto = crypto::SecretKey::new();
+        let fval = Fr::from(self.clone());
+        proto.set_skeyf(fval.into_proto());
+        proto
+    }
+    fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
+        let fval = Fr::from_proto(proto.get_skeyf())?;
+        Ok(SecretKey::from(fval))
+    }
+}
+
 impl ProtoConvert for PublicKey {
     type Proto = crypto::PublicKey;
     fn into_proto(&self) -> Self::Proto {
@@ -156,16 +170,14 @@ impl ProtoConvert for EncryptedPayload {
     type Proto = crypto::EncryptedPayload;
     fn into_proto(&self) -> Self::Proto {
         let mut proto = crypto::EncryptedPayload::new();
-        proto.set_apkg(self.apkg.into_proto());
         proto.set_ag(self.ag.into_proto());
         proto.set_ctxt(self.ctxt.clone());
         proto
     }
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
-        let apkg = Pt::from_proto(proto.get_apkg())?;
         let ag = Pt::from_proto(proto.get_ag())?;
         let ctxt = proto.get_ctxt().to_vec();
-        Ok(EncryptedPayload { apkg, ag, ctxt })
+        Ok(EncryptedPayload { ag, ctxt })
     }
 }
 

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -226,8 +226,10 @@ mod test {
         let (skey, pkey, _sig) = make_random_keys();
         let mut mempool = Mempool::new();
 
-        let (tx1, inputs1, outputs1) = Transaction::new_test(&skey, &pkey, 100, 2, 200, 1, 0);
-        let (tx2, inputs2, outputs2) = Transaction::new_test(&skey, &pkey, 300, 1, 100, 3, 0);
+        let (tx1, inputs1, outputs1) =
+            Transaction::new_test(&skey, &pkey, 100, 2, 200, 1, 0).expect("transaction valid");
+        let (tx2, inputs2, outputs2) =
+            Transaction::new_test(&skey, &pkey, 300, 1, 100, 3, 0).expect("transaction valid");
         let tx_hash1 = Hash::digest(&tx1);
         let tx_hash2 = Hash::digest(&tx2);
 
@@ -290,7 +292,8 @@ mod test {
         let (skey, pkey, _sig) = make_random_keys();
         let mut mempool = Mempool::new();
 
-        let (tx, inputs, _outputs) = Transaction::new_test(&skey, &pkey, 100, 1, 100, 1, 0);
+        let (tx, inputs, _outputs) =
+            Transaction::new_test(&skey, &pkey, 100, 1, 100, 1, 0).expect("transaction valid");
         let tx_hash = Hash::digest(&tx);
         mempool.push_tx(tx_hash.clone(), tx.clone());
         mempool.prune(&vec![Hash::digest(&inputs[0])], &vec![]);
@@ -302,7 +305,8 @@ mod test {
         let (skey, pkey, _sig) = make_random_keys();
         let mut mempool = Mempool::new();
 
-        let (tx, _inputs, outputs) = Transaction::new_test(&skey, &pkey, 100, 1, 100, 1, 0);
+        let (tx, _inputs, outputs) =
+            Transaction::new_test(&skey, &pkey, 100, 1, 100, 1, 0).expect("transaction valid");
         let tx_hash = Hash::digest(&tx);
         mempool.push_tx(tx_hash.clone(), tx.clone());
         mempool.prune(&vec![], &vec![Hash::digest(&outputs[0])]);
@@ -313,10 +317,10 @@ mod test {
         let (skey, pkey, _sig) = make_random_keys();
         let mut mempool = Mempool::new();
 
-        let (tx1, inputs1, _outputs1) = Transaction::new_test(&skey, &pkey, 3, 2, 2, 1, 4);
-        tx1.validate(&inputs1).expect("transaction is valid");
-        let (tx2, inputs2, _outputs2) = Transaction::new_test(&skey, &pkey, 6, 1, 2, 2, 2);
-        tx2.validate(&inputs2).expect("transaction is valid");
+        let (tx1, inputs1, _outputs1) =
+            Transaction::new_test(&skey, &pkey, 3, 2, 2, 1, 4).expect("transaction valid");
+        let (tx2, inputs2, _outputs2) =
+            Transaction::new_test(&skey, &pkey, 6, 1, 2, 2, 2).expect("transaction valid");
 
         let tx_hash1 = Hash::digest(&tx1);
         let tx_hash2 = Hash::digest(&tx2);

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -460,7 +460,7 @@ mod test {
             let fee = PAYMENT_FEE - 1;
             let (output, gamma) =
                 Output::new_payment(current_timestamp, &skey, &pkey, amount - fee).unwrap();
-            let tx = Transaction::new(&skey, &inputs, &[output], gamma, fee).unwrap();
+            let tx = Transaction::unchecked(&skey, &inputs, &[output], gamma, fee).unwrap();
             let e = validate_transaction(&tx, &mempool, &chain, current_timestamp)
                 .expect_err("transaction is not valid");
             match e.downcast::<NodeError>().unwrap() {
@@ -571,7 +571,7 @@ mod test {
             let output2 = Output::StakeOutput(output2);
             let outputs: Vec<Output> = vec![output1, output2];
             let outputs_gamma = gamma1;
-            let tx = Transaction::new(&skey, &inputs, &outputs, outputs_gamma, fee).unwrap();
+            let tx = Transaction::unchecked(&skey, &inputs, &outputs, outputs_gamma, fee).unwrap();
             let e = validate_transaction(&tx, &mempool, &chain, current_timestamp)
                 .expect_err("transaction is not valid");
             match e.downcast::<OutputError>().expect("proper error") {
@@ -587,7 +587,7 @@ mod test {
             let fee = PAYMENT_FEE;
             let (output, outputs_gamma) =
                 Output::new_payment(current_timestamp, &skey, &pkey, stake - fee).unwrap();
-            let tx = Transaction::new(&skey, &stakes, &[output], outputs_gamma, fee).unwrap();
+            let tx = Transaction::unchecked(&skey, &stakes, &[output], outputs_gamma, fee).unwrap();
             let e = validate_transaction(&tx, &mempool, &chain, current_timestamp)
                 .expect_err("transaction is not valid");
             match e.downcast::<EscrowError>().expect("proper error") {
@@ -617,10 +617,11 @@ mod test {
             let outputs: Vec<Output> = vec![output];
             let output_hashes: Vec<Hash> = outputs.iter().map(|o| Hash::digest(o)).collect();
             // Claim output in mempool.
-            let claim_tx = Transaction::new(&skey, &[], &outputs, outputs_gamma, fee).unwrap();
+            let claim_tx =
+                Transaction::unchecked(&skey, &[], &outputs, outputs_gamma, fee).unwrap();
             mempool.push_tx(Hash::digest(&claim_tx), claim_tx);
 
-            let tx = Transaction::new(&skey, &inputs, &outputs, outputs_gamma, fee).unwrap();
+            let tx = Transaction::unchecked(&skey, &inputs, &outputs, outputs_gamma, fee).unwrap();
             let e = validate_transaction(&tx, &mempool, &chain, current_timestamp)
                 .expect_err("transaction is not valid");
             match e.downcast::<BlockchainError>().expect("proper error") {
@@ -654,8 +655,8 @@ mod test {
                 .register_monetary_block(block, current_timestamp)
                 .expect("block is valid");
 
-            let tx =
-                Transaction::new(&skey, &inputs, &[output.clone()], outputs_gamma, fee).unwrap();
+            let tx = Transaction::unchecked(&skey, &inputs, &[output.clone()], outputs_gamma, fee)
+                .unwrap();
             let e = validate_transaction(&tx, &mempool, &chain, current_timestamp)
                 .expect_err("transaction is not valid");
             match e.downcast::<BlockchainError>().expect("proper error") {


### PR DESCRIPTION
- Upgrade Transactions to support TXINs to multiple payee pubkeys,
  all belonging to one node who knows the corresponding secret keys.

- Added crypto primitive curve1174::cpt::sign_hash_with_kval() to support
  construction of Schnorr multi-signatures.

- Add operators + and += for SchnorrSig to support multi-signatures.

- Corrections to Schnorr multi-signature construction.

- Shorten keying hint in UTXO EncryptedPayload to use only
  hint = alpha * P, key = H(s * alpha * G).
  Saves 32 bytes (256 bits) from every UTXO

Closes #328