### PR TITLE
Change default values for NetworkConfig

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -52,11 +52,11 @@ pub struct NetworkConfig {
 impl Default for NetworkConfig {
     fn default() -> NetworkConfig {
         NetworkConfig {
-            bind_port: 10055,
+            bind_port: 0,
             seed_pool: "".to_string(),
             seed_nodes: vec![],
             advertised_addresses: vec![],
-            advertise_local_ips: true,
+            advertise_local_ips: false,
             bind_ip: "0.0.0.0".to_string(),
             min_connections: 8,
             max_connections: 32,


### PR DESCRIPTION
- Use bind_port = 0 to allow multiple nodes on the same host.
- Disable advertise_local_ips by default.

Closes #438