### PR TITLE
Refactor block validation code

### DIFF
--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -32,6 +32,11 @@ pub enum BlockchainError {
     BlockHashCollision(Hash),
     #[fail(display = "UXTO hash collision: {}.", _0)]
     OutputHashCollision(Hash),
+    #[fail(
+        display = "Invalid or out-of-order epoch: block={}, expected={}, got={}",
+        _0, _1, _2
+    )]
+    OutOfOrderBlockEpoch(Hash, u64, u64),
     #[fail(display = "Missing UXTO {}.", _0)]
     MissingUTXO(Hash),
     #[fail(display = "Invalid block monetary balance.")]
@@ -48,4 +53,8 @@ pub enum BlockchainError {
     MissingValidators,
     #[fail(display = "The leader must be validator.")]
     LeaderIsNotValidator,
+    #[fail(display = "KeyBlocks validators not equal to our stakers view.")]
+    ValidatorsNotEqualToOurStakers,
+    #[fail(display = "Invalid block BLS multisignature: block={}", _0)]
+    InvalidBlockSignature(Hash),
 }

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -80,7 +80,6 @@ pub fn genesis(keychains: &[KeyChain], stake: i64, coins: i64, timestamp: u64) -
         let gamma = -outputs_gamma;
         MonetaryBlock::new(base, gamma, coins, &[], &outputs)
     };
-    block1.validate(&[]).expect("genesis is valid");
 
     //
     // Create initial Key Block.

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -40,11 +40,6 @@ pub enum NodeError {
         _0, _1, _2
     )]
     OutOfOrderBlockHash(Hash, Hash, Hash),
-    #[fail(
-        display = "Invalid or out-of-order epoch: block={}, expected={}, got={}",
-        _0, _1, _2
-    )]
-    OutOfOrderBlockEpoch(Hash, u64, u64),
     #[fail(display = "Block is already registered: hash={}", _0)]
     BlockAlreadyRegistered(Hash),
     #[fail(display = "Failed to validate block: expected={}, got={}", _0, _1)]
@@ -56,8 +51,6 @@ pub enum NodeError {
     InvalidBlockReward(Hash, i64, i64),
     #[fail(display = "Invalid fee UTXO: hash={}", _0)]
     InvalidFeeUTXO(Hash),
-    #[fail(display = "Invalid block BLS multisignature: block={}", _0)]
-    InvalidBlockSignature(Hash),
     #[fail(display = "Transaction missing in mempool: {}.", _0)]
     TransactionMissingInMempool(Hash),
     #[fail(display = "Transaction already exists in mempool: {}.", _0)]
@@ -67,6 +60,4 @@ pub enum NodeError {
         _0, _1
     )]
     UnsynchronizedBlock(u64, u64),
-    #[fail(display = "KeyBlocks validators not equal to our stakers view.")]
-    ValidatorsNotEqualToOurStakers,
 }

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -342,8 +342,9 @@ mod test {
             let input_hash = Hash::digest(input);
             inputs.insert(input_hash, input.clone());
         }
+
         let inputs: Vec<Output> = inputs.values().cloned().collect();
-        block.validate(&inputs).expect("block is valid");
+        block.validate_balance(&inputs).expect("block is valid");
 
         // Fee.
         if let Some(Output::PaymentOutput(o)) = output_fee {


### PR DESCRIPTION
- Merge key_block.validate(), node.validate_sealed_key_block() and
  validation checks from chain.register_key_block() into one method.
- Merge monetary_block.validate(), node.validate_sealed_monetary_block() and
  validation checks from chain.register_monegtary_block() into one method.
- Remove double validation of monetary blocks.
- Remove validation of blocks during recovery.
- Add leader's signature into block's proposals.
- Validate that block's proposals always have leader's signature.
- Fix a bug that loaded blocks from the disk were written back to the disk.

This patch disables tests for block.validate() code. These tests
will be ported to the new codebase by #394.

Closes #537
Needed for #394
Needed for #539