### PR TITLE
Make `Display` print shorter public keys.

### DIFF
--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 use failure::{Error, Fail};
-use std::fmt;
 use std::mem::transmute;
 use stegos_crypto::bulletproofs::{make_range_proof, BulletProof};
 use stegos_crypto::curve1174::cpt::{
@@ -493,12 +492,6 @@ impl Output {
             amount,
         )?;
         Ok(Output::StakeOutput(output))
-    }
-}
-
-impl fmt::Display for Output {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Output({})", Hash::digest(self))
     }
 }
 

--- a/consensus/src/state.rs
+++ b/consensus/src/state.rs
@@ -226,7 +226,7 @@ impl<Request: Hashable + Clone + Debug, Proof: Hashable + Clone + Debug> Consens
         assert_eq!(&request_hash, &expected_request_hash);
         assert!(!self.precommits.contains_key(&self.pkey));
         debug!(
-            "{}({}): pre-commit request={}",
+            "{}({}): pre-commit request={:?}",
             self.state.name(),
             self.height,
             &request_hash
@@ -408,7 +408,7 @@ impl<Request: Hashable + Clone + Debug, Proof: Hashable + Clone + Debug> Consens
                 assert!(self.request.is_none());
                 assert!(self.proof.is_none());
                 debug!(
-                    "{}({}) => {}({}): received a new proposal hash={}, from={}",
+                    "{}({}) => {}({}): received a new proposal hash={:?}, from={:?}",
                     self.state.name(),
                     self.height,
                     ConsensusState::Prevote.name(),

--- a/crypto/examples/pbc.rs
+++ b/crypto/examples/pbc.rs
@@ -28,51 +28,48 @@ use stegos_crypto::pbc::*;
 
 fn main() {
     let pt = fast::G1::generator() * fast::Zr::zero();
-    println!("pt = {}", pt);
+    println!("pt = {:?}", pt);
     // ------------------------------------------------------------
     // on Secure pairings
     // test PRNG
-    println!("rand Zr = {}", secure::Zr::random());
+    println!("rand Zr = {}", secure::Zr::random().to_hex());
 
     // test keying...
-    let (skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
-    println!("skey = {}", skey);
-    println!("pkey = {}", pkey);
-    println!("sig  = {}", sig);
+    let (_skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
+    println!("pkey = {:?}", pkey);
+    println!("sig  = {:?}", sig);
     assert!(secure::check_keying(&pkey, &sig));
     println!("");
 
     // -------------------------------------
     // on Fast pairings
     // test PRNG
-    println!("rand Zr = {}", fast::Zr::random());
+    println!("rand Zr = {:?}", fast::Zr::random());
 
     // test keying...
-    let (skey, pkey, sig) = fast::make_deterministic_keys(b"Testing");
-    println!("skey = {}", skey);
-    println!("pkey = {}", pkey);
-    println!("sig  = {}", sig);
+    let (_skey, pkey, sig) = fast::make_deterministic_keys(b"Testing");
+    println!("pkey = {:?}", pkey);
+    println!("sig  = {:?}", sig);
     assert!(fast::check_keying(&pkey, &sig));
 
     // -------------------------------------
     // check some arithmetic on the Fast curves
     let a = 0x123456789i64;
-    println!("chk Zr: 0x{:x} -> {}", a, fast::Zr::from(a));
-    println!("chk Zr: -1 -> {}", fast::Zr::from(-1));
-    println!("chk Zr: -1 + 1 -> {}", fast::Zr::from(-1) + 1);
+    println!("chk Zr: 0x{:x} -> {:?}", a, fast::Zr::from(a));
+    println!("chk Zr: -1 -> {:?}", fast::Zr::from(-1));
+    println!("chk Zr: -1 + 1 -> {:?}", fast::Zr::from(-1) + 1);
 
-    let (skey, pkey, sig) = secure::make_deterministic_keys(b"dev");
-    println!("skey = {}", skey);
-    println!("pkey = {}", pkey);
-    println!("sig = {}", sig);
+    let (_skey, pkey, sig) = secure::make_deterministic_keys(b"dev");
+    println!("pkey = {:?}", pkey);
+    println!("sig = {:?}", sig);
 
     // -----------------------------------------
     let (skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
     assert!(secure::check_keying(&pkey, &sig));
     let hseed = Hash::from_str("VRF_Seed");
     let vrf = secure::make_VRF(&skey, &hseed);
-    println!("VRF Rand: {:}", vrf.rand);
-    println!("VRF Proof: {:}", vrf.proof);
+    println!("VRF Rand: {:?}", vrf.rand);
+    println!("VRF Proof: {:?}", vrf.proof);
     assert!(secure::validate_VRF_randomness(&vrf));
     assert!(secure::validate_VRF_source(&vrf, &pkey, &hseed));
 }

--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -334,13 +334,7 @@ pub struct LR {
 
 impl Debug for BulletProof {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BP(vcmt: {}, ...)", self.vcmt)
-    }
-}
-
-impl fmt::Display for BulletProof {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        write!(f, "BP(vcmt: {:?}, ...)", self.vcmt)
     }
 }
 
@@ -700,11 +694,11 @@ pub mod tests {
 
     #[test]
     pub fn check_bp_init() {
-        debug!("G: {}", Point::compress(*G));
-        debug!("H: {}", Point::compress(BP.H));
+        debug!("G: {:?}", Point::compress(*G));
+        debug!("H: {:?}", Point::compress(BP.H));
         for ix in 0..NBASIS {
-            debug!("GV{} = {}", ix, Point::compress(BP.GV[ix]));
-            debug!("HV{} = {}", ix, Point::compress(BP.HV[ix]));
+            debug!("GV{} = {:?}", ix, Point::compress(BP.GV[ix]));
+            debug!("HV{} = {:?}", ix, Point::compress(BP.HV[ix]));
         }
     }
 
@@ -845,7 +839,7 @@ pub fn bulletproofs_tests() {
     let (proof, gamma) = make_range_proof(1234567890);
     let timing = start.elapsed();
     debug!("proof = {:#?}", proof);
-    debug!("gamma = {}", gamma);
+    debug!("gamma = {:?}", gamma);
     debug!("Time: {:?}", timing);
     debug!("");
     debug!("Start Validation");

--- a/crypto/src/curve1174/cpt.rs
+++ b/crypto/src/curve1174/cpt.rs
@@ -91,12 +91,6 @@ impl Pt {
     }
 }
 
-impl fmt::Display for Pt {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Pt({})", self.to_hex())
-    }
-}
-
 impl fmt::Debug for Pt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Pt({})", self.to_hex())
@@ -159,15 +153,9 @@ impl SecretKey {
     }
 }
 
-impl fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SKey({})", self.to_hex())
-    }
-}
-
 impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SKey({})", self.to_hex())
+        f.write_str("SKey(*HIDDEN DATA*)")
     }
 }
 
