### PR TITLE
Don't try process uniicast messages as broadcasts

### DIFF
--- a/network/src/libp2p_network/mod.rs
+++ b/network/src/libp2p_network/mod.rs
@@ -354,6 +354,7 @@ where
                     }
                     Err(e) => error!("Failure decoding unicast message: {}", e),
                 }
+                return;
             }
             for t in message.topics.into_iter() {
                 let topic = match self.topics_map.get(&t) {


### PR DESCRIPTION
Closes #587 

Removes log messages with Unknown topics from logs