### PR TITLE
Implement the rollback operation for monetary blocks

### DIFF
--- a/blockchain/src/metrics.rs
+++ b/blockchain/src/metrics.rs
@@ -33,8 +33,8 @@ lazy_static! {
     .unwrap();
     pub static ref EPOCH: IntCounter =
         register_int_counter!("stegos_blockchain_epoch", "Current blockchain epoch").unwrap();
-    pub static ref HEIGHT: IntCounter =
-        register_int_counter!("stegos_blockchain_height", "Blockchain blocks count").unwrap();
+    pub static ref HEIGHT: IntGauge =
+        register_int_gauge!("stegos_blockchain_height", "Blockchain blocks count").unwrap();
     pub static ref UTXO_LEN: IntGauge =
         register_int_gauge!("stegos_blockchain_utxo", "Size of UTXO map").unwrap();
 }

--- a/blockchain/src/storage.rs
+++ b/blockchain/src/storage.rs
@@ -84,6 +84,13 @@ impl ListDb {
         }
     }
 
+    /// Remove record by id.
+    pub fn remove(&self, height: u64) -> Result<(), Error> {
+        let key = Self::key_u64_to_bytes(height);
+        self.database.delete(&key)?;
+        Ok(())
+    }
+
     /// Create iterator that traverse fully block collection.
     pub fn iter(&self) -> impl Iterator<Item = Block> {
         let mode = IteratorMode::Start;


### PR DESCRIPTION
Add a new method to `struct Blockchain` called pop_monetary_block().
This method can be use to roll back all changes caused by previous
call of push_monetary_block(). Only monetary blocks can be reverted.
Every key block finalizes the state of blockchain database and cleans
the undo log for previous monetary blocks.

+ Add basic tests cases for persistency.

Closes #629