### PR TITLE
Add block_lag and block_idle metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,6 @@ version = "0.2.0"
 dependencies = [
  "bitvector 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2288,7 +2287,6 @@ dependencies = [
  "stegos_keychain 0.2.0",
  "stegos_serialization 0.2.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2296,7 +2294,6 @@ name = "stegos_consensus"
 version = "0.2.0"
 dependencies = [
  "bitvector 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2387,7 +2384,6 @@ version = "0.2.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvector 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2443,7 +2439,6 @@ dependencies = [
 name = "stegos_wallet"
 version = "0.2.0"
 dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-stream-select-all-send 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ stegos_serialization = { version = "0.2.0", path = "./serialization" }
 stegos_txpool = { version = "0.2.0", path = "./txpool" }
 stegos_wallet = { version = "0.2.0", path = "./wallet" }
 atty = "0.2"
-chrono = "0.4"
 clap = "2.32"
 dirs = "1.0"
 failure = "0.1"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -18,7 +18,6 @@ stegos_keychain = { version = "0.2.0", path = "../keychain" }
 stegos_serialization = { version = "0.2.0", path = "../serialization" }
 bitvector = "0.1"
 byteorder = "1.3"
-chrono = "0.4"
 failure = "0.1"
 lazy_static = "1.2"
 log = "0.4"
@@ -29,7 +28,6 @@ rocksdb = "0.11"
 serde = "1.0"
 serde_derive = "1.0"
 tempdir = "0.3"
-tokio-timer = "0.2"
 
 [dev-dependencies]
 simple_logger = "1.0"

--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -27,6 +27,7 @@ use crate::output::*;
 use crate::view_changes::ViewChangeProof;
 use bitvector::BitVector;
 use failure::Error;
+use std::time::SystemTime;
 use stegos_crypto::bulletproofs::{fee_a, validate_range_proof};
 use stegos_crypto::curve1174::cpt::Pt;
 use stegos_crypto::curve1174::ecpt::ECp;
@@ -57,7 +58,7 @@ pub struct BaseBlockHeader {
     pub view_change: u32,
 
     /// Timestamp at which the block was built.
-    pub timestamp: u64,
+    pub timestamp: SystemTime,
 }
 
 impl BaseBlockHeader {
@@ -66,7 +67,7 @@ impl BaseBlockHeader {
         previous: Hash,
         height: u64,
         view_change: u32,
-        timestamp: u64,
+        timestamp: SystemTime,
     ) -> Self {
         BaseBlockHeader {
             version,
@@ -394,7 +395,7 @@ impl Hashable for Block {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use chrono::Utc;
+    use std::time::SystemTime;
     use stegos_crypto::curve1174::cpt::make_random_keys;
     use stegos_crypto::pbc::secure::make_random_keys as make_secure_random_keys;
 
@@ -406,7 +407,7 @@ pub mod tests {
 
         let version: u64 = 1;
         let height: u64 = 0;
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let view_change = 0;
         let amount: i64 = 1_000_000;
         let previous = Hash::digest("test");
@@ -453,7 +454,7 @@ pub mod tests {
 
         let version: u64 = 1;
         let height: u64 = 0;
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let view_change = 0;
         let amount: i64 = 1_000_000;
         let previous = Hash::digest(&"test".to_string());
@@ -491,7 +492,7 @@ pub mod tests {
 
         let version: u64 = 1;
         let height: u64 = 0;
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let view_change = 0;
         let amount: i64 = 1_000_000;
         let previous = Hash::digest(&"test".to_string());
@@ -622,7 +623,7 @@ pub mod tests {
 
         let version: u64 = 1;
         let height: u64 = 0;
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let view_change = 0;
         let previous = Hash::digest(&"test".to_string());
 

--- a/blockchain/src/config.rs
+++ b/blockchain/src/config.rs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 use serde_derive::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// Blockchain configuration.
 #[derive(Debug, Clone)]
@@ -31,7 +32,7 @@ pub struct BlockchainConfig {
     /// Minimal stake amount.
     pub min_stake_amount: i64,
     /// Time to lock stakes.
-    pub bonding_time: u64,
+    pub bonding_time: Duration,
 }
 
 impl Default for BlockchainConfig {
@@ -39,7 +40,7 @@ impl Default for BlockchainConfig {
         BlockchainConfig {
             max_slot_count: 1000,
             min_stake_amount: 1000,
-            bonding_time: 900,
+            bonding_time: Duration::from_secs(15 * 600),
         }
     }
 }

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -25,12 +25,18 @@ use crate::block::*;
 use crate::multisignature::create_multi_signature;
 use crate::output::*;
 use std::collections::BTreeMap;
+use std::time::SystemTime;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::pbc::secure;
 use stegos_keychain::KeyChain;
 
 /// Genesis blocks.
-pub fn genesis(keychains: &[KeyChain], stake: i64, coins: i64, timestamp: u64) -> Vec<Block> {
+pub fn genesis(
+    keychains: &[KeyChain],
+    stake: i64,
+    coins: i64,
+    timestamp: SystemTime,
+) -> Vec<Block> {
     let mut blocks = Vec::with_capacity(2);
 
     // Both block are created at the same time in the same epoch.

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -23,6 +23,7 @@
 
 use failure::{Error, Fail};
 use std::mem::transmute;
+use std::time::SystemTime;
 use stegos_crypto::bulletproofs::{make_range_proof, BulletProof};
 use stegos_crypto::curve1174::cpt::{
     aes_decrypt, aes_encrypt, EncryptedPayload, Pt, PublicKey, SecretKey,
@@ -128,7 +129,7 @@ fn cloak_key(
     sender_skey: &SecretKey,
     recipient_pkey: &PublicKey,
     gamma: &Fr,
-    timestamp: u64,
+    timestamp: SystemTime,
 ) -> Result<(PublicKey, Fr), CryptoError> {
     // h is the digest of the recipients actual public key mixed with a timestamp.
     let mut hasher = Hasher::new();
@@ -386,7 +387,7 @@ impl StakePayload {
 impl PaymentOutput {
     /// Create a new PaymentOutput with generic payload.
     pub fn with_payload(
-        timestamp: u64,
+        timestamp: SystemTime,
         sender_skey: &SecretKey,
         recipient_pkey: &PublicKey,
         amount: i64,
@@ -418,7 +419,7 @@ impl PaymentOutput {
 
     /// Create a new PaymentOutput.
     pub fn new(
-        timestamp: u64,
+        timestamp: SystemTime,
         sender_skey: &SecretKey,
         recipient_pkey: &PublicKey,
         amount: i64,
@@ -468,7 +469,7 @@ impl PaymentOutput {
 impl StakeOutput {
     /// Create a new StakeOutput.
     pub fn new(
-        timestamp: u64,
+        timestamp: SystemTime,
         sender_skey: &SecretKey,
         recipient_pkey: &PublicKey,
         validator_pkey: &secure::PublicKey,
@@ -527,7 +528,7 @@ impl StakeOutput {
 impl Output {
     /// Create a new payment UTXO.
     pub fn new_payment(
-        timestamp: u64,
+        timestamp: SystemTime,
         sender_skey: &SecretKey,
         recipient_pkey: &PublicKey,
         amount: i64,
@@ -538,7 +539,7 @@ impl Output {
 
     /// Create a new escrow transaction.
     pub fn new_stake(
-        timestamp: u64,
+        timestamp: SystemTime,
         sender_skey: &SecretKey,
         recipient_pkey: &PublicKey,
         validator_pkey: &secure::PublicKey,
@@ -596,9 +597,9 @@ impl Hashable for Box<Output> {
 pub mod tests {
     use super::*;
 
-    use chrono::Utc;
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
+    use std::time::SystemTime;
     use stegos_crypto::curve1174::cpt::make_random_keys;
 
     fn random_string(len: usize) -> String {
@@ -818,7 +819,7 @@ pub mod tests {
         let (skey1, _pkey1, _sig1) = make_random_keys();
         let (skey2, pkey2, _sig2) = make_random_keys();
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let amount: i64 = 100500;
 
         let (output, gamma) =
@@ -850,7 +851,7 @@ pub mod tests {
         let (skey2, pkey2, _sig2) = make_random_keys();
         let (secure_skey1, secure_pkey1, _secure_sig1) = secure::make_random_keys();
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let amount: i64 = 100500;
 
         let output = StakeOutput::new(

--- a/blockchain/src/storage.rs
+++ b/blockchain/src/storage.rs
@@ -119,6 +119,7 @@ impl ListDb {
 mod test {
     use super::*;
     use crate::block::{BaseBlockHeader, KeyBlock};
+    use std::time::SystemTime;
     use stegos_crypto::hash::Hash;
     use stegos_crypto::pbc::secure;
 
@@ -126,9 +127,9 @@ mod test {
         let (skey0, _pkey0, _sig0) = secure::make_random_keys();
         let version: u64 = 1;
         let epoch: u64 = 1;
-        let timestamp = 0;
+        let timestamp = SystemTime::now();
 
-        let base = BaseBlockHeader::new(version, previous, epoch, timestamp, 0);
+        let base = BaseBlockHeader::new(version, previous, epoch, 0, timestamp);
 
         let random = secure::make_VRF(&skey0, &Hash::digest("random"));
 

--- a/blockchain/src/transaction.rs
+++ b/blockchain/src/transaction.rs
@@ -22,10 +22,10 @@
 // SOFTWARE.
 
 use crate::output::*;
-use chrono::Utc;
 use failure::Error;
 use failure::Fail;
 use std::collections::HashSet;
+use std::time::SystemTime;
 use stegos_crypto::bulletproofs::{fee_a, simple_commit, validate_range_proof};
 use stegos_crypto::curve1174::cpt::{
     sign_hash, sign_hash_with_kval, validate_sig, Pt, PublicKey, SchnorrSig, SecretKey,
@@ -398,7 +398,7 @@ impl Transaction {
         let mut inputs: Vec<Output> = Vec::with_capacity(input_count);
         let mut outputs: Vec<Output> = Vec::with_capacity(output_count);
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
 
         for _ in 0..input_count {
             let (input, _gamma) =
@@ -434,7 +434,7 @@ pub mod tests {
     #[test]
     pub fn no_inputs() {
         let (skey, pkey, _sig) = make_random_keys();
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
         let fee: i64 = amount;
         let (input, _gamma1) =
@@ -467,7 +467,7 @@ pub mod tests {
         let (skey1, pkey1, _sig1) = make_random_keys();
         let (_skey2, pkey2, _sig2) = make_random_keys();
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
         let fee: i64 = 1;
 
@@ -640,7 +640,7 @@ pub mod tests {
         let (skey1, pkey1, _sig1) = make_random_keys();
         let (secure_skey1, secure_pkey1, _secure_sig1) = secure::make_random_keys();
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
         let fee: i64 = 1;
 
@@ -775,7 +775,7 @@ pub mod tests {
         let (skey1, pkey1, _) = make_random_keys();
         let (skey2, pkey2, _) = make_random_keys();
         let (skey3, pkey3, _) = make_random_keys();
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let err_utxo = "Can't construct UTXO";
         let iamt1 = 101;
         let iamt2 = 102;

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -25,7 +25,6 @@ prometheus = "0.5"
 
 [dev-dependencies]
 stegos_keychain = { version = "0.2.0", path = "../keychain" }
-chrono = "0.4"
 rand = "0.6"
 simple_logger = "1.0"
 

--- a/consensus/src/protos.rs
+++ b/consensus/src/protos.rs
@@ -136,7 +136,7 @@ impl ProtoConvert for ViewChangeMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
+    use std::time::SystemTime;
     use stegos_crypto::hash::Hashable;
     use stegos_crypto::pbc::secure::make_random_keys as make_secure_random_keys;
 
@@ -184,7 +184,7 @@ mod tests {
 
         let version: u64 = 1;
         let height: u64 = 0;
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let previous = Hash::digest(&"test".to_string());
 
         let base = BaseBlockHeader::new(version, previous, height, 0, timestamp);

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -31,6 +31,7 @@ use std::fmt;
 use std::hash as stdhash;
 use std::mem;
 use std::slice;
+use std::time::SystemTime;
 
 // -----------------------------------------------------
 // Hashing with SHA3
@@ -278,6 +279,16 @@ impl Hashable for str {
 impl Hashable for String {
     fn hash(&self, state: &mut Hasher) {
         state.input(self.as_bytes());
+    }
+}
+
+impl Hashable for SystemTime {
+    fn hash(&self, state: &mut Hasher) {
+        let since_the_epoch = self
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time is valid");
+        let timestamp = since_the_epoch.as_secs() * 1000 + since_the_epoch.subsec_millis() as u64;
+        timestamp.hash(state);
     }
 }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,7 +20,6 @@ stegos_keychain = { version = "0.2.0", path = "../keychain" }
 stegos_network = { version = "0.4.0", path = "../network" }
 stegos_serialization = { version = "0.2.0", path = "../serialization" }
 bitvector = "0.1"
-chrono = "0.4"
 clap = "2.32"
 failure = "0.1"
 futures = "0.1"

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -24,6 +24,7 @@
 // SOFTWARE.
 
 use failure::Fail;
+use std::time::SystemTime;
 use stegos_crypto::hash::Hash;
 
 #[derive(Debug, Fail, PartialEq, Eq)]
@@ -42,8 +43,8 @@ pub enum NodeError {
     #[fail(display = "Expected a monetary block, got key block: height={}.", _0)]
     ExpectedMonetaryBlock(u64),
     #[fail(
-        display = "Found a block proposal with timestamp: {} that differ with our timestamp: {}.",
+        display = "Found a block proposal with timestamp: {:?} that differ with our timestamp: {:?}.",
         _0, _1
     )]
-    UnsynchronizedBlock(u64, u64),
+    UnsynchronizedBlock(SystemTime, SystemTime),
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -38,7 +38,6 @@ use crate::loader::{ChainLoader, ChainLoaderMessage};
 use crate::mempool::Mempool;
 use crate::validation::*;
 use bitvector::BitVector;
-use chrono::Utc;
 use failure::Error;
 use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::{Async, Future, Poll, Stream};
@@ -46,6 +45,7 @@ use futures_stream_select_all_send::select_all;
 use log::*;
 use protobuf;
 use protobuf::Message;
+use std::time::SystemTime;
 use std::time::{Duration, Instant};
 use stegos_blockchain::view_changes::ViewChangeProof;
 use stegos_blockchain::*;
@@ -198,8 +198,9 @@ pub enum NodeMessage {
     //
     Init,
     NetworkReady,
-    ConsensusTimer(Instant),
-    ViewChangeTimer(Instant),
+    MicroBlockProposeTimer(Instant),
+    MicroBlockViewChangeTimer(Instant),
+    KeyBlockViewChangeTimer(Instant),
 }
 
 pub struct NodeService {
@@ -227,6 +228,9 @@ pub struct NodeService {
 
     /// Optimistic consensus part, that collect ViewChange messages.
     optimistic: ViewChangeCollector,
+
+    /// Monotonic clock when the latest block was registered.
+    last_block_clock: Instant,
 
     //
     // Communication with environment.
@@ -257,9 +261,9 @@ impl NodeService {
             min_stake_amount: cfg.min_stake_amount,
             bonding_time: cfg.bonding_time,
         };
-        let current_timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let (outbox, inbox) = unbounded();
-        let chain = Blockchain::new(blockchain_cfg, storage_cfg, genesis, current_timestamp);
+        let chain = Blockchain::new(blockchain_cfg, storage_cfg, genesis, timestamp);
         let handler = Node {
             outbox,
             network: network.clone(),
@@ -280,8 +284,8 @@ impl NodeService {
             min_stake_amount: cfg.min_stake_amount,
             bonding_time: cfg.bonding_time,
         };
-        let current_timestamp = Utc::now().timestamp() as u64;
-        let chain = Blockchain::testing(blockchain_cfg, genesis, current_timestamp);
+        let timestamp = SystemTime::now();
+        let chain = Blockchain::testing(blockchain_cfg, genesis, timestamp);
         Self::with_blockchain(cfg, chain, keys, network, inbox)
     }
 
@@ -299,6 +303,7 @@ impl NodeService {
         let consensus = None;
         let optimistic =
             ViewChangeCollector::new(&chain, keys.network_pkey, keys.network_skey.clone());
+        let last_block_clock = clock::now();
 
         let on_epoch_changed = Vec::<UnboundedSender<EpochNotification>>::new();
         let on_outputs_received = Vec::<UnboundedSender<OutputsNotification>>::new();
@@ -337,17 +342,21 @@ impl NodeService {
             .map(NodeMessage::ChainLoaderMessage);
         streams.push(Box::new(requests_rx));
 
-        // Consensus timer events
-        let duration = Duration::from_secs(1); // every second
-        let timer = Interval::new_interval(duration)
-            .map(|i| NodeMessage::ConsensusTimer(i))
+        // Timer for the micro block proposals.
+        let timer = Interval::new_interval(cfg.tx_wait_timeout)
+            .map(|i| NodeMessage::MicroBlockProposeTimer(i))
             .map_err(|_e| ()); // ignore transient timer errors
         streams.push(Box::new(timer));
 
-        // ViewChange timer events
-        let duration = Duration::from_secs(cfg.micro_block_timeout); // every message_timeout
-        let timer = Interval::new_interval(duration)
-            .map(|i| NodeMessage::ViewChangeTimer(i))
+        // Timer for the micro block view changes.
+        let timer = Interval::new_interval(cfg.micro_block_timeout)
+            .map(|i| NodeMessage::MicroBlockViewChangeTimer(i))
+            .map_err(|_e| ()); // ignore transient timer errors
+        streams.push(Box::new(timer));
+
+        // Timer for the key block view changes.
+        let timer = Interval::new_interval(cfg.key_block_timeout)
+            .map(|i| NodeMessage::KeyBlockViewChangeTimer(i))
             .map_err(|_e| ()); // ignore transient timer errors
         streams.push(Box::new(timer));
 
@@ -362,6 +371,7 @@ impl NodeService {
             mempool,
             consensus,
             optimistic,
+            last_block_clock,
             network,
             on_epoch_changed,
             on_outputs_changed: on_outputs_received,
@@ -444,12 +454,12 @@ impl NodeService {
         );
 
         // Validate transaction.
-        let current_timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         validate_transaction(
             &tx,
             &self.mempool,
             &self.chain,
-            current_timestamp,
+            timestamp,
             self.cfg.payment_fee,
             self.cfg.stake_fee,
         )?;
@@ -530,7 +540,7 @@ impl NodeService {
 
                 assert!(self.consensus.is_none(), "consensus is for key blocks only");
 
-                let current_timestamp = Utc::now().timestamp() as u64;
+                let timestamp = SystemTime::now();
 
                 // Check monetary adjustment.
                 if self.chain.epoch() > 0
@@ -545,9 +555,8 @@ impl NodeService {
                     .into());
                 }
 
-                let (inputs, outputs) = self
-                    .chain
-                    .push_monetary_block(monetary_block, current_timestamp)?;
+                let (inputs, outputs) =
+                    self.chain.push_monetary_block(monetary_block, timestamp)?;
 
                 // Remove old transactions from the mempool.
                 let input_hashes: Vec<Hash> = inputs.iter().map(|o| Hash::digest(o)).collect();
@@ -566,6 +575,8 @@ impl NodeService {
                 self.optimistic.on_new_payment_block(&self.chain)
             }
         }
+
+        self.last_block_clock = clock::now();
 
         Ok(())
     }
@@ -617,7 +628,7 @@ impl NodeService {
     fn create_new_epoch(&mut self, random: VRF) -> Result<(), Error> {
         let consensus = self.consensus.as_mut().unwrap();
         let previous = self.chain.last_block_hash();
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let view_change = self.chain.view_change();
         let height = self.chain.height();
         let epoch = self.chain.epoch() + 1;
@@ -786,26 +797,29 @@ impl NodeService {
         self.chain.leader() == self.keys.network_pkey
     }
 
-    ///
-    /// Called periodically every CONSENSUS_TIMER seconds.
-    ///
-    fn handle_consensus_timer(&mut self) -> Result<(), Error> {
-        let now = clock::now();
-        let elapsed: Duration = now.duration_since(self.chain.last_block_timestamp());
+    /// Сhecks if it's time to create a micro block.
+    fn handle_micro_block_propose_timer(&mut self) -> Result<(), Error> {
+        let elapsed: Duration = clock::now().duration_since(self.last_block_clock);
 
         // Check that a new payment block should be created.
-        if self.consensus.is_none()
-            && elapsed >= Duration::from_secs(self.cfg.tx_wait_timeout)
-            && self.is_leader()
-            && self.chain.blocks_in_epoch() < self.cfg.blocks_in_epoch
-        {
+        if self.consensus.is_none() && elapsed >= self.cfg.tx_wait_timeout && self.is_leader() {
+            assert!(self.chain.blocks_in_epoch() < self.cfg.blocks_in_epoch);
             self.create_monetary_block(None)?;
         }
+
+        Ok(())
+    }
+
+    /// Checks if it's time to perform a view change on a micro block.
+    fn handle_key_block_viewchange_timer(&mut self) -> Result<(), Error> {
+        let elapsed: Duration = clock::now().duration_since(self.last_block_clock);
+
+        // TODO: implement view changes for key blocks.
 
         // Check that a block has been committed but haven't send by the leader.
         if self.consensus.is_some()
             && self.consensus.as_ref().unwrap().should_commit()
-            && elapsed >= Duration::from_secs(self.cfg.block_timeout)
+            && elapsed >= self.cfg.key_block_timeout
         {
             assert!(
                 !self.consensus.as_ref().unwrap().is_leader(),
@@ -831,6 +845,7 @@ impl NodeService {
 
         Ok(())
     }
+
     //
     // Optimisitc consensus
     //
@@ -853,14 +868,12 @@ impl NodeService {
         }
         Ok(())
     }
-    /// Request block history from leader, if no block was received
-    /// retry each message_timeout.
-    fn handle_view_change_timer(&mut self) -> Result<(), Error> {
-        let elapsed: Duration = clock::now().duration_since(self.chain.last_block_timestamp());
 
-        // TODO: Increment timeout for future view_changes.
-        if self.consensus.is_none() && elapsed >= Duration::from_secs(self.cfg.micro_block_timeout)
-        {
+    /// Checks if it's time to perform a view change on a monetary block.
+    fn handle_micro_block_viewchange_timer(&mut self) -> Result<(), Error> {
+        let elapsed: Duration = clock::now().duration_since(self.last_block_clock);
+
+        if self.consensus.is_none() && elapsed >= self.cfg.micro_block_timeout {
             metrics::FORCED_VIEW_CHANGES.inc();
             // No block was received, request leader directly, and start collecting view_changes.
             let leader = self.chain.leader();
@@ -875,6 +888,7 @@ impl NodeService {
         }
         Ok(())
     }
+
     ///
     /// Create a new monetary block.
     ///
@@ -1001,8 +1015,15 @@ impl Future for NodeService {
                             ChainLoaderMessage::from_buffer(&msg.data)
                                 .and_then(|data| self.handle_chain_loader_message(msg.from, data))
                         }
-                        NodeMessage::ConsensusTimer(_now) => self.handle_consensus_timer(),
-                        NodeMessage::ViewChangeTimer(_now) => self.handle_view_change_timer(),
+                        NodeMessage::MicroBlockProposeTimer(_now) => {
+                            self.handle_micro_block_propose_timer()
+                        }
+                        NodeMessage::MicroBlockViewChangeTimer(_now) => {
+                            self.handle_micro_block_viewchange_timer()
+                        }
+                        NodeMessage::KeyBlockViewChangeTimer(_now) => {
+                            self.handle_key_block_viewchange_timer()
+                        }
                     };
                     if let Err(e) = result {
                         error!("Error: {}", e);

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -21,11 +21,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use chrono::Utc;
 use linked_hash_map::LinkedHashMap;
 use log::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::time::SystemTime;
 use stegos_blockchain::view_changes::ViewChangeProof;
 use stegos_blockchain::*;
 use stegos_crypto::curve1174::cpt::PublicKey;
@@ -161,7 +161,7 @@ impl Mempool {
             self.pool.len()
         );
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let mut gamma = Fr::zero();
         let mut fee = 0i64;
         let mut inputs: Vec<Hash> = Vec::new();

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -21,6 +21,15 @@
 
 use lazy_static::lazy_static;
 use prometheus::*;
+use std::time::SystemTime;
+
+/// Convert SystemTime to unix timestamp in millisecond precision.
+pub fn time_to_timestamp_ms(time: SystemTime) -> i64 {
+    let since_the_epoch = time
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("timestamp is valid");
+    (since_the_epoch.as_secs() * 1000) as i64 + (since_the_epoch.subsec_millis() as i64)
+}
 
 lazy_static! {
     pub static ref MEMPOOL_LEN: IntGauge =
@@ -35,6 +44,15 @@ lazy_static! {
         "The number of forced view_changes, in case of dead leader."
     )
     .unwrap();
+
+    pub static ref BLOCK_REMOTE_TIMESTAMP: IntGauge =
+        register_int_gauge!("stegos_block_remote_timestamp_ms", "The local time at a remote leader when the last block began to be created, i.e it equals to the value of block.header.timestamp.").unwrap();
+    pub static ref BLOCK_LOCAL_TIMESTAMP: IntGauge =
+        register_int_gauge!("stegos_block_local_timestamp_ms", "The local time at this node when the last block was registered.").unwrap();
+    pub static ref BLOCK_LAG: IntGauge =
+        register_int_gauge!("stegos_block_lag_ms", "The last block creation + validation + propagation time, i.e. it is the time difference between the local time at a remote leader when the last block began to be created and the local time at this node when this block was registered.").unwrap();
+    pub static ref BLOCK_IDLE: IntGauge =
+        register_int_gauge!("stegos_block_idle_ms", "The elapsed time since the last block, i.e. it is the time difference between the local time at this node and the time when the last block was registered.").unwrap();
 }
 
 pub mod vrf {

--- a/node/src/test/consensus.rs
+++ b/node/src/test/consensus.rs
@@ -51,7 +51,7 @@ fn basic() {
         // Process N monetary blocks.
         let mut height = s.nodes[0].node_service.chain.height();
         for _ in 1..cfg.blocks_in_epoch {
-            wait(timer, Duration::from_secs(cfg.tx_wait_timeout));
+            wait(timer, cfg.tx_wait_timeout);
             s.poll();
             let block: Block = s.nodes[leader_id]
                 .network_service
@@ -177,7 +177,7 @@ fn basic() {
         );
 
         // Wait for TX_WAIT_TIMEOUT.
-        wait(timer, Duration::from_secs(cfg.block_timeout));
+        wait(timer, cfg.key_block_timeout);
         s.nodes[NUM_NODES - 1].poll();
 
         // Check that the last node has auto-committed the block.
@@ -224,10 +224,10 @@ fn request_on_timeout() {
             .unwrap();
 
         // let leader shot his block
-        wait(timer, Duration::from_secs(cfg.tx_wait_timeout));
+        wait(timer, cfg.tx_wait_timeout);
         s.poll();
         // emulate timeout on other nodes, and wait for request
-        wait(timer, Duration::from_secs(cfg.micro_block_timeout));
+        wait(timer, cfg.micro_block_timeout);
         info!("BEFORE POLL");
         s.poll();
         for (_, node) in s
@@ -266,10 +266,10 @@ fn micro_block_view_change() {
         }
         let leader_pk = s.nodes[0].node_service.chain.leader();
         // let leader shot his block
-        wait(timer, Duration::from_secs(cfg.tx_wait_timeout));
+        wait(timer, cfg.tx_wait_timeout);
         s.poll();
         // emulate timeout on other nodes, and wait for request
-        wait(timer, Duration::from_secs(cfg.micro_block_timeout));
+        wait(timer, cfg.micro_block_timeout);
         info!("PARTITION BEGIN");
         s.poll();
         // emulate dead leader for other nodes
@@ -355,14 +355,14 @@ fn micro_block_from_future_with_proof() {
             {
                 break;
             }
-            wait(timer, Duration::from_secs(cfg.tx_wait_timeout));
+            wait(timer, cfg.tx_wait_timeout);
             s.skip_monetary_block();
             starting_view_changes += 1;
         }
 
-        wait(timer, Duration::from_secs(cfg.tx_wait_timeout));
+        wait(timer, cfg.tx_wait_timeout);
         s.poll();
-        wait(timer, Duration::from_secs(cfg.micro_block_timeout));
+        wait(timer, cfg.micro_block_timeout);
         info!("======= PARTITION BEGIN =======");
         s.poll();
         // emulate dead leader for other nodes

--- a/node/src/test/mod.rs
+++ b/node/src/test/mod.rs
@@ -38,8 +38,9 @@ pub struct Sandbox {
 
 impl Sandbox {
     fn new(cfg: ChainConfig, num_nodes: usize) -> Self {
+        let timestamp = SystemTime::now();
         let nodes_keychains: Vec<_> = (0..num_nodes).map(|_num| KeyChain::new_mem()).collect();
-        let genesis = stegos_blockchain::genesis(&nodes_keychains, 1000, 1000000, 0);
+        let genesis = stegos_blockchain::genesis(&nodes_keychains, 1000, 1000000, timestamp);
 
         let nodes: Vec<NodeSandbox> = (0..num_nodes)
             .map(|i| NodeSandbox::new(cfg.clone(), nodes_keychains[i].clone(), genesis.clone()))

--- a/node/src/test/simple_tests.rs
+++ b/node/src/test/simple_tests.rs
@@ -21,7 +21,7 @@
 
 use super::Loopback;
 use crate::*;
-use chrono::Utc;
+use std::time::SystemTime;
 use stegos_blockchain::*;
 
 #[test]
@@ -31,8 +31,8 @@ pub fn init() {
     let (_outbox, inbox) = unbounded();
     let (_loopback, network) = Loopback::new();
 
-    let current_timestamp = Utc::now().timestamp() as u64;
-    let genesis = genesis(&[keys.clone()], 1000, 3_000_000, current_timestamp);
+    let timestamp = SystemTime::now();
+    let genesis = genesis(&[keys.clone()], 1000, 3_000_000, timestamp);
     let genesis_count = genesis.len() as u64;
     let node =
         NodeService::testing(Default::default(), keys.clone(), network, genesis, inbox).unwrap();
@@ -71,7 +71,7 @@ fn simulate_payment(node: &mut NodeService, amount: i64) -> Result<(), Error> {
     let fee: i64 = node.cfg.payment_fee * inputs.len() as i64;
     assert!(inputs_amount >= amount + fee);
     let change = inputs_amount - amount - fee;
-    let timestamp = Utc::now().timestamp() as u64;
+    let timestamp = SystemTime::now();
     let mut outputs: Vec<Output> = Vec::<Output>::with_capacity(2);
     let (output1, gamma1) = PaymentOutput::new(timestamp, sender_skey, sender_pkey, amount)?;
     outputs.push(Output::PaymentOutput(output1));
@@ -96,8 +96,8 @@ pub fn monetary_requests() {
 
     let total: i64 = 3_000_000;
     let stake: i64 = 1000;
-    let current_timestamp = Utc::now().timestamp() as u64;
-    let genesis = genesis(&[keys.clone()], stake, total, current_timestamp);
+    let timestamp = SystemTime::now();
+    let genesis = genesis(&[keys.clone()], stake, total, timestamp);
     let cfg: ChainConfig = Default::default();
     let mut node =
         NodeService::testing(cfg.clone(), keys.clone(), network, genesis, inbox).unwrap();

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -19,13 +19,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use chrono::Utc;
 use clap::{crate_version, App, Arg};
 use log::*;
 use protobuf::Message;
 use simple_logger;
 use std::fs;
 use std::process;
+use std::time::SystemTime;
 use stegos_blockchain::{genesis, BlockchainConfig};
 use stegos_keychain::KeyChain;
 use stegos_keychain::KeyChainConfig;
@@ -143,7 +143,7 @@ fn main() {
     }
 
     info!("Generating genesis blocks...");
-    let timestamp = Utc::now().timestamp() as u64;
+    let timestamp = SystemTime::now();
     let blocks = genesis(&keychains, stake, coins, timestamp);
     for (i, block) in blocks.iter().enumerate() {
         let block_data = block.into_proto();

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -24,7 +24,6 @@ mod console;
 mod consts;
 
 use atty;
-use chrono::NaiveDateTime;
 use clap;
 use clap::{App, Arg, ArgMatches};
 use dirs;
@@ -161,13 +160,11 @@ fn initialize_genesis(cfg: &config::Config) -> Result<Vec<Block>, Error> {
     for (i, block) in [block1.as_ref(), block2.as_ref()].iter().enumerate() {
         let block = Block::from_buffer(&block)?;
         let header = block.base_header();
-        let timestamp = NaiveDateTime::from_timestamp(header.timestamp as i64, 0);
         info!(
-            "Block #{}: hash={}, version={}, timestamp={}",
+            "Block #{}: hash={}, version={}",
             i,
             Hash::digest(&block),
             header.version,
-            timestamp
         );
         blocks.push(block);
     }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -19,7 +19,6 @@ stegos_network = { version = "0.4.0", path = "../network" }
 stegos_node = { version = "0.2.0", path = "../node" }
 stegos_serialization = { version = "0.2.0", path = "../serialization" }
 stegos_txpool = { version = "0.2.0", path = "../txpool" }
-chrono = "0.4"
 failure = "0.1"
 futures = "0.1"
 futures-stream-select-all-send = "0.1"

--- a/wallet/examples/show_utxo_chunks.rs
+++ b/wallet/examples/show_utxo_chunks.rs
@@ -25,7 +25,7 @@
 #![deny(warnings)]
 #![allow(non_snake_case)]
 
-use chrono::Utc;
+use std::time::SystemTime;
 use stegos_blockchain::Output;
 use stegos_blockchain::Transaction;
 use stegos_blockchain::{PaymentOutput, PaymentPayloadData};
@@ -45,7 +45,7 @@ use stegos_crypto::dicemix::*;
 fn main() {
     // Determine number of DiceMix chunks needed to support our UTXO's
     let (skey, pkey, _) = make_random_keys();
-    let tstamp = Utc::now().timestamp() as u64;
+    let tstamp = SystemTime::now();
     let data = PaymentPayloadData::Comment("Testing".to_string());
     let (out, gamma) = PaymentOutput::with_payload(tstamp, &skey, &pkey, 1500, data)
         .expect("Can't produce payment output");

--- a/wallet/src/transaction.rs
+++ b/wallet/src/transaction.rs
@@ -24,10 +24,10 @@
 use crate::change::*;
 use crate::error::*;
 use crate::valueshuffle::ProposedUTXO;
-use chrono::Utc;
 use failure::Error;
 use log::*;
 use std::collections::HashMap;
+use std::time::SystemTime;
 use stegos_blockchain::*;
 use stegos_crypto::curve1174::cpt::PublicKey;
 use stegos_crypto::curve1174::cpt::SecretKey;
@@ -194,7 +194,7 @@ pub(crate) fn create_payment_transaction(
     // Create outputs
     //
 
-    let timestamp = Utc::now().timestamp() as u64;
+    let timestamp = SystemTime::now();
     let mut outputs: Vec<Output> = Vec::<Output>::with_capacity(2);
 
     // Create an output for payment
@@ -293,7 +293,7 @@ pub(crate) fn create_staking_transaction(
     // Create outputs
     //
 
-    let timestamp = Utc::now().timestamp() as u64;
+    let timestamp = SystemTime::now();
     let mut outputs: Vec<Output> = Vec::<Output>::with_capacity(2);
 
     // Create an output for staking.
@@ -397,7 +397,7 @@ pub(crate) fn create_unstaking_transaction(
     // Create outputs
     //
 
-    let timestamp = Utc::now().timestamp() as u64;
+    let timestamp = SystemTime::now();
     let mut outputs: Vec<Output> = Vec::<Output>::with_capacity(2);
 
     // Create an output for payment
@@ -461,7 +461,7 @@ pub mod tests {
         let (skey, pkey, _sig0) = make_random_keys();
         let (validator_skey, validator_pkey, _validator_sig) = secure::make_random_keys();
 
-        let timestamp = Utc::now().timestamp() as u64;
+        let timestamp = SystemTime::now();
         let stake: i64 = 100;
 
         // Stake money.

--- a/wallet/src/valueshuffle/mod.rs
+++ b/wallet/src/valueshuffle/mod.rs
@@ -98,10 +98,13 @@ use std::collections::VecDeque;
 use std::time::{Duration, SystemTime};
 use stegos_blockchain::Output;
 use stegos_blockchain::Transaction;
+use stegos_blockchain::{PaymentOutput, PaymentPayloadData};
+use stegos_crypto::bulletproofs::{simple_commit, validate_range_proof};
 use stegos_crypto::curve1174::cpt::Pt;
 use stegos_crypto::curve1174::cpt::PublicKey;
 use stegos_crypto::curve1174::cpt::SchnorrSig;
 use stegos_crypto::curve1174::cpt::SecretKey;
+use stegos_crypto::curve1174::cpt::{make_deterministic_keys, sign_hash, validate_sig};
 use stegos_crypto::curve1174::ecpt::ECp;
 use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::dicemix::*;
@@ -115,13 +118,6 @@ use stegos_txpool::PoolJoin;
 use stegos_txpool::POOL_ANNOUNCE_TOPIC;
 use stegos_txpool::POOL_JOIN_TOPIC;
 use tokio_timer::Interval;
-
-// use super::*;
-use chrono::Utc;
-// use failure::Fail;
-use stegos_blockchain::{PaymentOutput, PaymentPayloadData};
-use stegos_crypto::bulletproofs::{simple_commit, validate_range_proof};
-use stegos_crypto::curve1174::cpt::{make_deterministic_keys, sign_hash, validate_sig};
 
 /// A topic used for ValueShuffle unicast communication.
 pub const VALUE_SHUFFLE_TOPIC: &'static str = "valueshuffle";
@@ -1704,7 +1700,7 @@ impl ValueShuffle {
         // generate a fresh set of UTXOs based on the list of proposed UTXOs
         // Return new UTXOs with fresh randomness, and the sum of all gamma factors
 
-        let tstamp = Utc::now().timestamp() as u64;
+        let tstamp = SystemTime::now();
         let mut outs = Vec::<(UTXO, Fr)>::new();
         for txout in txouts.clone() {
             let data = PaymentPayloadData::Comment(txout.data);


### PR DESCRIPTION
 - Use millisecond precision in block.header.timestamp.
 - Update default timeouts.
- Use `std::time::SystemTime` instead of u64.
- Use `std::time::Duration` instead of u64.
- Remove `chrono` from dependencies.
- Unify `current_timestamp`/`timestamp` usage.
- Add block_lag and block_idle metrics.

See #688