@@ -229,7 +217,8 @@ impl PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "PKey({})", self.to_hex())
+        // display only first 6 bytes.
+        write!(f, "{}", &self.to_hex()[0..12])
     }
 }
 
@@ -457,13 +446,7 @@ pub struct EncryptedPayload {
 
 impl fmt::Debug for EncryptedPayload {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ag={} cmsg={}", self.ag, u8v_to_hexstr(&self.ctxt))
-    }
-}
-
-impl fmt::Display for EncryptedPayload {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        write!(f, "ag={:?} cmsg={}", self.ag, u8v_to_hexstr(&self.ctxt))
     }
 }
 

--- a/crypto/src/curve1174/ecpt.rs
+++ b/crypto/src/curve1174/ecpt.rs
@@ -183,16 +183,6 @@ impl From<Hash> for ECp {
     }
 }
 
-impl fmt::Display for ECp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "ECp {{\n x: {},\n y: {},\n z: {},\n t: {} }}",
-            self.x, self.y, self.z, self.t
-        )
-    }
-}
-
 // --------------------------------------------------------
 
 impl Hashable for ECp {
@@ -643,17 +633,14 @@ mod tests {
         let gen_y = Fq::try_from_hex(&sy)?;
 
         println!("The Generator Point");
-        println!("gen_x: {}", gen_x);
-        println!("gen_y: {}", gen_y);
+        println!("gen_x: {:?}", gen_x);
+        println!("gen_y: {:?}", gen_y);
 
         let mut pt1 = ECp::inf();
         for _ in 0..100 {
             pt1 = ECp::try_from_xy(&gen_x, &gen_y).unwrap();
             mul_to_proj(&w, &mut pt1);
         }
-
-        println!("Result as Bignums");
-        println!("pt: {}", pt1);
 
         println!("Result as Fq51s");
         println!("pt: {:#?}", pt1);

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -245,15 +245,6 @@ macro_rules! field_impl {
             }
         }
 
-        // -------------------------------------------
-
-        impl fmt::Display for $name {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let tmp = (*self).unscaled_bits();
-                write!(f, $fmt, tmp.nbr_str())
-            }
-        }
-
         // --------------------------------------------------------
 
         impl Hashable for $name {

--- a/crypto/src/curve1174/fq51.rs
+++ b/crypto/src/curve1174/fq51.rs
@@ -116,12 +116,6 @@ impl fmt::Debug for Fq51 {
     }
 }
 
