### PR TITLE
Refactor stegos_blockchain

### DIFF
--- a/crypto/src/pbc/secure.rs
+++ b/crypto/src/pbc/secure.rs
@@ -496,6 +496,11 @@ impl Drop for SecretKey {
 pub struct PublicKey(G2);
 
 impl PublicKey {
+    /// A some dummy key for initialization.
+    pub fn dum() -> Self {
+        G2::zero().into()
+    }
+
     pub fn base_vector(&self) -> &[u8] {
         self.0.base_vector()
     }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -278,8 +278,9 @@ impl NodeService {
         genesis: Vec<Block>,
         network: Network,
     ) -> Result<(Self, Node), Error> {
+        let current_timestamp = Utc::now().timestamp() as u64;
         let (outbox, inbox) = unbounded();
-        let chain = Blockchain::new(&cfg, genesis);
+        let chain = Blockchain::new(&cfg, genesis, current_timestamp);
         let handler = Node {
             outbox,
             network: network.clone(),
@@ -295,7 +296,8 @@ impl NodeService {
         genesis: Vec<Block>,
         inbox: UnboundedReceiver<NodeMessage>,
     ) -> Result<Self, Error> {
-        let chain = Blockchain::testing(genesis);
+        let current_timestamp = Utc::now().timestamp() as u64;
+        let chain = Blockchain::testing(genesis, current_timestamp);
         Self::with_blockchain(chain, keys, network, inbox)
     }
 
@@ -402,7 +404,7 @@ impl NodeService {
 
         // Sync wallet.
         // TODO: this implementation can consume a lot of memory.
-        let unspent = self.chain.unspent();
+        let unspent: Vec<Hash> = self.chain.unspent().cloned().collect();
         let outputs = self
             .chain
             .outputs_by_hashes(&unspent)

--- a/node/src/test/simple_tests.rs
+++ b/node/src/test/simple_tests.rs
@@ -59,8 +59,7 @@ fn simulate_payment(node: &mut NodeService, amount: i64) -> Result<(), Error> {
         let output = node
             .chain
             .output_by_hash(&hash)
-            .expect("no disk errors")
-            .expect("utxo exists");
+            .expect("no errors and utxo exists");
         if let Output::PaymentOutput(ref o) = output {
             let PaymentPayload { amount, .. } = o.decrypt_payload(sender_skey).unwrap();
             inputs.push(output);
@@ -109,15 +108,18 @@ pub fn monetary_requests() {
     assert_eq!(node.chain.height(), block_count + 1);
     let mut amounts = Vec::new();
     for unspent in node.chain.unspent() {
-        match node.chain.output_by_hash(&unspent).expect("no disk errors") {
-            Some(Output::PaymentOutput(o)) => {
+        match node
+            .chain
+            .output_by_hash(&unspent)
+            .expect("exists and no disk errors ")
+        {
+            Output::PaymentOutput(o) => {
                 let PaymentPayload { amount, .. } = o.decrypt_payload(&keys.wallet_skey).unwrap();
                 amounts.push(amount);
             }
-            Some(Output::StakeOutput(o)) => {
+            Output::StakeOutput(o) => {
                 assert_eq!(o.amount, stake);
             }
-            _ => panic!(),
         }
     }
     amounts.sort();
@@ -135,15 +137,18 @@ pub fn monetary_requests() {
     assert_eq!(node.chain.height(), block_count + 1);
     let mut amounts = Vec::new();
     for unspent in node.chain.unspent() {
-        match node.chain.output_by_hash(&unspent).expect("no disk errors") {
-            Some(Output::PaymentOutput(o)) => {
+        match node
+            .chain
+            .output_by_hash(&unspent)
+            .expect("exists and no disk errors")
+        {
+            Output::PaymentOutput(o) => {
                 let PaymentPayload { amount, .. } = o.decrypt_payload(&keys.wallet_skey).unwrap();
                 amounts.push(amount);
             }
-            Some(Output::StakeOutput(o)) => {
+            Output::StakeOutput(o) => {
                 assert_eq!(o.amount, stake);
             }
-            _ => panic!(),
         }
     }
     amounts.sort();

--- a/txpool/src/lib.rs
+++ b/txpool/src/lib.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use stegos_blockchain::PaymentOutput;
 use stegos_crypto::curve1174;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::{self, G2};
+use stegos_crypto::pbc::secure;
 use stegos_keychain::KeyChain;
 use stegos_network::Network;
 use stegos_node::EpochNotification;
@@ -93,7 +93,7 @@ impl TransactionPoolService {
     /// Crates new TransactionPool.
     pub fn new(keychain: &KeyChain, network: Network, node: Node) -> TransactionPoolService {
         let pkey = keychain.network_pkey.clone();
-        let facilitator_pkey: ParticipantID = G2::generator().into(); // some fake key
+        let facilitator_pkey: ParticipantID = ParticipantID::dum();
 
         let events = || -> Result<_, Error> {
             let mut streams = Vec::<Box<Stream<Item = PoolEvent, Error = ()> + Send>>::new();

--- a/wallet/src/valueshuffle/mod.rs
+++ b/wallet/src/valueshuffle/mod.rs
@@ -107,7 +107,6 @@ use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::dicemix::*;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::hash::{Hashable, Hasher, HASH_SIZE};
-use stegos_crypto::pbc::secure;
 use stegos_network::Network;
 use stegos_node::Node;
 use stegos_serialization::traits::ProtoConvert;
@@ -342,7 +341,7 @@ impl ValueShuffle {
         //
         // State.
         //
-        let facilitator_pkey: ParticipantID = secure::G2::generator().into(); // some fake key
+        let facilitator_pkey: ParticipantID = ParticipantID::dum();
         let participants: Vec<ParticipantID> = Vec::new();
         let session_id: Hash = Hash::random();
         let state = State::Offline;


### PR DESCRIPTION
- Group fields.
- Unify output_by_hash()/outputs_by_hashes() API.
- Move timestamp creation to node.
- Update comments.
- Refactor recovery.
- Add secure::PublicKey::dum() constructor.
- Other minor fixes.

No semantic changes. This patch is pure refactoring.

See #629