### PR TITLE
Implement console command to show election status.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ dependencies = [
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_blockchain 0.1.0",
  "stegos_consensus 0.1.0",

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -1053,6 +1053,12 @@ impl Hashable for VRF {
     }
 }
 
+impl fmt::Display for VRF {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "VRF({})", self.rand.to_hex())
+    }
+}
+
 pub fn make_VRF(skey: &SecretKey, seed: &Hash) -> VRF {
     // whatever the source of the seed, it should all be
     // pre-hashed before calling this function

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.6"
 rand_isaac = "0.1.1"
 serde = "1.0"
 serde_derive = "1.0"
+serde_yaml = "0.8"
 simple_logger = "1.0"
 tokio-timer = "0.2"
 

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -266,7 +266,7 @@ fn run() -> Result<(), Error> {
         rt.spawn(wallet_service);
 
         // Initialize console
-        let console_service = ConsoleService::new(network.clone(), wallet.clone())?;
+        let console_service = ConsoleService::new(network.clone(), wallet.clone(), node.clone())?;
         rt.spawn(console_service);
     }
 


### PR DESCRIPTION
Added api to request info from Node.
For now it just contain a field that is used to render election state, but later could be replaced by enum:

```rust
pub struct InfoNotification {
    /// simple text output.
    pub display: tickets::DisplayState,
}
```

But later it can be Enum that agregate other information.


The output text looks like:
```console
---
- height: 2
  view_change: 0
  state: sleeping
  timeout: 0min 0s 247ms
  collected_tickets: ~

```
For collecting phase it's not friendly, but still usable:
```console
stegos> show election
---
- height: 2
  view_change: 1
  state: collecting
  timeout: 0min 59s 541ms
  collected_tickets:
    96f5dbc0ced2...: 6b93cd7a8f51a4...


```