-impl fmt::Display for Fq51 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Fq51({})", self.nbr_str())
-    }
-}
-
 impl Add<Fq51> for Fq51 {
     type Output = Fq51;
     fn add(self, other: Fq51) -> Fq51 {

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -287,20 +287,20 @@ pub fn curve1174_tests() {
         let pt1 = ECp::try_from_xy(&gx, &gy).unwrap();
         pt2 = pt1 * mx;
     }
-    println!("pt2: {}", pt2);
+    println!("pt2: {:?}", pt2);
 
     let pt1 = ECp::try_from_xy(&gx, &gy).unwrap();
     let pt2 = pt1 + pt1;
-    println!("ptsum {}", pt2);
+    println!("ptsum {:?}", pt2);
 
     let tmp = Fr::from(2);
     let tmp2 = 1 / tmp;
     // println!("1/mul: {}", 1/Fr::from(2));
     // println!("unity? {}", (1/Fr::from(2)) * 2);
-    println!("mul: {}", tmp);
-    println!("1/2 = {}", tmp2);
-    println!("R = {}", *R);
-    println!("mx: {}", tmp * tmp2);
+    println!("mul: {:?}", tmp);
+    println!("1/2 = {:?}", tmp2);
+    println!("R = {:?}", *R);
+    println!("mx: {:?}", tmp * tmp2);
     /* */
     let _ = StdRng::from_entropy();
     let mut r = StdRng::from_rng(thread_rng()).unwrap();
@@ -315,38 +315,37 @@ pub fn curve1174_tests() {
     let pt = ECp::try_from_xy(&gen_x, &gen_y).unwrap();
 
     println!("The Generator Point");
-    println!("gen_x: {}", gen_x);
-    println!("gen_y: {}", gen_y);
-    println!("gen_pt: {}", pt);
+    println!("gen_x: {:?}", gen_x);
+    println!("gen_y: {:?}", gen_y);
+    println!("gen_pt: {:?}", pt);
 
-    println!("x+y: {}", gen_x + gen_y);
+    println!("x+y: {:?}", gen_x + gen_y);
     /* */
     let ept = ECp::from(Hash::from_vector(b"Testing12")); // produces an odd Y
     let cpt = Pt::from(ept); // MSB should be set
     let ept2 = ECp::decompress(cpt).unwrap();
-    println!("hash -> {}", ept);
-    println!("hash -> {}", cpt);
-    println!("hash -> {}", ept2);
+    println!("hash -> {:?}", ept);
+    println!("hash -> {:?}", cpt);
+    println!("hash -> {:?}", ept2);
 
     // ---------------------------------------------------------------
     let (skey, pkey, sig) = make_deterministic_keys(b"Testing");
     println!("Key Check = {}", check_keying(&pkey, &sig).unwrap());
-    println!("skey = {}", skey);
-    println!("pkey = {}", pkey);
+    println!("pkey = {:?}", pkey);
 
     let delta = Fr::random();
-    println!("delta = {}", delta);
+    println!("delta = {:?}", delta);
 
     let cpt = Pt::from(pkey);
     let ept = ECp::decompress(cpt).unwrap() + delta * *G;
     let delta_pkey = PublicKey::from(ept);
-    println!("delta_key = {}", Pt::from(delta_pkey));
+    println!("delta_key = {:?}", Pt::from(delta_pkey));
 
     let delta_skey = SecretKey::from(Fr::from(skey.clone()) + delta);
 
     let hmsg = Hash::try_from_hex(&HASH_CONSTS).unwrap();
     let sig = sign_hash(&hmsg, &skey);
-    println!("sig = (u: {}, K: {})", sig.u, sig.K);
+    println!("sig = (u: {:?}, K: {:?})", sig.u, sig.K);
 
     use crate::hash;
     let msg = hash::hash_nbytes(72, b"This is a test");

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -129,7 +129,8 @@ impl fmt::Debug for Hash {
 
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        // display only first 6 bytes.
+        write!(f, "{}", &self.to_hex()[0..12])
     }
 }
 

--- a/crypto/src/pbc/fast.rs
+++ b/crypto/src/pbc/fast.rs
@@ -184,12 +184,6 @@ impl fmt::Debug for Zr {
     }
 }
 
-impl fmt::Display for Zr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastZr({})", self.to_hex())
-    }
-}
-
 impl Hashable for Zr {
     fn hash(&self, state: &mut Hasher) {
         "FastZr".hash(state);
@@ -447,12 +441,6 @@ impl fmt::Debug for G1 {
     }
 }
 
-impl fmt::Display for G1 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastG1({})", self.to_hex())
-    }
-}
-
 impl Hashable for G1 {
     fn hash(&self, state: &mut Hasher) {
         "FastG1".hash(state);
@@ -661,12 +649,6 @@ impl fmt::Debug for G2 {
     }
 }
 
-impl fmt::Display for G2 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastG2({})", self.to_hex())
-    }
-}
-
 impl Hashable for G2 {
     fn hash(&self, state: &mut Hasher) {
         "FastG2".hash(state);
@@ -818,12 +800,6 @@ impl GT {
     }
 }
 
-impl fmt::Display for GT {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastGT({})", self.to_hex())
-    }
-}
-
 impl Eq for GT {}
 impl PartialEq for GT {
     fn eq(&self, b: &Self) -> bool {
@@ -879,12 +855,11 @@ impl SecretKey {
     }
 }
 
-impl fmt::Display for SecretKey {
+impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastSKey({})", self.to_hex())
+        f.write_str("FastSKey(*HIDDEN DATA*)")
     }
 }
