### PR TITLE
Use `git describe` to generate application version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,6 @@ dependencies = [
  "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2981,16 +2980,6 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "vergen"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,7 +3406,6 @@ dependencies = [
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,8 @@ toml = "0.4"
 simple_logger = "1.0"
 
 [build-dependencies]
-vergen = "3.0.4"
+regex = "1.0"
+chrono = "0.4"
 
 [profile.release]
 debug = 2

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,59 @@
-extern crate vergen;
-
-use vergen::{generate_cargo_keys, ConstantsFlags};
+use chrono::Utc;
+use regex::Regex;
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
-    // Setup the flags, toggling off the 'SEMVER_FROM_CARGO_PKG' flag
-    let mut flags = ConstantsFlags::all();
-    flags.toggle(ConstantsFlags::SEMVER_FROM_CARGO_PKG);
+    // Run `git describe --long` and parse the output.
+    // v0.1-49-g895818f
+    let describe_re = Regex::new(
+        r"v(?P<major>[0-9]+)\.(?P<minor>[0-9]+)-(?P<patch>[0-9]+)-g(?P<commit>[0-9a-f]+)$",
+    )
+    .expect("regex is valid");
+    let describe = Command::new("git")
+        .args(&["describe", "--long"])
+        .output()
+        .expect("git describe works");
+    let describe = String::from_utf8_lossy(&describe.stdout).into_owned();
+    let describe = describe_re
+        .captures(describe.trim())
+        .expect("git describe is valid");
+    let major = describe.name("major").expect("major version").as_str();
+    let minor = describe.name("minor").expect("minor version").as_str();
+    let patch = describe.name("patch").expect("patch version").as_str();
+    let commit = describe.name("commit").expect("commit version").as_str();
+    println!("cargo:rustc-env=VERSION_MAJOR={}", major);
+    println!("cargo:rustc-env=VERSION_MINOR={}", minor);
+    println!("cargo:rustc-env=VERSION_PATCH={}", patch);
+    println!("cargo:rustc-env=VERSION_COMMIT={}", commit);
+    println!(
+        "cargo:rustc-env=VERSION_DATE={}",
+        Utc::now().format("%Y-%m-%d").to_string()
+    );
 
-    // Generate the 'cargo:' key output
-    generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate the cargo keys!");
+    // Stolen from `vergen`:
+    // https://github.com/rustyhorde/vergen/blob/master/src/output/envvar.rs
+    let git_dir = PathBuf::from(".git");
+    assert!(git_dir.is_dir(), ".git/ is directory");
+    // Echo the HEAD path
+    let git_head_path = git_dir.join("HEAD");
+    println!("cargo:rerun-if-changed={}", git_head_path.display());
+
+    // Determine where HEAD points and echo that path also.
+    let mut f = File::open(&git_head_path).expect(".git/HEAD is valid");
+    let mut git_head_contents = String::new();
+    let _ = f
+        .read_to_string(&mut git_head_contents)
+        .expect("can read .git/HEAD");
+    eprintln!("HEAD contents: {}", git_head_contents);
+    let ref_vec: Vec<&str> = git_head_contents.split(": ").collect();
+    if ref_vec.len() == 2 {
+        let current_head_file = ref_vec[1];
+        let git_refs_path = PathBuf::from(".git").join(current_head_file);
+        println!("cargo:rerun-if-changed={}", git_refs_path.display());
+    } else {
+        eprintln!("You are most likely in a detached HEAD state");
+    }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -376,10 +376,12 @@ impl ConsoleService {
             self.wallet.unstake(amount);
         } else if msg == "show version" {
             println!(
-                "Stegos {} ({} {})",
-                env!("VERGEN_SEMVER"),
-                env!("VERGEN_SHA_SHORT"),
-                env!("VERGEN_BUILD_DATE")
+                "Stegos {}.{}.{} ({} {})",
+                env!("VERSION_MAJOR"),
+                env!("VERSION_MINOR"),
+                env!("VERSION_PATCH"),
+                env!("VERSION_COMMIT"),
+                env!("VERSION_DATE")
             );
         } else if msg == "show keys" {
             self.wallet.keys_info();

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -212,10 +212,12 @@ fn report_metrics(_req: Request<Body>) -> Response<Body> {
 fn run() -> Result<(), Error> {
     let name = "Stegos";
     let version = format!(
-        "{} ({} {})",
-        env!("VERGEN_SEMVER"),
-        env!("VERGEN_SHA_SHORT"),
-        env!("VERGEN_BUILD_DATE")
+        "{}.{}.{} ({} {})",
+        env!("VERSION_MAJOR"),
+        env!("VERSION_MINOR"),
+        env!("VERSION_PATCH"),
+        env!("VERSION_COMMIT"),
+        env!("VERSION_DATE")
     );
 
     let args = App::new(name)


### PR DESCRIPTION
- Parse `git describe --long` output to generate version:

    v0.1-49-g895818f => major=0, minor=1, patch=49, commit=895818f

- Remove `vergen` crate.

Closes #571 

Example:

```
$ git describe --long
v0.1-50-g3dbe666
$ cargo run -- --version
    Finished dev [optimized + debuginfo] target(s) in 0.74s
     Running `target/debug/stegos --version`
Stegos 0.1.50 (3dbe666 2019-03-06)

$ touch test
$ git add test
$ git commit -m "test"
[rt-issue-571-vergen 87f429a] test
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 test

$ git describe --long
v0.1-51-g87f429a

$ cargo run -- --version
   Compiling stegos v0.1.0 (/home/roman/Stegos/Source/stegos)
    Finished dev [optimized + debuginfo] target(s) in 17.52s
     Running `target/debug/stegos --version`
Stegos 0.1.51 (87f429a 2019-03-06)
```
