### PR TITLE
Add metrics for lost monetary blocks.

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -817,6 +817,7 @@ impl NodeService {
 
         if self.consensus.is_none() && elapsed >= Duration::from_secs(self.cfg.micro_block_timeout)
         {
+            metrics::FORCED_VIEW_CHANGES.inc();
             let leader = self.chain.leader();
             debug!("Timed out while waiting for monetary block, request block from last leader: leader={}", leader);
             self.request_history_from(leader)?;

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -30,6 +30,11 @@ lazy_static! {
         "The number of auto-commits of proposed block"
     )
     .unwrap();
+    pub static ref FORCED_VIEW_CHANGES: IntCounter = register_int_counter!(
+        "stegos_forced_view_changes",
+        "The number of forced view_changes, in case of dead leader."
+    )
+    .unwrap();
 }
 
 pub mod vrf {


### PR DESCRIPTION
Subj.

For now if no monetary block was received for specific timeout, metrics will increased.