-
 impl Hashable for SecretKey {
     fn hash(&self, state: &mut Hasher) {
         "FastSKey".hash(state);
@@ -949,7 +924,8 @@ impl fmt::Debug for PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastPKey({})", self.to_hex())
+        // display only first 6 bytes.
+        write!(f, "{}", &self.to_hex()[0..12])
     }
 }
 
@@ -991,9 +967,9 @@ impl Signature {
     }
 }
 
-impl fmt::Display for Signature {
+impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FastSig({})", self.to_hex())
+        write!(f, "Signature({})", self.to_hex())
     }
 }
 

--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -175,12 +175,6 @@ impl PartialOrd for Zr {
     }
 }
 
-impl fmt::Display for Zr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureZr({})", self.to_hex())
-    }
-}
-
 impl Hashable for Zr {
     fn hash(&self, state: &mut Hasher) {
         "SecureZr".hash(state);
@@ -265,13 +259,6 @@ impl G1 {
 }
 
 impl fmt::Debug for G1 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureG1({})", self.to_hex())
-    }
-}
-
-impl fmt::Display for G1 {
-    // for display of signatures
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureG1({})", self.to_hex())
     }
@@ -377,12 +364,6 @@ impl fmt::Debug for G2 {
     }
 }
 
-impl fmt::Display for G2 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureG2({})", self.to_hex())
-    }
-}
-
 impl Hashable for G2 {
     fn hash(&self, state: &mut Hasher) {
         "SecureG2".hash(state);
@@ -448,12 +429,6 @@ impl GT {
     }
 }
 
-impl fmt::Display for GT {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureGT({})", self.to_hex())
-    }
-}
-
 impl Hashable for GT {
     fn hash(&self, state: &mut Hasher) {
         "SecureGT".hash(state);
@@ -489,15 +464,9 @@ impl SecretKey {
     }
 }
 
-impl fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureSKey({})", self.to_hex())
-    }
-}
-
 impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureSKey({})", self.to_hex())
