### PR TITLE
Hashcash delay() and check_proof()

### DIFF
--- a/crypto/protos/crypto.proto
+++ b/crypto/protos/crypto.proto
@@ -80,3 +80,9 @@ message VRF {
     stegos.crypto.Hash rand = 1;
     stegos.crypto.G1 proof = 2;
 }
+
+message HashCashProof {
+    int64 nbits = 1;
+    bytes seed = 2;
+    int64 count = 3;
+}

--- a/crypto/src/hashcash/mod.rs
+++ b/crypto/src/hashcash/mod.rs
@@ -1,0 +1,133 @@
+//! Hashcash.
+
+//
+// Copyright (c) 2019 Stegos AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/// --------------------------------------------------------------------------
+/// Provide iterated hash puzzle to provide for median-predictable delays, sans parallelism.
+///
+/// Puzzle is, given some seed string, and an incrementing counter, perform the hash
+/// of the seend and counter until some specified number of bits in the resulting hash
+/// value are zero, in some specific location inside the hash value.
+///
+/// Since the location can be arbitrary, we settle for the leading bits in the
+/// hash byte stream.
+///
+/// Implied delay has a median proportional to 2^N for N-bits of zeros
+/// --------------------------------------------------------------------------
+use crate::hash::*;
+
+pub struct HashCashProof {
+    pub nbits: usize,
+    pub seed: Vec<u8>,
+    pub count: i64,
+}
+
+fn trial(seed: &Vec<u8>, ctr: i64) -> Hash {
+    let mut state = Hasher::new();
+    seed.hash(&mut state);
+    ctr.hash(&mut state);
+    state.result()
+}
+
+fn chkbits(h: &[u8], nbits: usize) -> bool {
+    for i in 0..nbits {
+        let byte = i / 8;
+        let bit = i % 8;
+        if 0 != (h[byte] & (1 << bit)) {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn delay(nbits: usize, seed: &Vec<u8>) -> HashCashProof {
+    // user should check:
+    //   1. does proof indicate intended number of bits?
+    //   2. does H(seed | ctr) have the requisite number of zero bits?
+    let mut ctr = 0;
+    loop {
+        let h = trial(seed, ctr);
+        if chkbits(h.base_vector(), nbits) {
+            return HashCashProof {
+                nbits: nbits,
+                seed: seed.clone(),
+                count: ctr,
+            };
+        }
+        ctr += 1;
+    }
+}
+
+pub fn check_proof(proof: &HashCashProof, nbits: usize) -> bool {
+    // Proof is provided by challenged node
+    // nbits is our expected puzzle size
+    // verify that proof is for nbits, and that
+    // H(seed | ctr) has nbits of leading zero bits
+    if nbits != proof.nbits {
+        return false;
+    }
+    let h = trial(&proof.seed, proof.count);
+    chkbits(&h.base_vector(), proof.nbits)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use rand::rngs::ThreadRng;
+    use rand::thread_rng;
+    use rand::Rng;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    #[ignore]
+    fn test_delay() {
+        let nbmax = 20;
+        let mut tbl = Vec::<(usize, Duration)>::new();
+        for nb in 1..=nbmax {
+            let mut ans = Vec::<Duration>::new();
+            let mut rng: ThreadRng = thread_rng();
+            for _ in 0..3 {
+                let seed = rng.gen::<[u8; 32]>();
+                let start = SystemTime::now();
+                delay(nb, &seed.to_vec());
+                let timing = start.elapsed().expect("timing");
+                ans.push(timing);
+            }
+            ans.sort();
+            tbl.push((nb, ans[1]));
+            println!("Delay for {} bits: {:?}", nb, ans[1]);
+        }
+        dbg!(&tbl);
+    }
+
+    #[test]
+    fn test_delay_check() {
+        let mut rng: ThreadRng = thread_rng();
+        let nb = 10;
+        for _ in 0..100 {
+            let seed = rng.gen::<[u8; 32]>();
+            let proof = delay(nb, &seed.to_vec());
+            assert!(false == check_proof(&proof, nb + 1));
+            assert!(true == check_proof(&proof, nb));
+        }
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bulletproofs;
 pub mod curve1174;
 pub mod dicemix;
 pub mod hash;
+pub mod hashcash;
 pub mod keying;
 pub mod pbc;
 pub mod protos;

--- a/crypto/src/protos.rs
+++ b/crypto/src/protos.rs
@@ -27,6 +27,7 @@ use crate::curve1174::cpt::Pt;
 use crate::curve1174::cpt::{EncryptedPayload, PublicKey, SchnorrSig, SecretKey};
 use crate::curve1174::fields::Fr;
 use crate::hash::Hash;
+use crate::hashcash::HashCashProof;
 use crate::pbc::secure;
 use crate::pbc::secure::G1;
 use crate::pbc::secure::G2;
@@ -135,6 +136,23 @@ impl ProtoConvert for SchnorrSig {
         let k: Pt = Pt::from_proto(proto.get_K())?;
         let u: Fr = Fr::from_proto(proto.get_u())?;
         Ok(SchnorrSig { K: k, u })
+    }
+}
+
+impl ProtoConvert for HashCashProof {
+    type Proto = crypto::HashCashProof;
+    fn into_proto(&self) -> Self::Proto {
+        let mut proto = crypto::HashCashProof::new();
+        proto.set_nbits(self.nbits as i64);
+        proto.set_seed(self.seed.clone());
+        proto.set_count(self.count);
+        proto
+    }
+    fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
+        let nbits: usize = proto.get_nbits() as usize;
+        let seed: Vec<u8> = proto.get_seed().to_vec();
+        let count: i64 = proto.get_count();
+        Ok(HashCashProof { nbits, seed, count })
     }
 }
 


### PR DESCRIPTION
Hashcash implements a (more or less) tunable delay function by having provers find an index that, together with some seed value, produce a hash value with an indicated number of prefix bits of zero.

hashcash::delay(nbits: usize, seed: &Vec<u8>) -> Proof
hashcash::check_proof(proof: &Proof, nbits: usize) -> bool

struct Proof {
   nbits: usize,
   seed: Vec<u8>,
  count: i64,
}