### PR TITLE
speed up ECp compare from 5 microsec to 0.33 microsec

### DIFF
--- a/crypto/src/curve1174/ecpt.rs
+++ b/crypto/src/curve1174/ecpt.rs
@@ -208,8 +208,7 @@ impl Eq for ECp {}
 
 impl PartialEq for ECp {
     fn eq(&self, b: &Self) -> bool {
-        let tmp: [u8; 32] = (*self - *b).to_bytes();
-        tmp == [0u8; 32]
+        self.x * b.z == self.z * b.x && self.y * b.z == self.z * b.y
     }
 }
 


### PR DESCRIPTION
This small change speeds up comparison of ECp points by a considerable margin, from 5 microseconds down to 335 nanoseconds, by avoiding an expensive divide operation to convert the 51-bit representation into Fq field representations. We remain in the 51-bit representation here.