+        f.write_str("SecureSKey(*HIDDEN DATA*)")
     }
 }
 
@@ -565,7 +534,8 @@ impl fmt::Debug for PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecurePKey({})", self.to_hex())
+        // display only first 6 bytes.
+        write!(f, "{}", &self.to_hex()[0..12])
     }
 }
 
@@ -645,9 +615,10 @@ impl SecretSubKey {
     }
 }
 
-impl fmt::Display for SecretSubKey {
+impl fmt::Debug for SecretSubKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureSSubKey({})", self.to_hex())
+        // display only first 6 bytes.
+        write!(f, "SecretSubKey(*HIDDEN DATA*)")
     }
 }
 
@@ -694,7 +665,8 @@ impl PublicSubKey {
 
 impl fmt::Display for PublicSubKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecurePSubKey({})", self.to_hex())
+        // display only first 6 bytes.
+        write!(f, "{}", &self.to_hex()[0..12])
     }
 }
 
@@ -754,12 +726,6 @@ impl Signature {
 }
 
 impl fmt::Debug for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureSig({})", self.to_hex())
-    }
-}
-
-impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecureSig({})", self.to_hex())
     }
@@ -912,12 +878,6 @@ impl RVal {
     pub fn try_from_hex(s: &str) -> Result<Self, CryptoError> {
         let g = G2::try_from_hex(s)?;
         Ok(RVal(g))
-    }
-}
-
-impl fmt::Display for RVal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecureRVal({})", self.to_hex())
     }
 }
 

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -97,7 +97,7 @@ impl KeyChain {
             fs::write(skey_path, pem::encode(&skey_pem))?;
             fs::write(pkey_path, pem::encode(&pkey_pem))?;
 
-            debug!("Generated {}", pkey);
+            debug!("Generated {:?}", pkey);
             (skey, pkey)
         } else {
             debug!(

--- a/network/src/unicast_send/behavior.rs
+++ b/network/src/unicast_send/behavior.rs
@@ -254,13 +254,13 @@ where
                 }
                 UnicastBehaviorEvent::DataOrResult { peer_id, event } => match event {
                     UnicastSendMessage::Data(msg) => {
-                        debug!("Received data message from node: {}", msg.from);
+                        debug!("Received data message from node: {:?}", msg.from);
                         return Async::Ready(NetworkBehaviourAction::GenerateEvent(
                             UnicastOutEvent::Data(msg),
                         ));
                     }
                     UnicastSendMessage::Success(pkey) => {
-                        debug!("Successfully sent message to node: {}", pkey);
+                        debug!("Successfully sent message to node: {:?}", pkey);
                         return Async::Ready(NetworkBehaviourAction::GenerateEvent(
                             UnicastOutEvent::Success(pkey),
                         ));

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -377,7 +377,7 @@ impl NodeService {
 
             let last_hash = Hash::digest(self.chain.last_block());
             info!(
-                "Node successfully recovered from persistent storage: height={}, hash= {:?}",
+                "Node successfully recovered from persistent storage: height={}, hash={}",
                 self.chain.blocks().len(),
                 last_hash
             );
@@ -394,7 +394,7 @@ impl NodeService {
             match block {
                 Block::KeyBlock(key_block) => {
                     debug!(
-                        "Genesis key block: height={}, hash={}",
+                        "Genesis key block: height={}, hash={:?}",
                         self.chain.height() + 1,
                         Hash::digest(&key_block)
                     );
@@ -404,7 +404,7 @@ impl NodeService {
                 }
                 Block::MonetaryBlock(monetary_block) => {
                     debug!(
-                        "Genesis payment block: height={}, hash={}",
+                        "Genesis payment block: height={}, hash={:?}",
                         self.chain.height() + 1,
                         Hash::digest(&monetary_block)
                     );
@@ -545,7 +545,7 @@ impl NodeService {
         let previous_hash = Hash::digest(self.chain.last_block());
         if previous_hash != header.previous {
             debug!(
-                "Orphan sealed block: hash={}, epoch={}, expected_previous={}, got_previous={}",
+                "Orphan sealed block: hash={}, epoch={}, expected_previous={:?}, got_previous={:?}",
                 &block_hash, header.epoch, &previous_hash, &header.previous
             );
             return self.on_orphan_block(block);
@@ -657,7 +657,7 @@ impl NodeService {
 
         let base = BaseBlockHeader::new(VERSION, previous, epoch, timestamp);
         debug!(
-            "Creating a new epoch proposal: {}, with leader = {}",
+            "Creating a new epoch proposal: {}, with leader = {:?}",
             epoch,
             consensus.leader()
         );
@@ -726,7 +726,7 @@ impl NodeService {
     /// Request for changing group received from VRF system.
     /// Restars consensus with new params, and send new keyblock.
     fn on_change_group(&mut self, group: ConsensusGroup) -> Result<(), Error> {
-        info!("Changing group, new group leader = {:?}", group.leader);
+        info!("Changing group, new group leader = {}", group.leader);
         self.chain.change_group(
             group.leader,
             group.facilitator,
@@ -899,7 +899,7 @@ impl NodeService {
 
         let (block, proof) = consensus.get_proposal();
         let request_hash = Hash::digest(block);
-        debug!("Validating block: block={}", &request_hash);
+        debug!("Validating block: block={:?}", &request_hash);
         match Self::validate_block(consensus, &self.mempool, &self.chain, block, proof) {
             Ok(()) => {
                 let consensus = self.consensus.as_mut().unwrap();

--- a/node/src/loader.rs
+++ b/node/src/loader.rs
@@ -160,7 +160,7 @@ impl NodeService {
             .filter(|key| &self.keys.network_pkey != *key);
         let master = validators.choose(&mut rng).unwrap().clone();
         debug!(
-            "Selected a source node from the latest committed KeyBlock: hash={}, epoch={}, selected={}",
+            "Selected a source node from the latest committed KeyBlock: hash={:?}, epoch={}, selected={:?}",
             Hash::digest(self.chain.last_block()),
             self.chain.epoch,
             &master

--- a/node/src/tickets.rs
+++ b/node/src/tickets.rs
@@ -259,7 +259,7 @@ impl TicketsSystem {
 
     fn on_view_change(&mut self, last_block_hash: Hash) -> VRFTicket {
         info!(
-            "Trying to start new ticket collecting: height={}, block_hash={:?}",
+            "Trying to start new ticket collecting: height={}, block_hash={}",
             self.height, last_block_hash
         );
         self.view_change += 1;

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -154,7 +154,7 @@ pub(crate) fn validate_proposed_key_block(
             "Received Key block proposal with wrong consensus group."
         );
     }
-    debug!("Key block proposal is valid: block={}", block_hash);
+    debug!("Key block proposal is valid: block={:?}", block_hash);
     Ok(())
 }
 
@@ -227,7 +227,7 @@ pub(crate) fn validate_proposed_monetary_block(
     let mut outputs = Vec::<Output>::new();
     let mut outputs_hashes = BTreeSet::<Hash>::new();
     for tx_hash in tx_hashes {
-        debug!("Processing transaction: hash={}", &tx_hash);
+        debug!("Processing transaction: hash={:?}", &tx_hash);
 
         // Check that transaction is present in mempool.
         let tx = mempool.get_tx(&tx_hash);
@@ -322,7 +322,7 @@ pub(crate) fn validate_proposed_monetary_block(
         return Err(NodeError::InvalidBlockHash(block_hash, block_hash2).into());
     }
 
-    debug!("Block proposal is valid: block={}", block_hash);
+    debug!("Block proposal is valid: block={:?}", block_hash);
 
     Ok(())
 }

--- a/txpool/src/lib.rs
+++ b/txpool/src/lib.rs
@@ -156,7 +156,7 @@ impl TransactionPoolService {
             }
             NodeRole::Facilitator(ref mut state) => {
                 if state.add_participant(from) {
-                    info!("Added a new member: pkey={:?}", from);
+                    info!("Added a new member: pkey={}", from);
                 }
             }
         }

--- a/wallet/src/transaction.rs
+++ b/wallet/src/transaction.rs
@@ -52,7 +52,7 @@ pub(crate) fn create_payment_transaction(
     data.validate()?;
 
     debug!(
-        "Creating a payment transaction: recipient={}, amount={}",
+        "Creating a payment transaction: recipient={:?}, amount={}",
         recipient, amount
     );
 
@@ -72,7 +72,7 @@ pub(crate) fn create_payment_transaction(
     assert!(!inputs.is_empty());
 
     debug!(
-        "Transaction preview: recipient={}, amount={}, withdrawn={}, change={}, fee={}",
+        "Transaction preview: recipient={:?}, amount={}, withdrawn={}, change={}, fee={}",
         recipient,
         amount,
         amount + change + fee,
@@ -147,7 +147,7 @@ pub(crate) fn create_staking_transaction(
     }
 
     debug!(
-        "Creating a staking transaction: validator={}, amount={}",
+        "Creating a staking transaction: validator={:?}, amount={}",
         validator_pkey, amount
     );
 
@@ -167,7 +167,7 @@ pub(crate) fn create_staking_transaction(
     assert!(!inputs.is_empty());
 
     debug!(
-        "Transaction preview: recipient={}, validator={}, stake={}, withdrawn={}, change={}, fee={}",
+        "Transaction preview: recipient={:?}, validator={:?}, stake={}, withdrawn={}, change={}, fee={}",
         sender_pkey,
         validator_pkey,
         amount,
@@ -243,7 +243,7 @@ pub(crate) fn create_unstaking_transaction(
     }
 
     debug!(
-        "Creating a unstaking transaction: recipient={}, validator={}, amount={}",
+        "Creating a unstaking transaction: recipient={:?}, validator={:?}, amount={}",
         sender_pkey, validator_pkey, amount
     );
 
@@ -266,11 +266,11 @@ pub(crate) fn create_unstaking_transaction(
     }
 
     debug!(
-        "Transaction preview: recipient={}, validator={}, unstake={}, stake={}, fee={}",
+        "Transaction preview: recipient={:?}, validator={:?}, unstake={}, stake={}, fee={}",
         sender_pkey, validator_pkey, amount, change, fee
     );
     for input in &inputs {
-        debug!("Use stake UTXO: hash={}", Hash::digest(input));
+        debug!("Use stake UTXO: hash={:?}", Hash::digest(input));
     }
 
     //

--- a/wallet/src/valueshuffle/mod.rs
+++ b/wallet/src/valueshuffle/mod.rs
@@ -218,7 +218,7 @@ impl ValueShuffle {
         self.network
             .send(self.facilitator_pkey, POOL_JOIN_TOPIC, msg)?;
         info!(
-            "Sent pool join request facilitator={:?}",
+            "Sent pool join request facilitator={}",
             self.facilitator_pkey
         );
         Ok(())
@@ -289,7 +289,7 @@ impl ValueShuffle {
 
     /// Invoked when Example message is received.
     fn on_example_received(&mut self, from: ParticipantID, payload: String) -> Result<(), Error> {
-        info!("Example received: from={:?}, payload={}", from, payload);
+        info!("Example received: from={}, payload={}", from, payload);
         Ok(())
     }
 }


### PR DESCRIPTION
Remove redurant Display implementation.
Removed Display implementation for SecretKeys.

Modifyed all found logs, to use `Display` in `info!` and `Debug` in `debug!`


Closes: #566 