### PR TITLE
Stegos Kademlia (fork of libp2p-kad)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,8 @@ dependencies = [
 name = "stegos_network"
 version = "0.4.0"
 dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bigint 4.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cuckoofilter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -16,6 +16,8 @@ description = "Stegos - Network Library"
 stegos_crypto = { version = "0.2.0", path = "../crypto" }
 stegos_keychain = { version = "0.2.0", path = "../keychain" }
 stegos_serialization = { version = "0.2.0", path = "../serialization" }
+arrayvec = "0.4"
+bigint = "4.4"
 bs58 = "0.2"
 bytes = "0.4"
 cuckoofilter = "0.3"

--- a/network/build.rs
+++ b/network/build.rs
@@ -28,4 +28,5 @@ fn main() {
     build_script::build_protobuf("protos/unicast_proto.proto", "unicast_proto", &[]);
     build_script::build_protobuf("protos/pubsub_proto.proto", "pubsub", &[]);
     build_script::build_protobuf("protos/gatekeeper_proto.proto", "gatekeeper_proto", &[]);
+    build_script::build_protobuf("protos/dht.proto", "dht", &[]);
 }

--- a/network/protos/dht.proto
+++ b/network/protos/dht.proto
@@ -1,0 +1,83 @@
+syntax = "proto2";
+package dht.pb;
+
+// Record represents a dht record that contains a value
+// for a key value pair
+message Record {
+	// The key that references this record
+	optional string key = 1;
+
+	// The actual value this record is storing
+	optional bytes value = 2;
+
+	// hash of the authors public key
+	optional string author = 3;
+
+	// A PKI signature for the key+value+author
+	optional bytes signature = 4;
+
+	// Time the record was received, set by receiver
+	optional string timeReceived = 5;
+}
+
+message Message {
+	enum MessageType {
+		PUT_VALUE = 0;
+		GET_VALUE = 1;
+		ADD_PROVIDER = 2;
+		GET_PROVIDERS = 3;
+		FIND_NODE = 4;
+		PING = 5;
+	}
+
+	enum ConnectionType {
+		// sender does not have a connection to peer, and no extra information (default)
+		NOT_CONNECTED = 0;
+
+		// sender has a live connection to peer
+		CONNECTED = 1;
+
+		// sender recently connected to peer
+		CAN_CONNECT = 2;
+
+		// sender recently tried to connect to peer repeatedly but failed to connect
+		// ("try" here is loose, but this should signal "made strong effort, failed")
+		CANNOT_CONNECT = 3;
+	}
+
+	message Peer {
+        // ID of a given peer (PBC PublicKey)
+		optional bytes id = 1;
+
+        // LibP2P PeerId
+        optional bytes peer_id = 2;
+
+		// multiaddrs for a given peer
+		repeated bytes addrs = 3;
+
+		// used to signal the sender's connection capabilities to the peer
+		optional ConnectionType connection = 4;
+	}
+
+	// defines what type of message it is.
+	optional MessageType type = 1;
+
+	// defines what coral cluster level this query/response belongs to.
+	optional int32 clusterLevelRaw = 10;
+
+	// Used to specify the key associated with this message.
+	// PUT_VALUE, GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
+	optional bytes key = 2;
+
+	// Used to return a value
+	// PUT_VALUE, GET_VALUE
+	optional Record record = 3;
+
+	// Used to return peers closer to a key in a query
+	// GET_VALUE, GET_PROVIDERS, FIND_NODE
+	repeated Peer closerPeers = 8;
+
+	// Used to return Providers
+	// GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
+	repeated Peer providerPeers = 9;
+}

--- a/network/protos/ncp_proto.proto
+++ b/network/protos/ncp_proto.proto
@@ -9,7 +9,8 @@ message Message {
     
     message PeerInfo {
         required bytes peer_id = 1;
-        repeated bytes addrs = 2;
+        required bytes node_id = 2;
+        repeated bytes addrs = 3;
     }
 
 	// defines what type of message it is.

--- a/network/src/discovery/behavior.rs
+++ b/network/src/discovery/behavior.rs
@@ -1,0 +1,224 @@
+//
+// MIT License
+//
+// Copyright (c) 2018-2019 Stegos AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::kad::{Kademlia, KademliaOut};
+use futures::prelude::*;
+use libp2p::core::swarm::{
+    ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters,
+};
+use libp2p::{core::ProtocolsHandler, Multiaddr, PeerId};
+use log::*;
+use std::cmp;
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+use stegos_crypto::pbc::secure;
+use stegos_crypto::utils::u8v_to_hexstr;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::timer::Delay;
+
+pub enum DiscoveryOutEvent {
+    KadEvent(KademliaOut),
+}
+
+/// Kademlia-based network discovery
+pub struct Discovery<TSubstream> {
+    /// Kademlia systems
+    kademlia: Kademlia<TSubstream>,
+    /// Set of currently connected peers
+    connected_peers: HashSet<PeerId>,
+    /// When to send random request to gather network info
+    next_query: Delay,
+    /// Delay to the next random poll
+    delay_between_queries: Duration,
+}
+
+impl<TSubstream> Discovery<TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    pub fn new(local_node_id: secure::PublicKey) -> Self {
+        Discovery {
+            kademlia: Kademlia::without_init(local_node_id),
+            connected_peers: HashSet::new(),
+            next_query: Delay::new(Instant::now() + Duration::from_secs(30)),
+            delay_between_queries: Duration::from_secs(1),
+        }
+    }
+
+    /// Sets peer_id to the corresponging node_id
+    pub fn set_peer_id(&mut self, node_id: &secure::PublicKey, peer_id: PeerId) {
+        self.kademlia.set_peer_id(node_id, peer_id);
+    }
+
+    /// Adds a known address for the given `PeerId`. We are connected to this address.
+    pub fn add_connected_address(&mut self, node_id: &secure::PublicKey, address: Multiaddr) {
+        self.kademlia.add_connected_address(node_id, address);
+    }
+
+    /// Adds a known address for the given `PeerId`. We are not connected or don't know whether we
+    /// are connected to this address.
+    pub fn add_not_connected_address(&mut self, node_id: &secure::PublicKey, address: Multiaddr) {
+        self.kademlia.add_not_connected_address(node_id, address);
+    }
+}
+
+impl<TSubstream> NetworkBehaviour for Discovery<TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    type ProtocolsHandler = <Kademlia<TSubstream> as NetworkBehaviour>::ProtocolsHandler;
+    type OutEvent = DiscoveryOutEvent;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        NetworkBehaviour::new_handler(&mut self.kademlia)
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.kademlia.addresses_of_peer(peer_id)
+    }
+
+    fn inject_connected(&mut self, peer_id: PeerId, endpoint: ConnectedPoint) {
+        debug!(target: "stegos_network::discovery", "new peer connected: peer_id={}", peer_id.to_base58());
+        self.connected_peers.insert(peer_id.clone());
+        NetworkBehaviour::inject_connected(&mut self.kademlia, peer_id, endpoint)
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId, endpoint: ConnectedPoint) {
+        debug!(target: "stegos_network::discovery", "peer disconnected: peer_id={}", peer_id.to_base58());
+        self.connected_peers.remove(peer_id);
+        NetworkBehaviour::inject_disconnected(&mut self.kademlia, peer_id, endpoint)
+    }
+
+    fn inject_node_event(
+        &mut self,
+        peer_id: PeerId,
+        event: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent,
+    ) {
+        NetworkBehaviour::inject_node_event(&mut self.kademlia, peer_id, event)
+    }
+
+    fn poll(
+        &mut self,
+        params: &mut PollParameters,
+    ) -> Async<
+        NetworkBehaviourAction<
+            <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
+            Self::OutEvent,
+        >,
+    > {
+        // Process results of Kademlia discovery
+        match self.kademlia.poll(params) {
+            Async::Ready(NetworkBehaviourAction::GenerateEvent(action)) => {
+                trace!(target: "stegos_network::discovery", "Event from Kademlia: {:?}", action);
+                match action {
+                    KademliaOut::FindNodeResult {
+                        ref key,
+                        ref closer_peers,
+                    } => {
+                        debug!(
+                            target: "stegos_network::discovery",
+                            "Kademlia query for {} yielded {} results",
+                            u8v_to_hexstr(key.as_bytes()),
+                            closer_peers.len()
+                        );
+                    }
+                    KademliaOut::GetProvidersResult {
+                        ref key,
+                        closer_peers: _,
+                        ref provider_peers,
+                    } => {
+                        debug!(target: "stegos_network::discovery", "Got providers: key={} num_providers={}", u8v_to_hexstr(key.as_bytes()), provider_peers.len());
+                    }
+                    KademliaOut::Discovered {
+                        ref peer_id,
+                        ref node_id,
+                        ref addresses,
+                        ty,
+                    } => {
+                        if peer_id.is_some() {
+                            let peer_id = peer_id.clone().unwrap();
+                            debug!(target: "stegos_network::discovery",
+                                "Discovered peer: node_id={}, peer_id={}, addresses={:?}, connected={:?}",
+                                node_id, peer_id.to_base58(), addresses, ty
+                            );
+                            self.kademlia.set_peer_id(node_id, peer_id.clone());
+                            for addr in addresses.iter() {
+                                if self.connected_peers.contains(&peer_id) {
+                                    self.kademlia.add_connected_address(node_id, addr.clone());
+                                } else {
+                                    self.kademlia
+                                        .add_not_connected_address(node_id, addr.clone());
+                                }
+                            }
+                        } else {
+                            debug!(target: "stegos_network::discovery",
+                                "Discovered peer: node_id={}, peer_id=Unknown, addresses={:?} connected={:?}",
+                                node_id, addresses, ty
+                            );
+                        }
+                    }
+                }
+                return Async::Ready(NetworkBehaviourAction::GenerateEvent(
+                    DiscoveryOutEvent::KadEvent(action),
+                ));
+            }
+            Async::Ready(NetworkBehaviourAction::DialAddress { address }) => {
+                return Async::Ready(NetworkBehaviourAction::DialAddress { address });
+            }
+            Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }) => {
+                return Async::Ready(NetworkBehaviourAction::DialPeer { peer_id });
+            }
+            Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }) => {
+                return Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event });
+            }
+            Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) => {
+                return Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address });
+            }
+            Async::NotReady => (),
+        }
+        trace!("Done checking queues");
+        // Initiate new shake of DHT network
+        loop {
+            match self.next_query.poll() {
+                Ok(Async::NotReady) => break,
+                Ok(Async::Ready(_)) => {
+                    debug!("Shooting at DHT to gather nodes information");
+                    let (_, random_node_id, _) = secure::make_random_keys();
+                    self.kademlia.find_node(random_node_id);
+
+                    // Reset the `Delay` to the next random.
+                    self.next_query
+                        .reset(Instant::now() + self.delay_between_queries);
+                    self.delay_between_queries =
+                        cmp::min(self.delay_between_queries * 2, Duration::from_secs(60));
+                }
+                Err(err) => {
+                    error!("Kad discovery timer errored: {:?}", err);
+                    break;
+                }
+            }
+        }
+        trace!("Done discovery poll");
+        Async::NotReady
+    }
+}

--- a/network/src/discovery/mod.rs
+++ b/network/src/discovery/mod.rs
@@ -21,4 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-include!(concat!(env!("OUT_DIR"), "/ncp_proto/mod.rs"));
+mod behavior;
+
+pub use behavior::{Discovery, DiscoveryOutEvent};

--- a/network/src/kad/addresses.rs
+++ b/network/src/kad/addresses.rs
@@ -1,0 +1,253 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use arrayvec::ArrayVec;
+use libp2p::core::Multiaddr;
+use std::{fmt, time::Duration, time::Instant};
+
+/// List of addresses of a peer.
+#[derive(Clone)]
+pub struct Addresses {
+    /// Contains an `Instant` when the address expires. If `None`, we are connected to this
+    /// address.
+    addrs: ArrayVec<[(Multiaddr, Option<Instant>); 6]>,
+    /// Time-to-live for addresses we're not connected to.
+    expiration: Duration,
+}
+
+impl Addresses {
+    /// Creates a new list of addresses.
+    pub fn new() -> Addresses {
+        Self::with_time_to_live(Duration::from_secs(60 * 60))
+    }
+
+    /// Creates a new list of addresses. The addresses we're not connected to will use the given
+    /// time-to-live before they expire.
+    pub fn with_time_to_live(ttl: Duration) -> Addresses {
+        Addresses {
+            addrs: ArrayVec::new(),
+            expiration: ttl,
+        }
+    }
+
+    /// Returns the list of addresses.
+    pub fn iter(&self) -> impl Iterator<Item = &Multiaddr> {
+        let now = Instant::now();
+        self.addrs.iter().filter_map(move |(addr, exp)| {
+            if let Some(exp) = exp {
+                if *exp >= now {
+                    Some(addr)
+                } else {
+                    None
+                }
+            } else {
+                Some(addr)
+            }
+        })
+    }
+
+    /// If true, we are connected to all the addresses returned by `iter()`.
+    ///
+    /// Returns false if the list of addresses is empty.
+    pub fn is_connected(&self) -> bool {
+        // Note: we're either connected to all addresses or none. There's no in-between.
+        self.addrs
+            .first()
+            .map(|(_, exp)| exp.is_none())
+            .unwrap_or(false)
+    }
+
+    /// If we were connected to that addresses, indicates that we are now disconnected.
+    pub fn set_disconnected(&mut self, addr: &Multiaddr) {
+        let pos = match self.addrs.iter().position(|(a, _)| a == addr) {
+            Some(p) => p,
+            None => return,
+        };
+
+        // We were already disconnected.
+        if self.addrs[pos].1.is_some() {
+            return;
+        }
+
+        // Address is the only known address.
+        if self.addrs.len() == 1 {
+            self.addrs[pos].1 = Some(Instant::now() + self.expiration);
+            return;
+        }
+
+        // We know other connected addresses. Remove this one.
+        self.addrs.remove(pos);
+    }
+
+    /// Removes the given address from the list. Typically called if an address is determined to
+    /// be invalid or unreachable.
+    pub fn remove_addr(&mut self, addr: &Multiaddr) {
+        if let Some(pos) = self.addrs.iter().position(|(a, _)| a == addr) {
+            self.addrs.remove(pos);
+        }
+    }
+
+    /// Inserts an address in the list. The address is an address we're not connected to, or may
+    /// not be connected to.
+    pub fn insert_not_connected(&mut self, addr: Multiaddr) {
+        // Don't insert if either we're already in the list, or we're connected to any address.
+        if self
+            .addrs
+            .iter()
+            .any(|(a, expires)| a == &addr || expires.is_none())
+        {
+            return;
+        }
+
+        // Do a cleanup pass.
+        let now = Instant::now();
+        self.addrs.retain(move |(_, exp)| {
+            exp.expect("We check above that all the expires are Some") > now
+        });
+
+        let _ = self
+            .addrs
+            .try_push((addr, Some(Instant::now() + self.expiration)));
+    }
+
+    /// Inserts an address in the list. We know that the address is reachable.
+    pub fn insert_connected(&mut self, addr: Multiaddr) {
+        if !self.is_connected() {
+            self.addrs.clear();
+        }
+
+        if self.addrs.iter().all(|(a, _)| *a != addr) {
+            let _ = self.addrs.try_push((addr, None));
+        }
+    }
+}
+
+impl Default for Addresses {
+    fn default() -> Self {
+        Addresses::new()
+    }
+}
+
+impl fmt::Debug for Addresses {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list()
+            .entries(self.addrs.iter().map(|(a, _)| a))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Addresses;
+    use libp2p::core::multiaddr;
+    use std::{iter, thread, time::Duration};
+
+    #[test]
+    fn insert_connected_after_not_connected() {
+        let mut addrs = Addresses::new();
+        addrs.insert_not_connected("/ip4/1.2.3.4/tcp/5".parse().unwrap());
+        addrs.insert_not_connected("/ip4/6.7.8.9/tcp/5".parse().unwrap());
+        addrs.insert_not_connected("/ip4/10.11.12.13/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 3);
+        assert!(!addrs.is_connected());
+        addrs.insert_connected("/ip4/8.9.10.11".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+        assert!(addrs.is_connected());
+    }
+
+    #[test]
+    fn not_connected_expire() {
+        let mut addrs = Addresses::with_time_to_live(Duration::from_secs(2));
+
+        addrs.insert_not_connected("/ip4/1.2.3.4/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+
+        thread::sleep(Duration::from_secs(1));
+        assert_eq!(addrs.iter().count(), 1);
+
+        addrs.insert_not_connected("/ip4/6.7.8.9/tcp/5".parse().unwrap());
+        addrs.insert_not_connected("/ip4/10.11.12.13/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 3);
+
+        thread::sleep(Duration::from_secs(1));
+        assert_eq!(addrs.iter().count(), 2);
+
+        thread::sleep(Duration::from_secs(1));
+        assert_eq!(addrs.iter().count(), 0);
+    }
+
+    #[test]
+    fn connected_dont_expire() {
+        let mut addrs = Addresses::with_time_to_live(Duration::from_secs(1));
+        addrs.insert_connected("/ip4/1.2.3.4/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+
+        thread::sleep(Duration::from_secs(2));
+        assert_eq!(addrs.iter().count(), 1);
+        assert!(addrs.is_connected());
+    }
+
+    #[test]
+    fn dont_insert_disconnected_if_connected() {
+        let mut addrs = Addresses::new();
+        addrs.insert_connected("/ip4/1.2.3.4/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+
+        addrs.insert_not_connected("/ip4/5.6.7.8/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+        assert!(addrs.is_connected());
+    }
+
+    #[test]
+    fn disconnect_addr() {
+        let mut addrs = Addresses::new();
+
+        addrs.insert_connected("/ip4/1.2.3.4/tcp/5".parse().unwrap());
+        addrs.insert_connected("/ip4/6.7.8.9/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 2);
+
+        addrs.set_disconnected(&"/ip4/1.2.3.4/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+        assert!(addrs.is_connected());
+
+        addrs.set_disconnected(&"/ip4/6.7.8.9/tcp/5".parse().unwrap());
+        assert_eq!(addrs.iter().count(), 1);
+        assert!(!addrs.is_connected());
+    }
+
+    #[test]
+    fn max_addrs() {
+        // Check that the number of addresses stops increasing even if we continue inserting.
+        let mut addrs = Addresses::new();
+
+        let mut previous_loop_count = None;
+
+        for n in 0.. {
+            let addr: multiaddr::Multiaddr = iter::once(multiaddr::Protocol::Tcp(n)).collect();
+            addrs.insert_not_connected(addr);
+
+            let num = addrs.iter().count();
+            if previous_loop_count == Some(num) {
+                return; // Test success
+            }
+            previous_loop_count = Some(num);
+        }
+    }
+}

--- a/network/src/kad/behaviour.rs
+++ b/network/src/kad/behaviour.rs
@@ -1,0 +1,932 @@
+// Copyright 2019 Stegos AG
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use super::addresses::Addresses;
+use super::handler::{KademliaHandler, KademliaHandlerEvent, KademliaHandlerIn, KademliaRequestId};
+use super::kbucket::{KBucketsTable, Update};
+use super::metrics::{KBUCKET_TABLE_SIZE, PEER_TABLE_SIZE};
+use super::protocol::{KadConnectionType, KadPeer};
+use super::query::{QueryConfig, QueryState, QueryStatePollOut, QueryTarget};
+use fnv::{FnvHashMap, FnvHashSet};
+use futures::{prelude::*, stream};
+use libp2p::core::swarm::{
+    ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters,
+};
+use libp2p::core::{protocols_handler::ProtocolsHandler, Multiaddr, PeerId};
+use libp2p::multihash::Multihash;
+use log::{debug, trace};
+use lru_time_cache::LruCache;
+use rand;
+use smallvec::SmallVec;
+use std::{cmp::Ordering, error, marker::PhantomData, time::Duration, time::Instant};
+use stegos_crypto::pbc::secure;
+use stegos_crypto::utils::u8v_to_hexstr;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::timer::Interval;
+
+use crate::utils::IntoMultihash;
+
+// Buckets will be treated as expired, if they weren't touch during 5 minutes
+const BUCKET_EXPIRATION_PERIOD: u64 = 5 * 60;
+// At which interval update metrics (secs)
+const METRICS_UPDATE_INTERVAL: u64 = 1;
+
+/// Network behaviour that handles Kademlia.
+pub struct Kademlia<TSubstream> {
+    /// NodeId of this node
+    my_id: secure::PublicKey,
+    /// Storage for the nodes. Contains the known multiaddresses for this node.
+    kbuckets: KBucketsTable<secure::PublicKey, NodeInfo>,
+
+    /// Mapping PeerId -> secure::PublicKey (we use Vec<u8> here, 'cause PeerId doesn't implement Ord)
+    known_peers: LruCache<Vec<u8>, secure::PublicKey>,
+
+    /// All the iterative queries we are currently performing, with their ID. The last parameter
+    /// is the list of accumulated providers for `GET_PROVIDERS` queries.
+    active_queries: FnvHashMap<QueryId, (QueryState, QueryPurpose, Vec<secure::PublicKey>)>,
+
+    /// List of queries to start once we are inside `poll()`.
+    queries_to_starts: SmallVec<[(QueryId, QueryTarget, QueryPurpose); 8]>,
+
+    /// List of peers the swarm is connected to.
+    connected_peers: FnvHashSet<PeerId>,
+
+    /// Contains a list of peer IDs which we are not connected to, and an RPC query to send to them
+    /// once they connect.
+    pending_rpcs: SmallVec<[(secure::PublicKey, KademliaHandlerIn<QueryId>); 8]>,
+
+    /// Identifier for the next query that we start.
+    next_query_id: QueryId,
+
+    /// Requests received by a remote that we should fulfill as soon as possible.
+    remote_requests: SmallVec<[(PeerId, KademliaRequestId, QueryTarget); 4]>,
+
+    /// List of values and peers that are providing them.
+    ///
+    /// Our local peer ID can be in this container.
+    // TODO: Note that in reality the value is a SHA-256 of the actual value (https://github.com/libp2p/rust-libp2p/issues/694)
+    values_providers: FnvHashMap<Multihash, SmallVec<[secure::PublicKey; 20]>>,
+
+    /// List of values that we are providing ourselves. Must be kept in sync with
+    /// `values_providers`.
+    providing_keys: FnvHashSet<Multihash>,
+
+    /// Interval to send `ADD_PROVIDER` messages to everyone.
+    refresh_add_providers: stream::Fuse<Interval>,
+
+    /// `α` in the Kademlia reference papers. Designates the maximum number of queries that we
+    /// perform in parallel.
+    parallelism: usize,
+
+    /// `k` in the Kademlia reference papers. Number of results in a find node query.
+    num_results: usize,
+
+    /// Timeout for each individual RPC query.
+    rpc_timeout: Duration,
+
+    /// Events to return when polling.
+    queued_events: SmallVec<[NetworkBehaviourAction<KademliaHandlerIn<QueryId>, KademliaOut>; 32]>,
+
+    /// List of providers to add to the topology as soon as we are in `poll()`.
+    add_provider: SmallVec<[(Multihash, secure::PublicKey); 32]>,
+
+    /// When metrics were updated last time
+    metrics_last_update: Instant,
+
+    /// Marker to pin the generics.
+    marker: PhantomData<TSubstream>,
+}
+
+struct NodeInfo {
+    peer_id: Option<PeerId>,
+    addresses: Addresses,
+}
+
+impl Default for NodeInfo {
+    fn default() -> Self {
+        NodeInfo {
+            peer_id: None,
+            addresses: Addresses::default(),
+        }
+    }
+}
+
+/// Opaque type. Each query that we start gets a unique number.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct QueryId(usize);
+
+/// Reason why we have this query in the list of queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum QueryPurpose {
+    /// The query was created for the Kademlia initialization process.
+    Initialization,
+    /// The user requested this query to be performed. It should be reported when finished.
+    UserRequest,
+    /// We should add an `ADD_PROVIDER` message to the peers of the outcome.
+    AddProvider(Multihash),
+}
+
+impl<TSubstream> Kademlia<TSubstream> {
+    /// Creates a `Kademlia`.
+    #[inline]
+    pub fn new(local_node_id: secure::PublicKey) -> Self {
+        Self::new_inner(local_node_id, true)
+    }
+
+    /// Creates a `Kademlia`.
+    ///
+    /// Contrary to `new`, doesn't perform the initialization queries that store our local ID into
+    /// the DHT.
+    #[inline]
+    pub fn without_init(local_node_id: secure::PublicKey) -> Self {
+        Self::new_inner(local_node_id, false)
+    }
+
+    /// Sets peer_id to the corresponging node_id
+    pub fn set_peer_id(&mut self, node_id: &secure::PublicKey, peer_id: PeerId) {
+        if let Some(node_info) = self.kbuckets.entry_mut(node_id) {
+            node_info.peer_id = Some(peer_id.clone());
+        }
+        self.known_peers
+            .insert(peer_id.as_bytes().to_vec(), node_id.clone());
+    }
+
+    /// Adds a known address for the given `PeerId`. We are connected to this address.
+    pub fn add_connected_address(&mut self, node_id: &secure::PublicKey, address: Multiaddr) {
+        if let Some(node_info) = self.kbuckets.entry_mut(node_id) {
+            node_info.addresses.insert_connected(address);
+        }
+    }
+
+    /// Adds a known address for the given `PeerId`. We are not connected or don't know whether we
+    /// are connected to this address.
+    pub fn add_not_connected_address(&mut self, node_id: &secure::PublicKey, address: Multiaddr) {
+        if let Some(node_info) = self.kbuckets.entry_mut(node_id) {
+            node_info.addresses.insert_not_connected(address);
+        }
+    }
+
+    /// Inner implementation of the constructors.
+    fn new_inner(local_node_id: secure::PublicKey, initialize: bool) -> Self {
+        let parallelism = 3;
+
+        let mut behaviour = Kademlia {
+            my_id: local_node_id.clone(),
+            kbuckets: KBucketsTable::new(
+                local_node_id,
+                Duration::from_secs(BUCKET_EXPIRATION_PERIOD),
+            ),
+            known_peers: LruCache::<Vec<u8>, secure::PublicKey>::with_capacity(512 * (20 + 1)), // Total size of kBucketsTable
+            queued_events: SmallVec::new(),
+            queries_to_starts: SmallVec::new(),
+            active_queries: Default::default(),
+            connected_peers: Default::default(),
+            pending_rpcs: SmallVec::with_capacity(parallelism),
+            next_query_id: QueryId(0),
+            remote_requests: SmallVec::new(),
+            values_providers: FnvHashMap::default(),
+            providing_keys: FnvHashSet::default(),
+            refresh_add_providers: Interval::new_interval(Duration::from_secs(60)).fuse(), // TODO: constant
+            parallelism,
+            num_results: 20,
+            rpc_timeout: Duration::from_secs(8),
+            add_provider: SmallVec::new(),
+            metrics_last_update: Instant::now(),
+            marker: PhantomData,
+        };
+
+        if initialize {
+            // As part of the initialization process, we start one `FIND_NODE` for each bit of the
+            // possible range of node IDs.
+            let my_hash = behaviour.kbuckets.my_id().into_multihash();
+            for n in 0..512 {
+                let random_hash = match gen_random_hash(&my_hash, n) {
+                    Ok(p) => p,
+                    Err(()) => continue,
+                };
+
+                behaviour.start_query(
+                    QueryTarget::FindPeer(random_hash),
+                    QueryPurpose::Initialization,
+                );
+            }
+        }
+
+        behaviour
+    }
+
+    /// Builds the answer to a request.
+    fn build_result<TUserData>(
+        &mut self,
+        query: QueryTarget,
+        request_id: KademliaRequestId,
+        parameters: &mut PollParameters<'_>,
+    ) -> KademliaHandlerIn<TUserData> {
+        match query {
+            QueryTarget::FindPeer(key) => {
+                let closer_peers = self
+                    .kbuckets
+                    .find_closest_with_self(&key)
+                    .take(self.num_results)
+                    .map(|node_id| build_kad_peer(node_id, parameters, &self.kbuckets))
+                    .collect();
+                trace!(target: "stegos_network::kad", "sending FindNodeRes with: {:#?}", closer_peers);
+                KademliaHandlerIn::FindNodeRes {
+                    closer_peers,
+                    request_id,
+                }
+            }
+            QueryTarget::GetProviders(key) => {
+                let closer_peers = self
+                    .kbuckets
+                    .find_closest_with_self(&key)
+                    .take(self.num_results)
+                    .map(|node_id| build_kad_peer(node_id, parameters, &self.kbuckets))
+                    .collect();
+
+                let provider_peers = self
+                    .values_providers
+                    .get(&key)
+                    .into_iter()
+                    .flat_map(|peers| peers)
+                    .map(|node_id| build_kad_peer(node_id.clone(), parameters, &self.kbuckets))
+                    .collect();
+
+                KademliaHandlerIn::GetProvidersRes {
+                    closer_peers,
+                    provider_peers,
+                    request_id,
+                }
+            }
+        }
+    }
+}
+
+impl<TSubstream> Kademlia<TSubstream> {
+    /// Starts an iterative `FIND_NODE` request.
+    ///
+    /// This will eventually produce an event containing the nodes of the DHT closest to the
+    /// requested `PeerId`.
+    #[inline]
+    pub fn find_node(&mut self, node_id: secure::PublicKey) {
+        self.start_query(
+            QueryTarget::FindPeer(node_id.into_multihash()),
+            QueryPurpose::UserRequest,
+        );
+    }
+
+    /// Size of internal KBucketsTable
+    #[inline]
+    pub fn ktable_size(&self) -> usize {
+        self.kbuckets.size()
+    }
+
+    /// Starts an iterative `GET_PROVIDERS` request.
+    #[inline]
+    pub fn get_providers(&mut self, key: Multihash) {
+        self.start_query(QueryTarget::GetProviders(key), QueryPurpose::UserRequest);
+    }
+
+    /// Register the local node as the provider for the given key.
+    ///
+    /// This will periodically send `ADD_PROVIDER` messages to the nodes closest to the key. When
+    /// someone performs a `GET_PROVIDERS` iterative request on the DHT, our local node will be
+    /// returned as part of the results.
+    ///
+    /// The actual meaning of *providing* the value of a key is not defined, and is specific to
+    /// the value whose key is the hash.
+    pub fn add_providing(&mut self, key: secure::PublicKey) {
+        self.providing_keys.insert(key.clone().into_multihash());
+        let providers = self
+            .values_providers
+            .entry(key.into_multihash())
+            .or_insert_with(Default::default);
+        let my_id = self.kbuckets.my_id();
+        if !providers.iter().any(|k| k == my_id) {
+            providers.push(my_id.clone());
+        }
+
+        // Trigger the next refresh now.
+        self.refresh_add_providers = Interval::new(Instant::now(), Duration::from_secs(60)).fuse();
+    }
+
+    /// Cancels a registration done with `add_providing`.
+    ///
+    /// There doesn't exist any "remove provider" message to broadcast on the network, therefore we
+    /// will still be registered as a provider in the DHT for as long as the timeout doesn't expire.
+    pub fn remove_providing(&mut self, key: &Multihash) {
+        self.providing_keys.remove(key);
+
+        let providers = match self.values_providers.get_mut(key) {
+            Some(p) => p,
+            None => return,
+        };
+
+        // remove outselves from list of peers providing the key
+        let my_id = self.my_id;
+        if let Some(position) = providers.iter().position(|k| *k == my_id) {
+            providers.remove(position);
+            providers.shrink_to_fit();
+        }
+    }
+
+    /// Internal function that starts a query.
+    fn start_query(&mut self, target: QueryTarget, purpose: QueryPurpose) {
+        let query_id = self.next_query_id;
+        self.next_query_id.0 += 1;
+        self.queries_to_starts.push((query_id, target, purpose));
+    }
+}
+
+impl<TSubstream> NetworkBehaviour for Kademlia<TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    type ProtocolsHandler = KademliaHandler<TSubstream, QueryId>;
+    type OutEvent = KademliaOut;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        KademliaHandler::dial_and_listen()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        let peer = peer_id.clone();
+        if let Some(node_id) = self.known_peers.get(&peer.into_bytes()) {
+            self.kbuckets
+                .get(node_id)
+                .map(|l| l.addresses.iter().cloned().collect::<Vec<_>>())
+                .unwrap_or_else(Vec::new)
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn inject_connected(&mut self, id: PeerId, endpoint: ConnectedPoint) {
+        let peer_id = id.clone().into_bytes();
+        self.connected_peers.insert(id.clone());
+
+        let node_id = match self.known_peers.get(&peer_id) {
+            Some(id) => id,
+            None => return,
+        };
+
+        if let Some(pos) = self.pending_rpcs.iter().position(|(p, _)| p == node_id) {
+            let (_, rpc) = self.pending_rpcs.remove(pos);
+            self.queued_events.push(NetworkBehaviourAction::SendEvent {
+                peer_id: id.clone(),
+                event: rpc,
+            });
+        }
+
+        if let Update::Pending(to_ping) = self.kbuckets.set_connected(&node_id) {
+            let target_node = to_ping.clone();
+            if let Some(ref node_info) = self.kbuckets.get(&target_node) {
+                if let Some(ref peer_id) = node_info.peer_id {
+                    self.queued_events.push(NetworkBehaviourAction::DialPeer {
+                        peer_id: peer_id.clone(),
+                    })
+                }
+            }
+        }
+
+        if let ConnectedPoint::Dialer { address } = endpoint {
+            if let Some(node_info) = self.kbuckets.entry_mut(&node_id) {
+                node_info.addresses.insert_connected(address);
+            }
+        }
+    }
+
+    fn inject_dial_failure(
+        &mut self,
+        peer_id: Option<&PeerId>,
+        addr: &Multiaddr,
+        e: &dyn error::Error,
+    ) {
+        debug!(target: "stegos_network::kad", "dialout failure: error={}", e);
+        if let Some(peer_id) = peer_id {
+            let peer_id = peer_id.clone().into_bytes();
+            let node_id = match self.known_peers.get(&peer_id) {
+                Some(id) => id,
+                None => return,
+            };
+
+            if let Some(node_info) = self.kbuckets.get_mut(&node_id) {
+                // TODO: don't remove the address if the error is that we are already connected
+                //       to this peer
+                node_info.addresses.remove_addr(addr);
+            }
+        }
+    }
+
+    fn inject_disconnected(&mut self, id: &PeerId, old_endpoint: ConnectedPoint) {
+        let was_in = self.connected_peers.remove(id);
+        debug_assert!(was_in);
+        let peer_id = id.clone().into_bytes();
+        let node_id = match self.known_peers.get(&peer_id) {
+            Some(id) => id,
+            None => return,
+        };
+
+        for (query, _, _) in self.active_queries.values_mut() {
+            query.inject_rpc_error(&node_id);
+        }
+
+        if let ConnectedPoint::Dialer { address } = old_endpoint {
+            if let Some(node_info) = self.kbuckets.get_mut(&node_id) {
+                debug_assert!(node_info.addresses.is_connected());
+                node_info.addresses.set_disconnected(&address);
+            }
+        }
+
+        self.kbuckets.set_disconnected(&node_id);
+    }
+
+    fn inject_replaced(
+        &mut self,
+        peer_id: PeerId,
+        old_endpoint: ConnectedPoint,
+        new_endpoint: ConnectedPoint,
+    ) {
+        let peer = peer_id.clone().into_bytes();
+        let node_id = match self.known_peers.get(&peer) {
+            Some(id) => id,
+            None => return,
+        };
+        // We need to re-send the active queries.
+        for (query_id, (query, _, _)) in self.active_queries.iter() {
+            if query.is_waiting(&node_id) {
+                self.queued_events.push(NetworkBehaviourAction::SendEvent {
+                    peer_id: peer_id.clone(),
+                    event: query.target().to_rpc_request(*query_id),
+                });
+            }
+        }
+
+        if let ConnectedPoint::Dialer { address } = old_endpoint {
+            if let Some(node_info) = self.kbuckets.get_mut(&node_id) {
+                node_info.addresses.set_disconnected(&address);
+            }
+        }
+
+        if let ConnectedPoint::Dialer { address } = new_endpoint {
+            if let Some(node_info) = self.kbuckets.entry_mut(&node_id) {
+                node_info.addresses.insert_connected(address);
+            }
+        }
+    }
+
+    fn inject_node_event(&mut self, source: PeerId, event: KademliaHandlerEvent<QueryId>) {
+        match event {
+            KademliaHandlerEvent::FindNodeReq { key, request_id } => {
+                self.remote_requests
+                    .push((source, request_id, QueryTarget::FindPeer(key)));
+                return;
+            }
+            KademliaHandlerEvent::FindNodeRes {
+                closer_peers,
+                user_data,
+            } => {
+                // It is possible that we obtain a response for a query that has finished, which is
+                // why we may not find an entry in `self.active_queries`.
+                for peer in closer_peers.iter() {
+                    let peer_id = match &peer.peer_id {
+                        Some(p) => Some(p.clone()),
+                        None => None,
+                    };
+                    self.queued_events
+                        .push(NetworkBehaviourAction::GenerateEvent(
+                            KademliaOut::Discovered {
+                                node_id: peer.node_id.clone(),
+                                peer_id,
+                                addresses: peer.multiaddrs.clone(),
+                                ty: peer.connection_ty,
+                            },
+                        ));
+                }
+                if let Some((query, _, _)) = self.active_queries.get_mut(&user_data) {
+                    let peer_key = source.into_bytes();
+                    let my_id = self.my_id;
+                    if let Some(node_id) = self.known_peers.get(&peer_key) {
+                        query.inject_rpc_result(
+                            &node_id,
+                            closer_peers.into_iter().filter_map(|kp| {
+                                if kp.node_id == my_id {
+                                    None
+                                } else {
+                                    Some(kp.node_id)
+                                }
+                            }),
+                        )
+                    }
+                }
+            }
+            KademliaHandlerEvent::GetProvidersReq { key, request_id } => {
+                self.remote_requests
+                    .push((source, request_id, QueryTarget::GetProviders(key)));
+                return;
+            }
+            KademliaHandlerEvent::GetProvidersRes {
+                closer_peers,
+                provider_peers,
+                user_data,
+            } => {
+                for peer in closer_peers.iter().chain(provider_peers.iter()) {
+                    let peer_id = match &peer.peer_id {
+                        Some(p) => Some(p.clone()),
+                        None => None,
+                    };
+                    self.queued_events
+                        .push(NetworkBehaviourAction::GenerateEvent(
+                            KademliaOut::Discovered {
+                                node_id: peer.node_id.clone(),
+                                peer_id,
+                                addresses: peer.multiaddrs.clone(),
+                                ty: peer.connection_ty,
+                            },
+                        ));
+                }
+
+                // It is possible that we obtain a response for a query that has finished, which is
+                // why we may not find an entry in `self.active_queries`.
+                if let Some((query, _, providers)) = self.active_queries.get_mut(&user_data) {
+                    for peer in provider_peers {
+                        providers.push(peer.node_id);
+                    }
+                    let peer_key = source.into_bytes();
+                    if let Some(node_id) = self.known_peers.get(&peer_key) {
+                        query.inject_rpc_result(
+                            &node_id,
+                            closer_peers.into_iter().map(|kp| kp.node_id),
+                        )
+                    }
+                }
+            }
+            KademliaHandlerEvent::QueryError { user_data, .. } => {
+                // It is possible that we obtain a response for a query that has finished, which is
+                // why we may not find an entry in `self.active_queries`.
+                if let Some((query, _, _)) = self.active_queries.get_mut(&user_data) {
+                    let peer_key = source.into_bytes();
+                    if let Some(node_id) = self.known_peers.get(&peer_key) {
+                        query.inject_rpc_error(&node_id)
+                    }
+                }
+            }
+            KademliaHandlerEvent::AddProvider { key, provider_peer } => {
+                let peer_id = match provider_peer.peer_id {
+                    Some(p) => Some(p.clone()),
+                    None => None,
+                };
+                self.queued_events
+                    .push(NetworkBehaviourAction::GenerateEvent(
+                        KademliaOut::Discovered {
+                            node_id: provider_peer.node_id.clone(),
+                            peer_id,
+                            addresses: provider_peer.multiaddrs.clone(),
+                            ty: provider_peer.connection_ty,
+                        },
+                    ));
+                self.add_provider.push((key, provider_peer.node_id));
+                return;
+            }
+        };
+    }
+
+    fn poll(
+        &mut self,
+        parameters: &mut PollParameters<'_>,
+    ) -> Async<
+        NetworkBehaviourAction<
+            <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
+            Self::OutEvent,
+        >,
+    > {
+        // Update metrics
+        if self.metrics_last_update.elapsed() > Duration::from_secs(METRICS_UPDATE_INTERVAL) {
+            self.metrics_last_update = Instant::now();
+            KBUCKET_TABLE_SIZE.set(self.kbuckets.size() as i64);
+            PEER_TABLE_SIZE.set(self.known_peers.len() as i64);
+        }
+        // Flush the changes to the topology that we want to make.
+        for (key, provider) in self.add_provider.drain() {
+            // Don't add ourselves to the providers.
+            if provider == *self.kbuckets.my_id() {
+                continue;
+            }
+            let providers = self
+                .values_providers
+                .entry(key)
+                .or_insert_with(Default::default);
+            if !providers.iter().any(|k| k == &provider) {
+                providers.push(provider);
+            }
+        }
+        self.add_provider.shrink_to_fit();
+
+        // Handle `refresh_add_providers`.
+        match self.refresh_add_providers.poll() {
+            Ok(Async::NotReady) => {}
+            Ok(Async::Ready(Some(_))) => {
+                for provided in self.providing_keys.clone().into_iter() {
+                    let purpose = QueryPurpose::AddProvider(provided.clone());
+                    self.start_query(QueryTarget::FindPeer(provided), purpose);
+                }
+            }
+            // Ignore errors.
+            Ok(Async::Ready(None)) | Err(_) => {}
+        }
+
+        // Start queries that are waiting to start.
+        let table_size = self.ktable_size();
+        for (query_id, query_target, query_purpose) in self.queries_to_starts.drain() {
+            debug!(target: "stegos_network::kad", "Starting query: query_id={:?}, target={}, table_size={}", query_id, u8v_to_hexstr(query_target.as_hash().as_bytes()), table_size);
+            let known_closest_peers = self
+                .kbuckets
+                .find_closest(&query_target.as_hash())
+                .take(self.num_results);
+            trace!(target: "stegos_network::kad", "Known peers for query: query_id={:?}, known_closest_peers={:#?}", query_id, known_closest_peers);
+            self.active_queries.insert(
+                query_id,
+                (
+                    QueryState::new(QueryConfig {
+                        target: query_target,
+                        parallelism: self.parallelism,
+                        num_results: self.num_results,
+                        rpc_timeout: self.rpc_timeout,
+                        known_closest_peers,
+                    }),
+                    query_purpose,
+                    Vec::new(), // TODO: insert ourselves if we provide the data?
+                ),
+            );
+        }
+        self.queries_to_starts.shrink_to_fit();
+
+        // Handle remote queries.
+        if !self.remote_requests.is_empty() {
+            let (peer_id, request_id, query) = self.remote_requests.remove(0);
+            let result = self.build_result(query, request_id, parameters);
+            return Async::Ready(NetworkBehaviourAction::SendEvent {
+                peer_id,
+                event: result,
+            });
+        }
+
+        loop {
+            // Handle events queued by other parts of this struct
+            if !self.queued_events.is_empty() {
+                return Async::Ready(self.queued_events.remove(0));
+            }
+            self.queued_events.shrink_to_fit();
+
+            // If iterating finds a query that is finished, stores it here and stops looping.
+            let mut finished_query = None;
+            let mut nodes_without_peerids: Vec<secure::PublicKey> = Vec::new();
+
+            'queries_iter: for (&query_id, (query, _, _)) in self.active_queries.iter_mut() {
+                loop {
+                    match query.poll() {
+                        Async::Ready(QueryStatePollOut::Finished) => {
+                            finished_query = Some(query_id);
+                            break 'queries_iter;
+                        }
+                        Async::Ready(QueryStatePollOut::SendRpc {
+                            node_id,
+                            query_target,
+                        }) => {
+                            debug!(target: "stegos_network::kad", "got request to connect: node_id={}, target={}",
+                                node_id, u8v_to_hexstr(query_target.as_hash().as_bytes()));
+                            let rpc = query_target.to_rpc_request(query_id);
+                            let target_peer = {
+                                match self.kbuckets.get(&node_id) {
+                                    Some(node_info) => match &node_info.peer_id {
+                                        Some(p) => Some(p.clone()),
+                                        None => None,
+                                    },
+                                    None => None,
+                                }
+                            };
+                            if let Some(peer_id) = target_peer {
+                                if self.connected_peers.contains(&peer_id) {
+                                    debug!(target: "stegos_network::kad", "sending event to node: node_id={}, peer_id={}", node_id, peer_id.to_base58());
+                                    return Async::Ready(NetworkBehaviourAction::SendEvent {
+                                        peer_id: peer_id.clone(),
+                                        event: rpc,
+                                    });
+                                } else {
+                                    debug!(target: "stegos_network::kad", "dialing node: node_id={}, peer_id={}", node_id, peer_id.to_base58());
+                                    self.pending_rpcs.push((node_id.clone(), rpc));
+                                    return Async::Ready(NetworkBehaviourAction::DialPeer {
+                                        peer_id: peer_id.clone(),
+                                    });
+                                }
+                            } else {
+                                debug!(target: "stegos_network::kad", "Can't find peer_id for node: node_id={}", node_id);
+                                nodes_without_peerids.push(node_id.clone());
+                            }
+                        }
+                        Async::Ready(QueryStatePollOut::CancelRpc { node_id }) => {
+                            // We don't cancel if the RPC has already been sent out.
+                            self.pending_rpcs.retain(|(id, _)| id != node_id);
+                        }
+                        Async::NotReady => break,
+                    }
+                }
+            }
+
+            if !nodes_without_peerids.is_empty() {
+                for node in nodes_without_peerids.iter() {
+                    for (query, _, _) in self.active_queries.values_mut() {
+                        query.inject_rpc_error(&node);
+                    }
+                }
+            }
+
+            if let Some(finished_query) = finished_query {
+                let (query, purpose, provider_peers) = self
+                    .active_queries
+                    .remove(&finished_query)
+                    .expect("finished_query was gathered when iterating active_queries; QED.");
+                match purpose {
+                    QueryPurpose::Initialization => {}
+                    QueryPurpose::UserRequest => {
+                        let event = match query.target().clone() {
+                            QueryTarget::FindPeer(key) => {
+                                debug_assert!(provider_peers.is_empty());
+                                KademliaOut::FindNodeResult {
+                                    key,
+                                    closer_peers: query.into_closest_peers().collect(),
+                                }
+                            }
+                            QueryTarget::GetProviders(key) => KademliaOut::GetProvidersResult {
+                                key,
+                                closer_peers: query.into_closest_peers().collect(),
+                                provider_peers,
+                            },
+                        };
+
+                        break Async::Ready(NetworkBehaviourAction::GenerateEvent(event));
+                    }
+                    QueryPurpose::AddProvider(key) => {
+                        for closest in query.into_closest_peers() {
+                            let node_info = match self.kbuckets.get(&closest) {
+                                Some(n) => n,
+                                None => continue,
+                            };
+                            if let Some(peer_id) = &node_info.peer_id {
+                                let event = NetworkBehaviourAction::SendEvent {
+                                    peer_id: peer_id.clone(),
+                                    event: KademliaHandlerIn::AddProvider {
+                                        key: key.clone(),
+                                        provider_peer: build_kad_peer(
+                                            self.my_id.clone(),
+                                            parameters,
+                                            &self.kbuckets,
+                                        ),
+                                    },
+                                };
+                                self.queued_events.push(event);
+                            }
+                        }
+                    }
+                }
+            } else {
+                break Async::NotReady;
+            }
+        }
+    }
+}
+
+/// Output event of the `Kademlia` behaviour.
+#[derive(Debug, Clone)]
+pub enum KademliaOut {
+    /// We have discovered a node.
+    Discovered {
+        /// PBC PublicKey of the Node
+        node_id: secure::PublicKey,
+        /// Id of the node that was discovered.
+        peer_id: Option<PeerId>,
+        /// Addresses of the node.
+        addresses: Vec<Multiaddr>,
+        /// How the reporter is connected to the reported.
+        ty: KadConnectionType,
+    },
+
+    /// Result of a `FIND_NODE` iterative query.
+    FindNodeResult {
+        /// The key that we looked for in the query.
+        key: Multihash,
+        /// List of peers ordered from closest to furthest away.
+        closer_peers: Vec<secure::PublicKey>,
+    },
+
+    /// Result of a `GET_PROVIDERS` iterative query.
+    GetProvidersResult {
+        /// The key that we looked for in the query.
+        key: Multihash,
+        /// The peers that are providing the requested key.
+        provider_peers: Vec<secure::PublicKey>,
+        /// List of peers ordered from closest to furthest away.
+        closer_peers: Vec<secure::PublicKey>,
+    },
+}
+
+// Generates a random `Multihash (SHA3-512)` that belongs to the given bucket.
+//
+// Returns an error if `bucket_num` is out of range.
+fn gen_random_hash(my_id: &Multihash, bucket_num: usize) -> Result<Multihash, ()> {
+    let my_id_len = my_id.as_bytes().len();
+
+    // TODO: this 2 is magic here; it is the length of the hash of the multihash
+    let bits_diff = bucket_num + 1;
+    if bits_diff > 8 * (my_id_len - 2) {
+        return Err(());
+    }
+
+    let mut random_id = [0; 128];
+    for byte in 0..my_id_len {
+        match byte.cmp(&(my_id_len - bits_diff / 8 - 1)) {
+            Ordering::Less => {
+                random_id[byte] = my_id.as_bytes()[byte];
+            }
+            Ordering::Equal => {
+                let mask: u8 = (1 << (bits_diff % 8)) - 1;
+                random_id[byte] = (my_id.as_bytes()[byte] & !mask) | (rand::random::<u8>() & mask);
+            }
+            Ordering::Greater => {
+                random_id[byte] = rand::random();
+            }
+        }
+    }
+
+    let random_hash = Multihash::from_bytes(random_id[..my_id_len].to_owned())
+        .expect("randomly-generated Multihash should always be valid");
+    Ok(random_hash)
+}
+
+/// Builds a `KadPeer` struct corresponding to the given `NodeId`.
+/// The `PeerId` can be the same as the local one.
+///
+/// > **Note**: This is just a convenience function that doesn't do anything note-worthy.
+fn build_kad_peer(
+    node_id: secure::PublicKey,
+    parameters: &mut PollParameters<'_>,
+    kbuckets: &KBucketsTable<secure::PublicKey, NodeInfo>,
+) -> KadPeer {
+    let is_self = node_id == *kbuckets.my_id();
+
+    let (peer_id, multiaddrs, connection_ty) = if is_self {
+        let addrs = parameters.external_addresses().map(|v| v.clone()).collect();
+        (
+            Some(parameters.local_peer_id().clone()),
+            addrs,
+            KadConnectionType::Connected,
+        )
+    } else if let Some(node_info) = kbuckets.get(&node_id) {
+        let connected = if node_info.addresses.is_connected() {
+            KadConnectionType::Connected
+        } else {
+            // TODO: there's also pending connection
+            KadConnectionType::NotConnected
+        };
+
+        let peer_id = if let Some(peer) = &node_info.peer_id {
+            Some(peer.clone())
+        } else {
+            None
+        };
+
+        (
+            peer_id,
+            node_info.addresses.iter().cloned().collect(),
+            connected,
+        )
+    } else {
+        // TODO: there's also pending connection
+        (None, Vec::new(), KadConnectionType::NotConnected)
+    };
+
+    KadPeer {
+        node_id: node_id.clone(),
+        peer_id,
+        multiaddrs,
+        connection_ty,
+    }
+}

--- a/network/src/kad/dht_proto.rs
+++ b/network/src/kad/dht_proto.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/dht/mod.rs"));

--- a/network/src/kad/handler.rs
+++ b/network/src/kad/handler.rs
@@ -1,0 +1,781 @@
+// Copyright 2019 Stegos AG
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use super::protocol::{
+    KadInStreamSink, KadOutStreamSink, KadPeer, KadRequestMsg, KadResponseMsg,
+    KademliaProtocolConfig,
+};
+use futures::prelude::*;
+use libp2p::core::protocols_handler::{
+    KeepAlive, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr,
+};
+use libp2p::core::{either::EitherOutput, upgrade, InboundUpgrade, OutboundUpgrade};
+use libp2p::multihash::Multihash;
+use std::{error, fmt, io, time::Duration, time::Instant};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Protocol handler that handles Kademlia communications with the remote.
+///
+/// The handler will automatically open a Kademlia substream with the remote for each request we
+/// make.
+///
+/// It also handles requests made by the remote.
+pub struct KademliaHandler<TSubstream, TUserData>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    /// Configuration for the Kademlia protocol.
+    config: KademliaProtocolConfig,
+
+    /// If false, we always refuse incoming Kademlia substreams.
+    allow_listening: bool,
+
+    /// Next unique ID of a connection.
+    next_connec_unique_id: UniqueConnecId,
+
+    /// List of active substreams with the state they are in.
+    substreams: Vec<SubstreamState<TSubstream, TUserData>>,
+
+    /// Until when to keep the connection alive.
+    keep_alive: KeepAlive,
+}
+
+/// State of an active substream, opened either by us or by the remote.
+enum SubstreamState<TSubstream, TUserData>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    /// We haven't started opening the outgoing substream yet.
+    /// Contains the request we want to send, and the user data if we expect an answer.
+    OutPendingOpen(KadRequestMsg, Option<TUserData>),
+    /// We are waiting for the outgoing substream to be upgraded.
+    /// Contains the request we want to send, and the user data if we expect an answer.
+    OutPendingUpgrade(KadRequestMsg, Option<TUserData>),
+    /// Waiting to send a message to the remote.
+    OutPendingSend(
+        KadOutStreamSink<TSubstream>,
+        KadRequestMsg,
+        Option<TUserData>,
+    ),
+    /// Waiting to send a message to the remote.
+    /// Waiting to flush the substream so that the data arrives to the remote.
+    OutPendingFlush(KadOutStreamSink<TSubstream>, Option<TUserData>),
+    /// Waiting for an answer back from the remote.
+    // TODO: add timeout
+    OutWaitingAnswer(KadOutStreamSink<TSubstream>, TUserData),
+    /// An error happened on the substream and we should report the error to the user.
+    OutReportError(KademliaHandlerQueryErr, TUserData),
+    /// The substream is being closed.
+    OutClosing(KadOutStreamSink<TSubstream>),
+    /// Waiting for a request from the remote.
+    InWaitingMessage(UniqueConnecId, KadInStreamSink<TSubstream>),
+    /// Waiting for the user to send a `KademliaHandlerIn` event containing the response.
+    InWaitingUser(UniqueConnecId, KadInStreamSink<TSubstream>),
+    /// Waiting to send an answer back to the remote.
+    InPendingSend(UniqueConnecId, KadInStreamSink<TSubstream>, KadResponseMsg),
+    /// Waiting to flush an answer back to the remote.
+    InPendingFlush(UniqueConnecId, KadInStreamSink<TSubstream>),
+    /// The substream is being closed.
+    InClosing(KadInStreamSink<TSubstream>),
+}
+
+impl<TSubstream, TUserData> SubstreamState<TSubstream, TUserData>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    /// Consumes this state and tries to close the substream.
+    ///
+    /// If the substream is not ready to be closed, returns it back.
+    fn try_close(self) -> AsyncSink<Self> {
+        match self {
+            SubstreamState::OutPendingOpen(_, _)
+            | SubstreamState::OutPendingUpgrade(_, _)
+            | SubstreamState::OutReportError(_, _) => AsyncSink::Ready,
+            SubstreamState::OutPendingSend(mut stream, _, _)
+            | SubstreamState::OutPendingFlush(mut stream, _)
+            | SubstreamState::OutWaitingAnswer(mut stream, _)
+            | SubstreamState::OutClosing(mut stream) => match stream.close() {
+                Ok(Async::Ready(())) | Err(_) => AsyncSink::Ready,
+                Ok(Async::NotReady) => AsyncSink::NotReady(SubstreamState::OutClosing(stream)),
+            },
+            SubstreamState::InWaitingMessage(_, mut stream)
+            | SubstreamState::InWaitingUser(_, mut stream)
+            | SubstreamState::InPendingSend(_, mut stream, _)
+            | SubstreamState::InPendingFlush(_, mut stream)
+            | SubstreamState::InClosing(mut stream) => match stream.close() {
+                Ok(Async::Ready(())) | Err(_) => AsyncSink::Ready,
+                Ok(Async::NotReady) => AsyncSink::NotReady(SubstreamState::InClosing(stream)),
+            },
+        }
+    }
+}
+
+/// Event produced by the Kademlia handler.
+#[derive(Debug)]
+pub enum KademliaHandlerEvent<TUserData> {
+    /// Request for the list of nodes whose IDs are the closest to `key`. The number of nodes
+    /// returned is not specified, but should be around 20.
+    FindNodeReq {
+        /// Identifier of the node.
+        key: Multihash,
+        /// Identifier of the request. Needs to be passed back when answering.
+        request_id: KademliaRequestId,
+    },
+
+    /// Response to an `KademliaHandlerIn::FindNodeReq`.
+    FindNodeRes {
+        /// Results of the request.
+        closer_peers: Vec<KadPeer>,
+        /// The user data passed to the `FindNodeReq`.
+        user_data: TUserData,
+    },
+
+    /// Same as `FindNodeReq`, but should also return the entries of the local providers list for
+    /// this key.
+    GetProvidersReq {
+        /// Identifier being searched.
+        key: Multihash,
+        /// Identifier of the request. Needs to be passed back when answering.
+        request_id: KademliaRequestId,
+    },
+
+    /// Response to an `KademliaHandlerIn::GetProvidersReq`.
+    GetProvidersRes {
+        /// Nodes closest to the key.
+        closer_peers: Vec<KadPeer>,
+        /// Known providers for this key.
+        provider_peers: Vec<KadPeer>,
+        /// The user data passed to the `GetProvidersReq`.
+        user_data: TUserData,
+    },
+
+    /// An error happened when performing a query.
+    QueryError {
+        /// The error that happened.
+        error: KademliaHandlerQueryErr,
+        /// The user data passed to the query.
+        user_data: TUserData,
+    },
+
+    /// The remote indicates that this list of providers is known for this key.
+    AddProvider {
+        /// Key for which we should add providers.
+        key: Multihash,
+        /// Known provider for this key.
+        provider_peer: KadPeer,
+    },
+}
+
+/// Error that can happen when requesting an RPC query.
+#[derive(Debug)]
+pub enum KademliaHandlerQueryErr {
+    /// Error while trying to perform the query.
+    Upgrade(ProtocolsHandlerUpgrErr<io::Error>),
+    /// Received an answer that doesn't correspond to the request.
+    UnexpectedMessage,
+    /// I/O error in the substream.
+    Io(io::Error),
+}
+
+impl fmt::Display for KademliaHandlerQueryErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            KademliaHandlerQueryErr::Upgrade(err) => {
+                write!(f, "Error while performing Kademlia query: {}", err)
+            }
+            KademliaHandlerQueryErr::UnexpectedMessage => write!(
+                f,
+                "Remote answered our Kademlia RPC query with the wrong message type"
+            ),
+            KademliaHandlerQueryErr::Io(err) => {
+                write!(f, "I/O error during a Kademlia RPC query: {}", err)
+            }
+        }
+    }
+}
+
+impl error::Error for KademliaHandlerQueryErr {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            KademliaHandlerQueryErr::Upgrade(err) => Some(err),
+            KademliaHandlerQueryErr::UnexpectedMessage => None,
+            KademliaHandlerQueryErr::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<ProtocolsHandlerUpgrErr<io::Error>> for KademliaHandlerQueryErr {
+    #[inline]
+    fn from(err: ProtocolsHandlerUpgrErr<io::Error>) -> Self {
+        KademliaHandlerQueryErr::Upgrade(err)
+    }
+}
+
+/// Event to send to the handler.
+pub enum KademliaHandlerIn<TUserData> {
+    /// Request for the list of nodes whose IDs are the closest to `key`. The number of nodes
+    /// returned is not specified, but should be around 20.
+    FindNodeReq {
+        /// Identifier of the node.
+        key: Multihash,
+        /// Custom user data. Passed back in the out event when the results arrive.
+        user_data: TUserData,
+    },
+
+    /// Response to a `FindNodeReq`.
+    FindNodeRes {
+        /// Results of the request.
+        closer_peers: Vec<KadPeer>,
+        /// Identifier of the request that was made by the remote.
+        ///
+        /// It is a logic error to use an id of the handler of a different node.
+        request_id: KademliaRequestId,
+    },
+
+    /// Same as `FindNodeReq`, but should also return the entries of the local providers list for
+    /// this key.
+    GetProvidersReq {
+        /// Identifier being searched.
+        key: Multihash,
+        /// Custom user data. Passed back in the out event when the results arrive.
+        user_data: TUserData,
+    },
+
+    /// Response to a `GetProvidersReq`.
+    GetProvidersRes {
+        /// Nodes closest to the key.
+        closer_peers: Vec<KadPeer>,
+        /// Known providers for this key.
+        provider_peers: Vec<KadPeer>,
+        /// Identifier of the request that was made by the remote.
+        ///
+        /// It is a logic error to use an id of the handler of a different node.
+        request_id: KademliaRequestId,
+    },
+
+    /// Indicates that this provider is known for this key.
+    ///
+    /// The API of the handler doesn't expose any event that allows you to know whether this
+    /// succeeded.
+    AddProvider {
+        /// Key for which we should add providers.
+        key: Multihash,
+        /// Known provider for this key.
+        provider_peer: KadPeer,
+    },
+}
+
+/// Unique identifier for a request. Must be passed back in order to answer a request from
+/// the remote.
+///
+/// We don't implement `Clone` on purpose, in order to prevent users from answering the same
+/// request twice.
+#[derive(Debug, PartialEq, Eq)]
+pub struct KademliaRequestId {
+    /// Unique identifier for an incoming connection.
+    connec_unique_id: UniqueConnecId,
+}
+
+/// Unique identifier for a connection.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct UniqueConnecId(u64);
+
+impl<TSubstream, TUserData> KademliaHandler<TSubstream, TUserData>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    /// Create a `KademliaHandler` that only allows sending messages to the remote but denying
+    /// incoming connections.
+    #[inline]
+    pub fn dial_only() -> Self {
+        KademliaHandler::with_allow_listening(false)
+    }
+
+    /// Create a `KademliaHandler` that only allows sending messages but also receive incoming
+    /// requests.
+    ///
+    /// The `Default` trait implementation wraps around this function.
+    #[inline]
+    pub fn dial_and_listen() -> Self {
+        KademliaHandler::with_allow_listening(true)
+    }
+
+    fn with_allow_listening(allow_listening: bool) -> Self {
+        KademliaHandler {
+            config: Default::default(),
+            allow_listening,
+            next_connec_unique_id: UniqueConnecId(0),
+            substreams: Vec::new(),
+            keep_alive: KeepAlive::Forever,
+        }
+    }
+}
+
+impl<TSubstream, TUserData> Default for KademliaHandler<TSubstream, TUserData>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    #[inline]
+    fn default() -> Self {
+        KademliaHandler::dial_and_listen()
+    }
+}
+
+impl<TSubstream, TUserData> ProtocolsHandler for KademliaHandler<TSubstream, TUserData>
+where
+    TSubstream: AsyncRead + AsyncWrite,
+    TUserData: Clone,
+{
+    type InEvent = KademliaHandlerIn<TUserData>;
+    type OutEvent = KademliaHandlerEvent<TUserData>;
+    type Error = io::Error; // TODO: better error type?
+    type Substream = TSubstream;
+    type InboundProtocol = upgrade::EitherUpgrade<KademliaProtocolConfig, upgrade::DeniedUpgrade>;
+    type OutboundProtocol = KademliaProtocolConfig;
+    // Message of the request to send to the remote, and user data if we expect an answer.
+    type OutboundOpenInfo = (KadRequestMsg, Option<TUserData>);
+
+    #[inline]
+    fn listen_protocol(&self) -> Self::InboundProtocol {
+        if self.allow_listening {
+            upgrade::EitherUpgrade::A(self.config)
+        } else {
+            upgrade::EitherUpgrade::B(upgrade::DeniedUpgrade)
+        }
+    }
+
+    fn inject_fully_negotiated_outbound(
+        &mut self,
+        protocol: <Self::OutboundProtocol as OutboundUpgrade<TSubstream>>::Output,
+        (msg, user_data): Self::OutboundOpenInfo,
+    ) {
+        self.substreams
+            .push(SubstreamState::OutPendingSend(protocol, msg, user_data));
+    }
+
+    fn inject_fully_negotiated_inbound(
+        &mut self,
+        protocol: <Self::InboundProtocol as InboundUpgrade<TSubstream>>::Output,
+    ) {
+        // If `self.allow_listening` is false, then we produced a `DeniedUpgrade` and `protocol`
+        // is a `Void`.
+        let protocol = match protocol {
+            EitherOutput::First(p) => p,
+            EitherOutput::Second(p) => void::unreachable(p),
+        };
+
+        debug_assert!(self.allow_listening);
+        let connec_unique_id = self.next_connec_unique_id;
+        self.next_connec_unique_id.0 += 1;
+        self.substreams
+            .push(SubstreamState::InWaitingMessage(connec_unique_id, protocol));
+    }
+
+    #[inline]
+    fn inject_event(&mut self, message: KademliaHandlerIn<TUserData>) {
+        match message {
+            KademliaHandlerIn::FindNodeReq { key, user_data } => {
+                let msg = KadRequestMsg::FindNode { key: key.clone() };
+                self.substreams
+                    .push(SubstreamState::OutPendingOpen(msg, Some(user_data.clone())));
+            }
+            KademliaHandlerIn::FindNodeRes {
+                closer_peers,
+                request_id,
+            } => {
+                let pos = self.substreams.iter().position(|state| match state {
+                    SubstreamState::InWaitingUser(ref conn_id, _)
+                        if conn_id == &request_id.connec_unique_id =>
+                    {
+                        true
+                    }
+                    _ => false,
+                });
+
+                if let Some(pos) = pos {
+                    let (conn_id, substream) = match self.substreams.remove(pos) {
+                        SubstreamState::InWaitingUser(conn_id, substream) => (conn_id, substream),
+                        _ => unreachable!(),
+                    };
+
+                    let msg = KadResponseMsg::FindNode {
+                        closer_peers: closer_peers.clone(),
+                    };
+                    self.substreams
+                        .push(SubstreamState::InPendingSend(conn_id, substream, msg));
+                }
+            }
+            KademliaHandlerIn::GetProvidersReq { key, user_data } => {
+                let msg = KadRequestMsg::GetProviders { key: key.clone() };
+                self.substreams
+                    .push(SubstreamState::OutPendingOpen(msg, Some(user_data.clone())));
+            }
+            KademliaHandlerIn::GetProvidersRes {
+                closer_peers,
+                provider_peers,
+                request_id,
+            } => {
+                let pos = self.substreams.iter().position(|state| match state {
+                    SubstreamState::InWaitingUser(ref conn_id, _)
+                        if conn_id == &request_id.connec_unique_id =>
+                    {
+                        true
+                    }
+                    _ => false,
+                });
+
+                if let Some(pos) = pos {
+                    let (conn_id, substream) = match self.substreams.remove(pos) {
+                        SubstreamState::InWaitingUser(conn_id, substream) => (conn_id, substream),
+                        _ => unreachable!(),
+                    };
+
+                    let msg = KadResponseMsg::GetProviders {
+                        closer_peers: closer_peers.clone(),
+                        provider_peers: provider_peers.clone(),
+                    };
+                    self.substreams
+                        .push(SubstreamState::InPendingSend(conn_id, substream, msg));
+                }
+            }
+            KademliaHandlerIn::AddProvider { key, provider_peer } => {
+                let msg = KadRequestMsg::AddProvider {
+                    key: key.clone(),
+                    provider_peer: provider_peer.clone(),
+                };
+                self.substreams
+                    .push(SubstreamState::OutPendingOpen(msg, None));
+            }
+        }
+    }
+
+    #[inline]
+    fn inject_dial_upgrade_error(
+        &mut self,
+        (_, user_data): Self::OutboundOpenInfo,
+        error: ProtocolsHandlerUpgrErr<io::Error>,
+    ) {
+        // TODO: cache the fact that the remote doesn't support kademlia at all, so that we don't
+        //       continue trying
+        if let Some(user_data) = user_data {
+            self.substreams
+                .push(SubstreamState::OutReportError(error.into(), user_data));
+        }
+    }
+
+    #[inline]
+    fn connection_keep_alive(&self) -> KeepAlive {
+        self.keep_alive
+    }
+
+    fn poll(
+        &mut self,
+    ) -> Poll<
+        ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent>,
+        io::Error,
+    > {
+        // We remove each element from `substreams` one by one and add them back.
+        for n in (0..self.substreams.len()).rev() {
+            let mut substream = self.substreams.swap_remove(n);
+
+            loop {
+                match advance_substream(substream, self.config) {
+                    (Some(new_state), Some(event), _) => {
+                        self.substreams.push(new_state);
+                        return Ok(Async::Ready(event));
+                    }
+                    (None, Some(event), _) => {
+                        return Ok(Async::Ready(event));
+                    }
+                    (Some(new_state), None, false) => {
+                        self.substreams.push(new_state);
+                        break;
+                    }
+                    (Some(new_state), None, true) => {
+                        substream = new_state;
+                        continue;
+                    }
+                    (None, None, _) => {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if self.substreams.is_empty() {
+            self.keep_alive = KeepAlive::Until(Instant::now() + Duration::from_secs(10));
+        } else {
+            self.keep_alive = KeepAlive::Forever;
+        }
+
+        Ok(Async::NotReady)
+    }
+}
+
+/// Advances one substream.
+///
+/// Returns the new state for that substream, an event to generate, and whether the substream
+/// should be polled again.
+fn advance_substream<TSubstream, TUserData>(
+    state: SubstreamState<TSubstream, TUserData>,
+    upgrade: KademliaProtocolConfig,
+) -> (
+    Option<SubstreamState<TSubstream, TUserData>>,
+    Option<
+        ProtocolsHandlerEvent<
+            KademliaProtocolConfig,
+            (KadRequestMsg, Option<TUserData>),
+            KademliaHandlerEvent<TUserData>,
+        >,
+    >,
+    bool,
+)
+where
+    TSubstream: AsyncRead + AsyncWrite,
+{
+    match state {
+        SubstreamState::OutPendingOpen(msg, user_data) => {
+            let ev = ProtocolsHandlerEvent::OutboundSubstreamRequest {
+                upgrade,
+                info: (msg, user_data),
+            };
+            (None, Some(ev), false)
+        }
+        SubstreamState::OutPendingUpgrade(msg, user_data) => (
+            Some(SubstreamState::OutPendingUpgrade(msg, user_data)),
+            None,
+            false,
+        ),
+        SubstreamState::OutPendingSend(mut substream, msg, user_data) => {
+            match substream.start_send(msg) {
+                Ok(AsyncSink::Ready) => (
+                    Some(SubstreamState::OutPendingFlush(substream, user_data)),
+                    None,
+                    true,
+                ),
+                Ok(AsyncSink::NotReady(msg)) => (
+                    Some(SubstreamState::OutPendingSend(substream, msg, user_data)),
+                    None,
+                    false,
+                ),
+                Err(error) => {
+                    let event = if let Some(user_data) = user_data {
+                        Some(ProtocolsHandlerEvent::Custom(
+                            KademliaHandlerEvent::QueryError {
+                                error: KademliaHandlerQueryErr::Io(error),
+                                user_data,
+                            },
+                        ))
+                    } else {
+                        None
+                    };
+
+                    (None, event, false)
+                }
+            }
+        }
+        SubstreamState::OutPendingFlush(mut substream, user_data) => {
+            match substream.poll_complete() {
+                Ok(Async::Ready(())) => {
+                    if let Some(user_data) = user_data {
+                        (
+                            Some(SubstreamState::OutWaitingAnswer(substream, user_data)),
+                            None,
+                            true,
+                        )
+                    } else {
+                        (Some(SubstreamState::OutClosing(substream)), None, true)
+                    }
+                }
+                Ok(Async::NotReady) => (
+                    Some(SubstreamState::OutPendingFlush(substream, user_data)),
+                    None,
+                    false,
+                ),
+                Err(error) => {
+                    let event = if let Some(user_data) = user_data {
+                        Some(ProtocolsHandlerEvent::Custom(
+                            KademliaHandlerEvent::QueryError {
+                                error: KademliaHandlerQueryErr::Io(error),
+                                user_data,
+                            },
+                        ))
+                    } else {
+                        None
+                    };
+
+                    (None, event, false)
+                }
+            }
+        }
+        SubstreamState::OutWaitingAnswer(mut substream, user_data) => match substream.poll() {
+            Ok(Async::Ready(Some(msg))) => {
+                let new_state = SubstreamState::OutClosing(substream);
+                let event = process_kad_response(msg, user_data);
+                (
+                    Some(new_state),
+                    Some(ProtocolsHandlerEvent::Custom(event)),
+                    true,
+                )
+            }
+            Ok(Async::NotReady) => (
+                Some(SubstreamState::OutWaitingAnswer(substream, user_data)),
+                None,
+                false,
+            ),
+            Err(error) => {
+                let event = KademliaHandlerEvent::QueryError {
+                    error: KademliaHandlerQueryErr::Io(error),
+                    user_data,
+                };
+                (None, Some(ProtocolsHandlerEvent::Custom(event)), false)
+            }
+            Ok(Async::Ready(None)) => {
+                let event = KademliaHandlerEvent::QueryError {
+                    error: KademliaHandlerQueryErr::Io(io::ErrorKind::UnexpectedEof.into()),
+                    user_data,
+                };
+                (None, Some(ProtocolsHandlerEvent::Custom(event)), false)
+            }
+        },
+        SubstreamState::OutReportError(error, user_data) => {
+            let event = KademliaHandlerEvent::QueryError { error, user_data };
+            (None, Some(ProtocolsHandlerEvent::Custom(event)), false)
+        }
+        SubstreamState::OutClosing(mut stream) => match stream.close() {
+            Ok(Async::Ready(())) => (None, None, false),
+            Ok(Async::NotReady) => (Some(SubstreamState::OutClosing(stream)), None, false),
+            Err(_) => (None, None, false),
+        },
+        SubstreamState::InWaitingMessage(id, mut substream) => match substream.poll() {
+            Ok(Async::Ready(Some(msg))) => {
+                if let Ok(ev) = process_kad_request(msg, id) {
+                    (
+                        Some(SubstreamState::InWaitingUser(id, substream)),
+                        Some(ProtocolsHandlerEvent::Custom(ev)),
+                        false,
+                    )
+                } else {
+                    (Some(SubstreamState::InClosing(substream)), None, true)
+                }
+            }
+            Ok(Async::NotReady) => (
+                Some(SubstreamState::InWaitingMessage(id, substream)),
+                None,
+                false,
+            ),
+            Ok(Async::Ready(None)) | Err(_) => (None, None, false),
+        },
+        SubstreamState::InWaitingUser(id, substream) => (
+            Some(SubstreamState::InWaitingUser(id, substream)),
+            None,
+            false,
+        ),
+        SubstreamState::InPendingSend(id, mut substream, msg) => match substream.start_send(msg) {
+            Ok(AsyncSink::Ready) => (
+                Some(SubstreamState::InPendingFlush(id, substream)),
+                None,
+                true,
+            ),
+            Ok(AsyncSink::NotReady(msg)) => (
+                Some(SubstreamState::InPendingSend(id, substream, msg)),
+                None,
+                false,
+            ),
+            Err(_) => (None, None, false),
+        },
+        SubstreamState::InPendingFlush(id, mut substream) => match substream.poll_complete() {
+            Ok(Async::Ready(())) => (
+                Some(SubstreamState::InWaitingMessage(id, substream)),
+                None,
+                true,
+            ),
+            Ok(Async::NotReady) => (
+                Some(SubstreamState::InPendingFlush(id, substream)),
+                None,
+                false,
+            ),
+            Err(_) => (None, None, false),
+        },
+        SubstreamState::InClosing(mut stream) => match stream.close() {
+            Ok(Async::Ready(())) => (None, None, false),
+            Ok(Async::NotReady) => (Some(SubstreamState::InClosing(stream)), None, false),
+            Err(_) => (None, None, false),
+        },
+    }
+}
+
+/// Processes a Kademlia message that's expected to be a request from a remote.
+fn process_kad_request<TUserData>(
+    event: KadRequestMsg,
+    connec_unique_id: UniqueConnecId,
+) -> Result<KademliaHandlerEvent<TUserData>, io::Error> {
+    match event {
+        KadRequestMsg::Ping => {
+            // TODO: implement; although in practice the PING message is never
+            //       used, so we may consider removing it altogether
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "the PING Kademlia message is not implemented",
+            ))
+        }
+        KadRequestMsg::FindNode { key } => Ok(KademliaHandlerEvent::FindNodeReq {
+            key,
+            request_id: KademliaRequestId { connec_unique_id },
+        }),
+        KadRequestMsg::GetProviders { key } => Ok(KademliaHandlerEvent::GetProvidersReq {
+            key,
+            request_id: KademliaRequestId { connec_unique_id },
+        }),
+        KadRequestMsg::AddProvider { key, provider_peer } => {
+            Ok(KademliaHandlerEvent::AddProvider { key, provider_peer })
+        }
+    }
+}
+
+/// Process a Kademlia message that's supposed to be a response to one of our requests.
+fn process_kad_response<TUserData>(
+    event: KadResponseMsg,
+    user_data: TUserData,
+) -> KademliaHandlerEvent<TUserData> {
+    // TODO: must check that the response corresponds to the request
+    match event {
+        KadResponseMsg::Pong => {
+            // We never send out pings.
+            KademliaHandlerEvent::QueryError {
+                error: KademliaHandlerQueryErr::UnexpectedMessage,
+                user_data,
+            }
+        }
+        KadResponseMsg::FindNode { closer_peers } => KademliaHandlerEvent::FindNodeRes {
+            closer_peers,
+            user_data,
+        },
+        KadResponseMsg::GetProviders {
+            closer_peers,
+            provider_peers,
+        } => KademliaHandlerEvent::GetProvidersRes {
+            closer_peers,
+            provider_peers,
+            user_data,
+        },
+    }
+}

--- a/network/src/kad/kbucket.rs
+++ b/network/src/kad/kbucket.rs
@@ -1,0 +1,721 @@
+// Copyright 2019 Stegos AG
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Key-value storage, with a refresh and a time-to-live system.
+//!
+//! A k-buckets table allows one to store a value identified by keys, ordered by their distance
+//! to a reference key passed to the constructor.
+//!
+//! If the local ID has `N` bits, then the k-buckets table contains `N` *buckets* each containing
+//! a constant number of entries. Storing a key in the k-buckets table adds it to the bucket
+//! corresponding to its distance with the reference key.
+
+use crate::utils::IntoMultihash;
+use arrayvec::ArrayVec;
+use bigint::U512;
+use libp2p::core::PeerId;
+use libp2p::multihash::Multihash;
+use std::slice::IterMut as SliceIterMut;
+use std::time::{Duration, Instant};
+use std::vec::IntoIter as VecIntoIter;
+use stegos_crypto::pbc::secure;
+
+/// Maximum number of nodes in a bucket.
+pub const MAX_NODES_PER_BUCKET: usize = 20;
+
+/// Table of k-buckets.
+#[derive(Debug, Clone)]
+pub struct KBucketsTable<TPeerId, TVal> {
+    /// Peer ID of the local node.
+    my_id: TPeerId,
+    /// The actual tables that store peers or values.
+    tables: Vec<KBucket<TPeerId, TVal>>,
+    /// The timeout when trying to reach the first node after which we consider it unresponsive.
+    unresponsive_timeout: Duration,
+}
+
+/// An individual table that stores peers or values.
+#[derive(Debug, Clone)]
+struct KBucket<TPeerId, TVal> {
+    /// Nodes are always ordered from oldest to newest. The nodes we are connected to are always
+    /// all on top of the nodes we are not connected to.
+    nodes: ArrayVec<[Node<TPeerId, TVal>; MAX_NODES_PER_BUCKET]>,
+
+    /// Index in `nodes` over which all nodes are connected. Must always be <= to the length
+    /// of `nodes`.
+    first_connected_pos: usize,
+
+    /// Node received when the bucket was full. Will be added to the list if the first node doesn't
+    /// respond in time to our reach attempt. The second element is the time when the pending node
+    /// was added. If it is too old we drop the first node and add the pending node to the end of
+    /// the list.
+    pending_node: Option<(Node<TPeerId, TVal>, Instant)>,
+
+    /// Last time this bucket was updated.
+    latest_update: Instant,
+}
+
+/// A single node in a k-bucket.
+#[derive(Debug, Clone)]
+struct Node<TPeerId, TVal> {
+    /// Id of the node.
+    id: TPeerId,
+    /// Value associated to it.
+    value: TVal,
+}
+
+impl<TPeerId, TVal> KBucket<TPeerId, TVal> {
+    /// Puts the kbucket into a coherent state.
+    /// If a node is pending and the timeout has expired, removes the first element of `nodes`
+    /// and puts the node back in `pending_node`.
+    fn flush(&mut self, timeout: Duration) {
+        if let Some((pending_node, instant)) = self.pending_node.take() {
+            if instant.elapsed() >= timeout {
+                let _ = self.nodes.remove(0);
+                self.nodes.push(pending_node);
+            } else {
+                self.pending_node = Some((pending_node, instant));
+            }
+        }
+    }
+}
+
+/// Trait that must be implemented on types that can be used as an identifier in a k-bucket.
+pub trait KBucketsPeerId<TOther = Self>: IntoMultihash + Clone {
+    /// Computes the XOR of this value and another one. The lower the closer.
+    fn distance_with(&self, other: &TOther) -> u32;
+
+    /// Returns then number of bits that are necessary to store the distance between peer IDs.
+    /// Used for pre-allocations.
+    ///
+    /// > **Note**: Returning 0 would lead to a panic.
+    fn max_distance() -> usize;
+}
+
+impl KBucketsPeerId for PeerId {
+    #[inline]
+    fn distance_with(&self, other: &Self) -> u32 {
+        Multihash::distance_with(self.as_ref(), other.as_ref())
+    }
+
+    #[inline]
+    fn max_distance() -> usize {
+        <Multihash as KBucketsPeerId>::max_distance()
+    }
+}
+
+impl KBucketsPeerId<Multihash> for PeerId {
+    #[inline]
+    fn distance_with(&self, other: &Multihash) -> u32 {
+        Multihash::distance_with(self.as_ref(), other)
+    }
+
+    #[inline]
+    fn max_distance() -> usize {
+        <Multihash as KBucketsPeerId>::max_distance()
+    }
+}
+
+impl KBucketsPeerId for secure::PublicKey {
+    #[inline]
+    fn distance_with(&self, other: &Self) -> u32 {
+        Multihash::distance_with(
+            &self.clone().into_multihash(),
+            &other.clone().into_multihash(),
+        )
+    }
+
+    #[inline]
+    fn max_distance() -> usize {
+        <Multihash as KBucketsPeerId>::max_distance()
+    }
+}
+
+impl KBucketsPeerId<Multihash> for secure::PublicKey {
+    #[inline]
+    fn distance_with(&self, other: &Multihash) -> u32 {
+        Multihash::distance_with(&self.clone().into_multihash(), other)
+    }
+
+    #[inline]
+    fn max_distance() -> usize {
+        <Multihash as KBucketsPeerId>::max_distance()
+    }
+}
+
+impl KBucketsPeerId for Multihash {
+    #[inline]
+    fn distance_with(&self, other: &Self) -> u32 {
+        // Note that we don't compare the hash functions because there's no chance of collision
+        // of the same value hashed with two different hash functions.
+        let my_hash = U512::from(self.digest());
+        let other_hash = U512::from(other.digest());
+        let xor = my_hash ^ other_hash;
+        512 - xor.leading_zeros()
+    }
+
+    #[inline]
+    fn max_distance() -> usize {
+        512
+    }
+}
+
+impl<TPeerId, TVal> KBucketsTable<TPeerId, TVal>
+where
+    TPeerId: KBucketsPeerId + PartialEq,
+{
+    /// Builds a new routing table.
+    pub fn new(my_id: TPeerId, unresponsive_timeout: Duration) -> Self {
+        KBucketsTable {
+            my_id,
+            tables: (0..TPeerId::max_distance())
+                .map(|_| KBucket {
+                    nodes: ArrayVec::new(),
+                    first_connected_pos: 0,
+                    pending_node: None,
+                    latest_update: Instant::now(),
+                })
+                .collect(),
+            unresponsive_timeout,
+        }
+    }
+
+    // Returns the id of the bucket that should contain the peer with the given ID.
+    //
+    // Returns `None` if out of range, which happens if `id` is the same as the local peer id.
+    #[inline]
+    fn bucket_num(&self, id: &TPeerId) -> Option<usize> {
+        (self.my_id.distance_with(id) as usize).checked_sub(1)
+    }
+
+    /// Returns an iterator to all the buckets of this table.
+    ///
+    /// Ordered by proximity to the local node. Closest bucket (with max. one node in it) comes
+    /// first.
+    #[inline]
+    pub fn buckets(&mut self) -> BucketsIter<'_, TPeerId, TVal> {
+        BucketsIter(self.tables.iter_mut(), self.unresponsive_timeout)
+    }
+
+    #[inline]
+    pub fn size(&self) -> usize {
+        self.tables.iter().map(|t| t.nodes.len()).sum()
+    }
+
+    /// Returns the ID of the local node.
+    #[inline]
+    pub fn my_id(&self) -> &TPeerId {
+        &self.my_id
+    }
+
+    /// Returns the value associated to a node, if any is present.
+    ///
+    /// Does **not** include pending nodes.
+    pub fn get(&self, id: &TPeerId) -> Option<&TVal> {
+        let table = match self.bucket_num(&id) {
+            Some(n) => &self.tables[n],
+            None => return None,
+        };
+
+        for elem in &table.nodes {
+            if elem.id == *id {
+                return Some(&elem.value);
+            }
+        }
+
+        None
+    }
+
+    /// Returns the value associated to a node, if any is present.
+    ///
+    /// Does **not** include pending nodes.
+    pub fn get_mut(&mut self, id: &TPeerId) -> Option<&mut TVal> {
+        let table = match self.bucket_num(&id) {
+            Some(n) => &mut self.tables[n],
+            None => return None,
+        };
+
+        table.flush(self.unresponsive_timeout);
+
+        for elem in &mut table.nodes {
+            if elem.id == *id {
+                return Some(&mut elem.value);
+            }
+        }
+
+        None
+    }
+
+    /// Returns the value associated to a node if any is present. Otherwise, tries to add the
+    /// node to the table in a disconnected state and return its value. Returns `None` if `id` is
+    /// the local peer, or if the table is full.
+    pub fn entry_mut(&mut self, id: &TPeerId) -> Option<&mut TVal>
+    where
+        TVal: Default,
+    {
+        if let Some((bucket, entry)) = self.entry_mut_inner(id) {
+            Some(&mut self.tables[bucket].nodes[entry].value)
+        } else {
+            None
+        }
+    }
+
+    /// Apparently non-lexical lifetimes still aren't working properly in some situations, so we
+    /// delegate `entry_mut` to this method that returns an index within `self.tables` and the
+    /// node index within that table.
+    fn entry_mut_inner(&mut self, id: &TPeerId) -> Option<(usize, usize)>
+    where
+        TVal: Default,
+    {
+        let (bucket_num, table) = match self.bucket_num(&id) {
+            Some(n) => (n, &mut self.tables[n]),
+            None => return None,
+        };
+
+        table.flush(self.unresponsive_timeout);
+
+        if let Some(pos) = table.nodes.iter().position(|elem| elem.id == *id) {
+            table.latest_update = Instant::now();
+            return Some((bucket_num, pos));
+        }
+
+        if !table.nodes.is_full() {
+            table.nodes.insert(
+                table.first_connected_pos,
+                Node {
+                    id: id.clone(),
+                    value: Default::default(),
+                },
+            );
+            table.first_connected_pos += 1;
+            table.latest_update = Instant::now();
+            return Some((bucket_num, table.first_connected_pos - 1));
+        }
+
+        None
+    }
+
+    /// Reports that we are connected to the given node.
+    ///
+    /// This inserts the node in the k-buckets, if possible. If it is already in a k-bucket, puts
+    /// it above the disconnected nodes. If it is not already in a k-bucket, then the value will
+    /// be built with the `Default` trait.
+    pub fn set_connected(&mut self, id: &TPeerId) -> Update<'_, TPeerId>
+    where
+        TVal: Default,
+    {
+        let table = match self.bucket_num(&id) {
+            Some(n) => &mut self.tables[n],
+            None => return Update::FailSelfUpdate,
+        };
+
+        table.flush(self.unresponsive_timeout);
+
+        if let Some(pos) = table.nodes.iter().position(|elem| elem.id == *id) {
+            // Node is already in the table; move it over `first_connected_pos` if necessary.
+            // We do a `saturating_sub(1)`, because if `first_connected_pos` is 0 then
+            // `pos < first_connected_pos` can never be true anyway.
+            if pos < table.first_connected_pos.saturating_sub(1) {
+                let elem = table.nodes.remove(pos);
+                table.first_connected_pos -= 1;
+                table.nodes.insert(table.first_connected_pos, elem);
+            }
+            table.latest_update = Instant::now();
+            Update::Updated
+        } else if !table.nodes.is_full() {
+            // Node is not in the table yet, but there's plenty of space for it.
+            table.nodes.insert(
+                table.first_connected_pos,
+                Node {
+                    id: id.clone(),
+                    value: Default::default(),
+                },
+            );
+            table.latest_update = Instant::now();
+            Update::Added
+        } else if table.first_connected_pos > 0 && table.pending_node.is_none() {
+            // Node is not in the table yet, but there could be room for it if we drop the first
+            // element. However we first add the node to add to `pending_node` and try to reconnect
+            // to the oldest node.
+            let pending_node = Node {
+                id: id.clone(),
+                value: Default::default(),
+            };
+            table.pending_node = Some((pending_node, Instant::now()));
+            Update::Pending(&table.nodes[0].id)
+        } else {
+            debug_assert!(table.first_connected_pos == 0 || table.pending_node.is_some());
+            Update::Discarded
+        }
+    }
+
+    /// Reports that we are now disconnected from the given node.
+    ///
+    /// This does *not* remove the node from the k-buckets, but moves it underneath the nodes we
+    /// are still connected to.
+    pub fn set_disconnected(&mut self, id: &TPeerId) {
+        let table = match self.bucket_num(&id) {
+            Some(n) => &mut self.tables[n],
+            None => return,
+        };
+
+        table.flush(self.unresponsive_timeout);
+
+        let pos = match table.nodes.iter().position(|elem| elem.id == *id) {
+            Some(pos) => pos,
+            None => return,
+        };
+
+        if pos > table.first_connected_pos {
+            let elem = table.nodes.remove(pos);
+            table.nodes.insert(table.first_connected_pos, elem);
+            table.first_connected_pos += 1;
+        } else if pos == table.first_connected_pos {
+            table.first_connected_pos += 1;
+        }
+    }
+
+    /// Finds the `num` nodes closest to `id`, ordered by distance.
+    pub fn find_closest<TOther>(&mut self, id: &TOther) -> VecIntoIter<TPeerId>
+    where
+        TPeerId: Clone + KBucketsPeerId<TOther>,
+    {
+        // TODO: optimize
+        let mut out = Vec::new();
+        for table in self.tables.iter_mut() {
+            table.flush(self.unresponsive_timeout);
+            if table.latest_update.elapsed() > self.unresponsive_timeout {
+                continue; // ignore bucket with expired nodes
+            }
+            for node in table.nodes.iter() {
+                out.push(node.id.clone());
+            }
+        }
+        out.sort_by(|a, b| b.distance_with(id).cmp(&a.distance_with(id)));
+        out.into_iter()
+    }
+
+    /// Same as `find_closest`, but includes the local peer as well.
+    pub fn find_closest_with_self<TOther>(&mut self, id: &TOther) -> VecIntoIter<TPeerId>
+    where
+        TPeerId: Clone + KBucketsPeerId<TOther>,
+    {
+        // TODO: optimize
+        let mut intermediate: Vec<_> = self.find_closest(id).collect();
+        if let Some(pos) = intermediate
+            .iter()
+            .position(|e| e.distance_with(id) >= self.my_id.distance_with(id))
+        {
+            if intermediate[pos] != self.my_id {
+                intermediate.insert(pos, self.my_id.clone());
+            }
+        } else {
+            intermediate.push(self.my_id.clone());
+        }
+        intermediate.into_iter()
+    }
+}
+
+/// Return value of the `set_connected()` method.
+#[derive(Debug)]
+#[must_use]
+pub enum Update<'a, TPeerId> {
+    /// The node has been added to the bucket.
+    Added,
+    /// The node was already in the bucket and has been updated.
+    Updated,
+    /// The node has been added as pending. We need to try connect to the node passed as parameter.
+    Pending(&'a TPeerId),
+    /// The node wasn't added at all because a node was already pending.
+    Discarded,
+    /// Tried to update the local peer ID. This is an invalid operation.
+    FailSelfUpdate,
+}
+
+/// Iterator giving access to a bucket.
+pub struct BucketsIter<'a, TPeerId, TVal>(SliceIterMut<'a, KBucket<TPeerId, TVal>>, Duration);
+
+impl<'a, TPeerId, TVal> Iterator for BucketsIter<'a, TPeerId, TVal> {
+    type Item = Bucket<'a, TPeerId, TVal>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|bucket| {
+            bucket.flush(self.1);
+            Bucket(bucket)
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a, TPeerId, TVal> ExactSizeIterator for BucketsIter<'a, TPeerId, TVal> {}
+
+/// Access to a bucket.
+pub struct Bucket<'a, TPeerId, TVal>(&'a mut KBucket<TPeerId, TVal>);
+
+impl<'a, TPeerId, TVal> Bucket<'a, TPeerId, TVal> {
+    /// Returns the number of entries in that bucket.
+    ///
+    /// > **Note**: Keep in mind that this operation can be racy. If `update()` is called on the
+    /// >           table while this function is running, the `update()` may or may not be taken
+    /// >           into account.
+    #[inline]
+    pub fn num_entries(&self) -> usize {
+        self.0.nodes.len()
+    }
+
+    /// Returns true if this bucket has a pending node.
+    #[inline]
+    pub fn has_pending(&self) -> bool {
+        self.0.pending_node.is_some()
+    }
+
+    /// Returns the time when any of the values in this bucket was last updated.
+    ///
+    /// If the bucket is empty, this returns the time when the whole table was created.
+    #[inline]
+    pub fn latest_update(&self) -> Instant {
+        self.0.latest_update
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kad::kbucket::{KBucketsPeerId, KBucketsTable, Update, MAX_NODES_PER_BUCKET};
+    use libp2p::multihash::{Hash, Multihash};
+    use rand::random;
+    use std::thread;
+    use std::time::Duration;
+    use stegos_crypto::pbc::secure;
+
+    #[test]
+    fn basic_closest() {
+        let my_id = Multihash::random(Hash::SHA2256);
+        let other_id = Multihash::random(Hash::SHA2256);
+
+        let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
+        table.entry_mut(&other_id);
+
+        let res = table.find_closest(&other_id).collect::<Vec<_>>();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0], other_id);
+    }
+
+    #[test]
+    fn update_local_id_fails() {
+        let my_id = Multihash::random(Hash::SHA2256);
+
+        let mut table = KBucketsTable::<_, ()>::new(my_id.clone(), Duration::from_secs(5));
+        assert!(table.entry_mut(&my_id).is_none());
+        match table.set_connected(&my_id) {
+            Update::FailSelfUpdate => (),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn update_time_last_refresh() {
+        let my_id = Multihash::random(Hash::SHA2256);
+
+        // Generate some other IDs varying by just one bit.
+        let other_ids = (0..random::<usize>() % 20)
+            .map(|_| {
+                let bit_num = random::<usize>() % 256;
+                let mut id = my_id.as_bytes().to_vec().clone();
+                id[33 - (bit_num / 8)] ^= 1 << (bit_num % 8);
+                (Multihash::from_bytes(id).unwrap(), bit_num)
+            })
+            .collect::<Vec<_>>();
+
+        let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
+        let before_update = table
+            .buckets()
+            .map(|b| b.latest_update())
+            .collect::<Vec<_>>();
+
+        thread::sleep(Duration::from_secs(2));
+        for &(ref id, _) in &other_ids {
+            table.entry_mut(&id);
+        }
+
+        let after_update = table
+            .buckets()
+            .map(|b| b.latest_update())
+            .collect::<Vec<_>>();
+
+        for (offset, (bef, aft)) in before_update.iter().zip(after_update.iter()).enumerate() {
+            if other_ids.iter().any(|&(_, bucket)| bucket == offset) {
+                assert_ne!(bef, aft);
+            } else {
+                assert_eq!(bef, aft);
+            }
+        }
+    }
+
+    #[test]
+    fn full_kbucket() {
+        let my_id = Multihash::random(Hash::SHA2256);
+
+        assert!(MAX_NODES_PER_BUCKET <= 251); // Test doesn't work otherwise.
+        let mut fill_ids = (0..MAX_NODES_PER_BUCKET + 3)
+            .map(|n| {
+                let mut id = my_id.clone().into_bytes();
+                id[2] ^= 0x80; // Flip the first bit so that we get in the most distant bucket.
+                id[33] = id[33].wrapping_add(n as u8);
+                Multihash::from_bytes(id).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let first_node = fill_ids[0].clone();
+        let second_node = fill_ids[1].clone();
+
+        let mut table = KBucketsTable::<_, ()>::new(my_id.clone(), Duration::from_secs(1));
+
+        for (num, id) in fill_ids.drain(..MAX_NODES_PER_BUCKET).enumerate() {
+            match table.set_connected(&id) {
+                Update::Added => (),
+                _ => panic!(),
+            }
+            table.set_disconnected(&id);
+            assert_eq!(table.buckets().nth(255).unwrap().num_entries(), num + 1);
+        }
+
+        assert_eq!(
+            table.buckets().nth(255).unwrap().num_entries(),
+            MAX_NODES_PER_BUCKET
+        );
+        assert!(!table.buckets().nth(255).unwrap().has_pending());
+        match table.set_connected(&fill_ids.remove(0)) {
+            Update::Pending(to_ping) => {
+                assert_eq!(*to_ping, first_node);
+            }
+            _ => panic!(),
+        }
+
+        assert_eq!(
+            table.buckets().nth(255).unwrap().num_entries(),
+            MAX_NODES_PER_BUCKET
+        );
+        assert!(table.buckets().nth(255).unwrap().has_pending());
+        match table.set_connected(&fill_ids.remove(0)) {
+            Update::Discarded => (),
+            _ => panic!(),
+        }
+
+        thread::sleep(Duration::from_secs(2));
+        assert!(!table.buckets().nth(255).unwrap().has_pending());
+        match table.set_connected(&fill_ids.remove(0)) {
+            Update::Pending(to_ping) => {
+                assert_eq!(*to_ping, second_node);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn self_distance_zero() {
+        let a = Multihash::random(Hash::SHA2256);
+        assert_eq!(a.distance_with(&a), 0);
+    }
+
+    #[test]
+    fn distance_correct_order() {
+        let a = Multihash::random(Hash::SHA2256);
+        let b = Multihash::random(Hash::SHA2256);
+        assert!(a.distance_with(&a) < b.distance_with(&a));
+        assert!(a.distance_with(&b) > b.distance_with(&b));
+    }
+
+    #[test]
+    fn pbc_distance_between_keys() {
+        let (_, a, _) = secure::make_random_keys();
+        let (_, b, _) = secure::make_random_keys();
+        assert_eq!(a.distance_with(&a), 0);
+        assert!(a.distance_with(&a) < b.distance_with(&a));
+        assert!(a.distance_with(&b) > b.distance_with(&b));
+    }
+
+    #[test]
+    fn pbc_basic_closest() {
+        let (_, my_id, _) = secure::make_random_keys();
+        let (_, other_id, _) = secure::make_random_keys();
+
+        let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
+        table.entry_mut(&other_id);
+
+        let res = table.find_closest(&other_id).collect::<Vec<_>>();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0], other_id);
+    }
+
+    #[test]
+    fn pbc_update_local_id_fails() {
+        let (_, my_id, _) = secure::make_random_keys();
+
+        let mut table = KBucketsTable::<_, ()>::new(my_id.clone(), Duration::from_secs(5));
+        assert!(table.entry_mut(&my_id).is_none());
+        match table.set_connected(&my_id) {
+            Update::FailSelfUpdate => (),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn pbc_update_time_last_refresh() {
+        let (_, my_id, _) = secure::make_random_keys();
+        let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
+
+        // Generate some other IDs varying by just one bit.
+        let other_ids = (0..random::<usize>() % 128)
+            .map(|_| {
+                let (_, id, _) = secure::make_random_keys();
+                (id, table.bucket_num(&id).unwrap())
+            })
+            .collect::<Vec<_>>();
+
+        let before_update = table
+            .buckets()
+            .map(|b| b.latest_update())
+            .collect::<Vec<_>>();
+
+        thread::sleep(Duration::from_secs(2));
+        for &(ref id, _) in &other_ids {
+            table.entry_mut(&id);
+        }
+
+        let after_update = table
+            .buckets()
+            .map(|b| b.latest_update())
+            .collect::<Vec<_>>();
+
+        for (offset, (bef, aft)) in before_update.iter().zip(after_update.iter()).enumerate() {
+            if other_ids.iter().any(|&(_, bucket)| bucket == offset) {
+                assert_ne!(bef, aft);
+            } else {
+                assert_eq!(bef, aft);
+            }
+        }
+    }
+}

--- a/network/src/kad/metrics.rs
+++ b/network/src/kad/metrics.rs
@@ -1,7 +1,5 @@
 //
-// MIT License
-//
-// Copyright (c) 2018-2019 Stegos AG
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,4 +19,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-include!(concat!(env!("OUT_DIR"), "/ncp_proto/mod.rs"));
+use lazy_static::lazy_static;
+use prometheus::*;
+
+lazy_static! {
+    pub static ref KBUCKET_TABLE_SIZE: IntGauge =
+        register_int_gauge!("stegos_kad_kbutcket_table_size", "Size of k-buckets table.").unwrap();
+    pub static ref PEER_TABLE_SIZE: IntGauge =
+        register_int_gauge!("stegos_kad_peer_table_size", "Size of k-buckets table.").unwrap();
+}

--- a/network/src/kad/mod.rs
+++ b/network/src/kad/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Stegos AG.
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Kademlia protocol. Allows peer discovery, records store and records fetch.
+//!
+#![allow(dead_code)]
+
+pub use self::behaviour::{Kademlia, KademliaOut};
+pub use self::kbucket::KBucketsPeerId;
+pub use self::protocol::KadConnectionType;
+
+pub mod handler;
+pub mod kbucket;
+pub mod protocol;
+
+mod addresses;
+mod behaviour;
+mod dht_proto;
+mod metrics;
+mod query;

--- a/network/src/kad/protocol.rs
+++ b/network/src/kad/protocol.rs
@@ -1,0 +1,652 @@
+// Copyright 2019 Stegos AG
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Provides the `KadRequestMsg` and `KadResponseMsg` enums of all the possible messages
+//! transmitted with the Kademlia protocol, and the `KademliaProtocolConfig` connection upgrade.
+//!
+//! The upgrade's output a `Sink + Stream` of messages.
+//!
+//! The `Stream` component is used to poll the underlying transport, and the `Sink` component is
+//! used to send messages.
+
+use super::dht_proto;
+use bytes::BytesMut;
+use futures::{future, sink, stream, Sink, Stream};
+use libp2p::core::{InboundUpgrade, Multiaddr, OutboundUpgrade, PeerId, UpgradeInfo};
+use libp2p::multihash::Multihash;
+use protobuf::{self, Message};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::iter;
+use stegos_crypto::pbc::secure;
+use tokio::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
+use unsigned_varint::codec;
+
+/// Status of our connection to a node reported by the Kademlia protocol.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+pub enum KadConnectionType {
+    /// Sender hasn't tried to connect to peer.
+    NotConnected = 0,
+    /// Sender is currently connected to peer.
+    Connected = 1,
+    /// Sender was recently connected to peer.
+    CanConnect = 2,
+    /// Sender tried to connect to peer but failed.
+    CannotConnect = 3,
+}
+
+impl From<dht_proto::dht::Message_ConnectionType> for KadConnectionType {
+    #[inline]
+    fn from(raw: dht_proto::dht::Message_ConnectionType) -> KadConnectionType {
+        use super::dht_proto::dht::Message_ConnectionType::{
+            CANNOT_CONNECT, CAN_CONNECT, CONNECTED, NOT_CONNECTED,
+        };
+        match raw {
+            NOT_CONNECTED => KadConnectionType::NotConnected,
+            CONNECTED => KadConnectionType::Connected,
+            CAN_CONNECT => KadConnectionType::CanConnect,
+            CANNOT_CONNECT => KadConnectionType::CannotConnect,
+        }
+    }
+}
+
+impl Into<dht_proto::dht::Message_ConnectionType> for KadConnectionType {
+    #[inline]
+    fn into(self) -> dht_proto::dht::Message_ConnectionType {
+        use super::dht_proto::dht::Message_ConnectionType::{
+            CANNOT_CONNECT, CAN_CONNECT, CONNECTED, NOT_CONNECTED,
+        };
+        match self {
+            KadConnectionType::NotConnected => NOT_CONNECTED,
+            KadConnectionType::Connected => CONNECTED,
+            KadConnectionType::CanConnect => CAN_CONNECT,
+            KadConnectionType::CannotConnect => CANNOT_CONNECT,
+        }
+    }
+}
+
+/// Information about a peer, as known by the sender.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KadPeer {
+    /// Identifier of the peer.
+    pub node_id: secure::PublicKey,
+    /// Network PeerId
+    pub peer_id: Option<PeerId>,
+    /// The multiaddresses that the sender think can be used in order to reach the peer.
+    pub multiaddrs: Vec<Multiaddr>,
+    /// How the sender is connected to that remote.
+    pub connection_ty: KadConnectionType,
+}
+
+impl KadPeer {
+    fn from_peer(peer: &mut dht_proto::dht::Message_Peer) -> Result<KadPeer, IoError> {
+        let node_id = secure::PublicKey::try_from_bytes(peer.get_id()).map_err(|_| {
+            IoError::new(
+                IoErrorKind::InvalidData,
+                "bad protobuf encoding, failed to decode node_id",
+            )
+        })?;
+
+        let peer_id = if peer.has_peer_id() {
+            Some(
+                PeerId::from_bytes(peer.get_peer_id().to_vec())
+                    .map_err(|_| IoError::new(IoErrorKind::InvalidData, "invalid peer id"))?,
+            )
+        } else {
+            None
+        };
+
+        let mut addrs = Vec::with_capacity(peer.get_addrs().len());
+        for addr in peer.take_addrs().into_iter() {
+            let as_ma = Multiaddr::from_bytes(addr)
+                .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))?;
+            addrs.push(as_ma);
+        }
+        debug_assert_eq!(addrs.len(), addrs.capacity());
+
+        let connection_ty = peer.get_connection().into();
+
+        Ok(KadPeer {
+            node_id,
+            peer_id,
+            multiaddrs: addrs,
+            connection_ty,
+        })
+    }
+}
+
+impl Into<dht_proto::dht::Message_Peer> for KadPeer {
+    fn into(self) -> dht_proto::dht::Message_Peer {
+        let mut out = dht_proto::dht::Message_Peer::new();
+        out.set_id(self.node_id.to_bytes().to_vec());
+        if let Some(peer) = self.peer_id {
+            out.set_peer_id(peer.into_bytes());
+        }
+        for addr in self.multiaddrs {
+            out.mut_addrs().push(addr.into_bytes());
+        }
+        out.set_connection(self.connection_ty.into());
+        out
+    }
+}
+
+/// Configuration for a Kademlia connection upgrade. When applied to a connection, turns this
+/// connection into a `Stream + Sink` whose items are of type `KadRequestMsg` and `KadResponseMsg`.
+// TODO: if, as suspected, we can confirm with Protocol Labs that each open Kademlia substream does
+//       only one request, then we can change the output of the `InboundUpgrade` and
+//       `OutboundUpgrade` to be just a single message
+#[derive(Debug, Default, Copy, Clone)]
+pub struct KademliaProtocolConfig;
+
+impl UpgradeInfo for KademliaProtocolConfig {
+    type Info = &'static [u8];
+    type InfoIter = iter::Once<Self::Info>;
+
+    #[inline]
+    fn protocol_info(&self) -> Self::InfoIter {
+        iter::once(b"/stegos/kad/1.0.0")
+    }
+}
+
+impl<C> InboundUpgrade<C> for KademliaProtocolConfig
+where
+    C: AsyncRead + AsyncWrite,
+{
+    type Output = KadInStreamSink<C>;
+    type Future = future::FutureResult<Self::Output, IoError>;
+    type Error = IoError;
+
+    #[inline]
+    fn upgrade_inbound(self, incoming: C, _: Self::Info) -> Self::Future {
+        let mut codec = codec::UviBytes::default();
+        codec.set_max_len(4096);
+
+        future::ok(
+            Framed::new(incoming, codec)
+                .from_err::<IoError>()
+                .with::<_, fn(_) -> _, _>(|response| -> Result<_, IoError> {
+                    let proto_struct = resp_msg_to_proto(response);
+                    proto_struct
+                        .write_to_bytes()
+                        .map_err(|err| IoError::new(IoErrorKind::InvalidData, err.to_string()))
+                })
+                .and_then::<fn(_) -> _, _>(|bytes: BytesMut| {
+                    let request = protobuf::parse_from_bytes(&bytes)?;
+                    proto_to_req_msg(request)
+                }),
+        )
+    }
+}
+
+impl<C> OutboundUpgrade<C> for KademliaProtocolConfig
+where
+    C: AsyncRead + AsyncWrite,
+{
+    type Output = KadOutStreamSink<C>;
+    type Future = future::FutureResult<Self::Output, IoError>;
+    type Error = IoError;
+
+    #[inline]
+    fn upgrade_outbound(self, incoming: C, _: Self::Info) -> Self::Future {
+        let mut codec = codec::UviBytes::default();
+        codec.set_max_len(4096);
+
+        future::ok(
+            Framed::new(incoming, codec)
+                .from_err::<IoError>()
+                .with::<_, fn(_) -> _, _>(|request| -> Result<_, IoError> {
+                    let proto_struct = req_msg_to_proto(request);
+                    match proto_struct.write_to_bytes() {
+                        Ok(msg) => Ok(msg),
+                        Err(err) => Err(IoError::new(IoErrorKind::Other, err.to_string())),
+                    }
+                })
+                .and_then::<fn(_) -> _, _>(|bytes: BytesMut| {
+                    let response = protobuf::parse_from_bytes(&bytes)?;
+                    proto_to_resp_msg(response)
+                }),
+        )
+    }
+}
+
+/// Sink of responses and stream of requests.
+pub type KadInStreamSink<S> = stream::AndThen<
+    sink::With<
+        stream::FromErr<Framed<S, codec::UviBytes<Vec<u8>>>, IoError>,
+        KadResponseMsg,
+        fn(KadResponseMsg) -> Result<Vec<u8>, IoError>,
+        Result<Vec<u8>, IoError>,
+    >,
+    fn(BytesMut) -> Result<KadRequestMsg, IoError>,
+    Result<KadRequestMsg, IoError>,
+>;
+
+/// Sink of requests and stream of responses.
+pub type KadOutStreamSink<S> = stream::AndThen<
+    sink::With<
+        stream::FromErr<Framed<S, codec::UviBytes<Vec<u8>>>, IoError>,
+        KadRequestMsg,
+        fn(KadRequestMsg) -> Result<Vec<u8>, IoError>,
+        Result<Vec<u8>, IoError>,
+    >,
+    fn(BytesMut) -> Result<KadResponseMsg, IoError>,
+    Result<KadResponseMsg, IoError>,
+>;
+
+/// Request that we can send to a peer or that we received from a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KadRequestMsg {
+    /// Ping request.
+    Ping,
+
+    /// Request for the list of nodes whose IDs are the closest to `key`. The number of nodes
+    /// returned is not specified, but should be around 20.
+    FindNode {
+        /// Hash of the node's identifier
+        key: Multihash,
+    },
+
+    /// Same as `FindNode`, but should also return the entries of the local providers list for
+    /// this key.
+    GetProviders {
+        /// Identifier being searched.
+        key: Multihash,
+    },
+
+    /// Indicates that this list of providers is known for this key.
+    AddProvider {
+        /// Key for which we should add providers.
+        key: Multihash,
+        /// Known provider for this key.
+        provider_peer: KadPeer,
+    },
+}
+
+/// Response that we can send to a peer or that we received from a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KadResponseMsg {
+    /// Ping response.
+    Pong,
+
+    /// Response to a `FindNode`.
+    FindNode {
+        /// Results of the request.
+        closer_peers: Vec<KadPeer>,
+    },
+
+    /// Response to a `GetProviders`.
+    GetProviders {
+        /// Nodes closest to the key.
+        closer_peers: Vec<KadPeer>,
+        /// Known providers for this key.
+        provider_peers: Vec<KadPeer>,
+    },
+}
+
+// Turns a type-safe Kadmelia message into the corresponding raw protobuf message.
+fn req_msg_to_proto(kad_msg: KadRequestMsg) -> dht_proto::dht::Message {
+    match kad_msg {
+        KadRequestMsg::Ping => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::PING);
+            msg
+        }
+        KadRequestMsg::FindNode { key } => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::FIND_NODE);
+            msg.set_key(key.into_bytes());
+            msg.set_clusterLevelRaw(10);
+            msg
+        }
+        KadRequestMsg::GetProviders { key } => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::GET_PROVIDERS);
+            msg.set_key(key.into_bytes());
+            msg.set_clusterLevelRaw(10);
+            msg
+        }
+        KadRequestMsg::AddProvider { key, provider_peer } => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::ADD_PROVIDER);
+            msg.set_clusterLevelRaw(10);
+            msg.set_key(key.into_bytes());
+            msg.mut_providerPeers().push(provider_peer.into());
+            msg
+        }
+    }
+}
+
+// Turns a type-safe Kadmelia message into the corresponding raw protobuf message.
+fn resp_msg_to_proto(kad_msg: KadResponseMsg) -> dht_proto::dht::Message {
+    match kad_msg {
+        KadResponseMsg::Pong => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::PING);
+            msg
+        }
+        KadResponseMsg::FindNode { closer_peers } => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::FIND_NODE);
+            msg.set_clusterLevelRaw(9);
+            for peer in closer_peers {
+                msg.mut_closerPeers().push(peer.into());
+            }
+            msg
+        }
+        KadResponseMsg::GetProviders {
+            closer_peers,
+            provider_peers,
+        } => {
+            let mut msg = dht_proto::dht::Message::new();
+            msg.set_field_type(dht_proto::dht::Message_MessageType::GET_PROVIDERS);
+            msg.set_clusterLevelRaw(9);
+            for peer in closer_peers {
+                msg.mut_closerPeers().push(peer.into());
+            }
+            for peer in provider_peers {
+                msg.mut_providerPeers().push(peer.into());
+            }
+            msg
+        }
+    }
+}
+
+/// Turns a raw Kademlia message into a type-safe message.
+fn proto_to_req_msg(mut message: dht_proto::dht::Message) -> Result<KadRequestMsg, IoError> {
+    match message.get_field_type() {
+        dht_proto::dht::Message_MessageType::PING => Ok(KadRequestMsg::Ping),
+
+        dht_proto::dht::Message_MessageType::PUT_VALUE => Err(IoError::new(
+            IoErrorKind::InvalidData,
+            "received a PUT_VALUE message, but this is not supported by rust-libp2p yet",
+        )),
+
+        dht_proto::dht::Message_MessageType::GET_VALUE => Err(IoError::new(
+            IoErrorKind::InvalidData,
+            "received a GET_VALUE message, but this is not supported by rust-libp2p yet",
+        )),
+
+        dht_proto::dht::Message_MessageType::FIND_NODE => {
+            let key = Multihash::from_bytes(message.take_key()).map_err(|_| {
+                IoError::new(
+                    IoErrorKind::InvalidData,
+                    "bad protobuf encoding, failed to decode node_id",
+                )
+            })?;
+            Ok(KadRequestMsg::FindNode { key })
+        }
+
+        dht_proto::dht::Message_MessageType::GET_PROVIDERS => {
+            let key = Multihash::from_bytes(message.take_key())
+                .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))?;
+            Ok(KadRequestMsg::GetProviders { key })
+        }
+
+        dht_proto::dht::Message_MessageType::ADD_PROVIDER => {
+            // TODO: for now we don't parse the peer properly, so it is possible that we get
+            //       parsing errors for peers even when they are valid; we ignore these
+            //       errors for now, but ultimately we should just error altogether
+            let provider_peer = message
+                .mut_providerPeers()
+                .iter_mut()
+                .filter_map(|peer| KadPeer::from_peer(peer).ok())
+                .next();
+
+            if let Some(provider_peer) = provider_peer {
+                let key = Multihash::from_bytes(message.take_key())
+                    .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))?;
+                Ok(KadRequestMsg::AddProvider { key, provider_peer })
+            } else {
+                Err(IoError::new(
+                    IoErrorKind::InvalidData,
+                    "received an ADD_PROVIDER message with no valid peer",
+                ))
+            }
+        }
+    }
+}
+
+/// Turns a raw Kademlia message into a type-safe message.
+fn proto_to_resp_msg(mut message: dht_proto::dht::Message) -> Result<KadResponseMsg, IoError> {
+    match message.get_field_type() {
+        dht_proto::dht::Message_MessageType::PING => Ok(KadResponseMsg::Pong),
+
+        dht_proto::dht::Message_MessageType::GET_VALUE => Err(IoError::new(
+            IoErrorKind::InvalidData,
+            "received a GET_VALUE message, but this is not supported by rust-libp2p yet",
+        )),
+
+        dht_proto::dht::Message_MessageType::FIND_NODE => {
+            let closer_peers = message
+                .mut_closerPeers()
+                .iter_mut()
+                .filter_map(|peer| KadPeer::from_peer(peer).ok())
+                .collect::<Vec<_>>();
+
+            Ok(KadResponseMsg::FindNode { closer_peers })
+        }
+
+        dht_proto::dht::Message_MessageType::GET_PROVIDERS => {
+            let closer_peers = message
+                .mut_closerPeers()
+                .iter_mut()
+                .filter_map(|peer| KadPeer::from_peer(peer).ok())
+                .collect::<Vec<_>>();
+            let provider_peers = message
+                .mut_providerPeers()
+                .iter_mut()
+                .filter_map(|peer| KadPeer::from_peer(peer).ok())
+                .collect::<Vec<_>>();
+
+            Ok(KadResponseMsg::GetProviders {
+                closer_peers,
+                provider_peers,
+            })
+        }
+
+        dht_proto::dht::Message_MessageType::PUT_VALUE => Err(IoError::new(
+            IoErrorKind::InvalidData,
+            "received an unexpected PUT_VALUE message",
+        )),
+
+        dht_proto::dht::Message_MessageType::ADD_PROVIDER => Err(IoError::new(
+            IoErrorKind::InvalidData,
+            "received an unexpected ADD_PROVIDER message",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kad::protocol::{
+        KadConnectionType, KadPeer, KadRequestMsg, KadResponseMsg, KademliaProtocolConfig,
+    };
+    use futures::{Future, Sink, Stream};
+    use libp2p::core::{
+        upgrade::{InboundUpgrade, OutboundUpgrade},
+        PeerId,
+    };
+    use libp2p::multihash::{encode, Hash, Multihash};
+    use stegos_crypto::pbc::secure;
+    use tokio::net::{TcpListener, TcpStream};
+
+    #[test]
+    fn correct_transfer() {
+        // We open a server and a client, send a message between the two, and check that they were
+        // successfully received.
+
+        // Requests
+        test_one_req(KadRequestMsg::Ping);
+        test_one_req(KadRequestMsg::FindNode {
+            key: Multihash::random(Hash::SHA3512),
+        });
+        test_one_req(KadRequestMsg::GetProviders {
+            key: encode(Hash::SHA3512, &[9, 12, 0, 245, 245, 201, 28, 95]).unwrap(),
+        });
+        test_one_req(KadRequestMsg::AddProvider {
+            key: encode(Hash::SHA3512, &[9, 12, 0, 245, 245, 201, 28, 95]).unwrap(),
+            provider_peer: KadPeer {
+                node_id: secure::PublicKey::from(secure::G2::generator()),
+                peer_id: Some(PeerId::random()),
+                multiaddrs: vec!["/ip4/9.1.2.3/udp/23".parse().unwrap()],
+                connection_ty: KadConnectionType::Connected,
+            },
+        });
+
+        // Responses
+        test_one_res(KadResponseMsg::Pong);
+        test_one_res(KadResponseMsg::FindNode {
+            closer_peers: vec![KadPeer {
+                node_id: secure::PublicKey::from(secure::G2::generator()),
+                peer_id: Some(PeerId::random()),
+                multiaddrs: vec!["/ip4/100.101.102.103/tcp/20105".parse().unwrap()],
+                connection_ty: KadConnectionType::Connected,
+            }],
+        });
+        test_one_res(KadResponseMsg::GetProviders {
+            closer_peers: vec![KadPeer {
+                node_id: secure::PublicKey::from(secure::G2::generator()),
+                peer_id: Some(PeerId::random()),
+                multiaddrs: vec!["/ip4/100.101.102.103/tcp/20105".parse().unwrap()],
+                connection_ty: KadConnectionType::Connected,
+            }],
+            provider_peers: vec![KadPeer {
+                node_id: secure::PublicKey::from(secure::G2::generator()),
+                peer_id: Some(PeerId::random()),
+                multiaddrs: vec!["/ip4/200.201.202.203/tcp/1999".parse().unwrap()],
+                connection_ty: KadConnectionType::NotConnected,
+            }],
+        });
+
+        fn test_one_req(msg: KadRequestMsg) {
+            let msg_server = msg.clone();
+            let msg_client = msg.clone();
+
+            let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+            let listener_addr = listener.local_addr().unwrap();
+
+            let server = listener
+                .incoming()
+                .into_future()
+                .map_err(|(e, _)| e)
+                .and_then(|(c, _)| {
+                    KademliaProtocolConfig::default()
+                        .upgrade_inbound(c.unwrap(), b"/stegos/kad/1.0.0")
+                })
+                .and_then({
+                    let msg_server = msg_server.clone();
+                    move |s| {
+                        s.into_future().map_err(|(err, _)| err).map(move |(v, _)| {
+                            assert_eq!(v.unwrap(), msg_server);
+                            ()
+                        })
+                    }
+                });
+
+            let client = TcpStream::connect(&listener_addr)
+                .and_then(|c| {
+                    KademliaProtocolConfig::default().upgrade_outbound(c, b"/stegos/kad/1.0.0")
+                })
+                .and_then(|s| s.send(msg_client))
+                .map(|_| ());
+
+            let mut runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime
+                .block_on(server.select(client).map_err(|_| panic!()))
+                .unwrap();
+        }
+
+        fn test_one_res(msg: KadResponseMsg) {
+            let msg_server = msg.clone();
+            let msg_client = msg.clone();
+
+            let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+            let listener_addr = listener.local_addr().unwrap();
+
+            let server = listener
+                .incoming()
+                .into_future()
+                .map_err(|(e, _)| e)
+                .and_then(|(c, _)| {
+                    KademliaProtocolConfig::default()
+                        .upgrade_inbound(c.unwrap(), b"/stegos/kad/1.0.0")
+                })
+                .and_then(|s| s.send(msg_server))
+                .map(|_| ());
+
+            let client = TcpStream::connect(&listener_addr)
+                .and_then(|c| {
+                    KademliaProtocolConfig::default().upgrade_outbound(c, b"/stegos/kad/1.0.0")
+                })
+                .and_then({
+                    let msg_client = msg_client.clone();
+                    move |s| {
+                        s.into_future().map_err(|(err, _)| err).map(move |(v, _)| {
+                            assert_eq!(v.unwrap(), msg_client);
+                            ()
+                        })
+                    }
+                });
+
+            let mut runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime
+                .block_on(server.select(client).map_err(|_| panic!()))
+                .unwrap();
+        }
+
+        // fn test_one(msg_server: KadMsg) {
+        //     let msg_client = msg_server.clone();
+        //     let (tx, rx) = mpsc::channel();
+
+        //     let bg_thread = thread::spawn(move || {
+        //         let transport = TcpConfig::new().with_upgrade(KademliaProtocolConfig);
+
+        //         let (listener, addr) = transport
+        //             .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        //             .unwrap();
+        //         tx.send(addr).unwrap();
+
+        //         let future = listener
+        //             .into_future()
+        //             .map_err(|(err, _)| err)
+        //             .and_then(|(client, _)| client.unwrap().0)
+        //             .and_then(|proto| proto.into_future().map_err(|(err, _)| err).map(|(v, _)| v))
+        //             .map(|recv_msg| {
+        //                 assert_eq!(recv_msg.unwrap(), msg_server);
+        //                 ()
+        //             });
+        //         let mut rt = Runtime::new().unwrap();
+        //         let _ = rt.block_on(future).unwrap();
+        //     });
+
+        //     let transport = TcpConfig::new().with_upgrade(KademliaProtocolConfig);
+
+        //     let future = transport
+        //         .dial(rx.recv().unwrap())
+        //         .unwrap()
+        //         .and_then(|proto| proto.send(msg_client))
+        //         .map(|_| ());
+        //     let mut rt = Runtime::new().unwrap();
+        //     let _ = rt.block_on(future).unwrap();
+        //     bg_thread.join().unwrap();
+        // }
+    }
+}

--- a/network/src/kad/query.rs
+++ b/network/src/kad/query.rs
@@ -1,0 +1,611 @@
+// Copyright 2019 Stegos AG
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Contains the iterative querying process of Kademlia.
+//!
+//! This allows one to create queries that iterate on the DHT on nodes that become closer and
+//! closer to the target.
+
+use super::handler::KademliaHandlerIn;
+use super::kbucket::KBucketsPeerId;
+use futures::prelude::*;
+use libp2p::multihash::Multihash;
+use log::debug;
+use smallvec::SmallVec;
+use std::time::{Duration, Instant};
+use stegos_crypto::pbc::secure;
+use stegos_crypto::utils::u8v_to_hexstr;
+use tokio_timer::Delay;
+
+use crate::utils::IntoMultihash;
+
+/// State of a query iterative process.
+///
+/// The API of this state machine is similar to the one of `Future`, `Stream` or `Swarm`. You need
+/// to call `poll()` to query the state for actions to perform. If `NotReady` is returned, the
+/// current task will be woken up automatically when `poll()` needs to be called again.
+///
+/// Note that this struct only handles iterating over nodes that are close to the target. For
+/// `FIND_NODE` queries you don't need more than that. However for `FIND_VALUE` and
+/// `GET_PROVIDERS`, you need to extract yourself the value or list of providers from RPC requests
+/// received by remotes as this is not handled by the `QueryState`.
+#[derive(Debug)]
+pub struct QueryState {
+    /// Target we're looking for.
+    target: QueryTarget,
+
+    /// Stage of the query. See the documentation of `QueryStage`.
+    stage: QueryStage,
+
+    /// Ordered list of the peers closest to the result we're looking for.
+    /// Entries that are `InProgress` shouldn't be removed from the list before they complete.
+    /// Must never contain two entries with the same peer IDs.
+    closest_peers: SmallVec<[(secure::PublicKey, QueryPeerState); 32]>,
+
+    /// Allowed level of parallelism.
+    parallelism: usize,
+
+    /// Number of results to produce.
+    num_results: usize,
+
+    /// Timeout for each individual RPC query.
+    rpc_timeout: Duration,
+}
+
+/// Configuration for a query.
+#[derive(Debug, Clone)]
+pub struct QueryConfig<TIter> {
+    /// Target of the query.
+    pub target: QueryTarget,
+
+    /// Iterator to a list of `num_results` nodes that we know of whose distance is close to the
+    /// target.
+    pub known_closest_peers: TIter,
+
+    /// Allowed level of parallelism.
+    pub parallelism: usize,
+
+    /// Number of results to produce.
+    pub num_results: usize,
+
+    /// Timeout for each individual RPC query.
+    pub rpc_timeout: Duration,
+}
+
+/// Stage of the query.
+#[derive(Debug)]
+enum QueryStage {
+    /// We are trying to find a closest node.
+    Iterating {
+        /// Number of successful query results in a row that didn't find any closer node.
+        // TODO: this is not great, because we don't necessarily receive responses in the order
+        //       we made the queries. It is possible that we query multiple far-away nodes in a
+        //       row, and obtain results before the result of the closest nodes.
+        no_closer_in_a_row: usize,
+    },
+
+    // We have found the closest node, and we are now pinging the nodes we know about.
+    Frozen,
+}
+
+impl QueryState {
+    /// Creates a new query.
+    ///
+    /// You should call `poll()` this function returns in order to know what to do.
+    pub fn new(config: QueryConfig<impl IntoIterator<Item = secure::PublicKey>>) -> QueryState {
+        let mut closest_peers: SmallVec<[_; 32]> = config
+            .known_closest_peers
+            .into_iter()
+            .map(|node_id| (node_id, QueryPeerState::NotContacted))
+            .take(config.num_results)
+            .collect();
+        let target = config.target;
+        closest_peers.sort_by_key(|e| target.as_hash().distance_with(&e.0.into_multihash()));
+        closest_peers.dedup_by(|a, b| a.0 == b.0);
+
+        QueryState {
+            target,
+            stage: QueryStage::Iterating {
+                no_closer_in_a_row: 0,
+            },
+            closest_peers,
+            parallelism: config.parallelism,
+            num_results: config.num_results,
+            rpc_timeout: config.rpc_timeout,
+        }
+    }
+
+    /// Returns the target of the query. Always the same as what was passed to `new()`.
+    #[inline]
+    pub fn target(&self) -> &QueryTarget {
+        &self.target
+    }
+
+    /// After `poll()` returned `SendRpc`, this method should be called when the node sends back
+    /// the result of the query.
+    ///
+    /// Note that if this query is a `FindValue` query and a node returns a record, feel free to
+    /// immediately drop the query altogether and use the record.
+    ///
+    /// After this function returns, you should call `poll()` again.
+    pub fn inject_rpc_result(
+        &mut self,
+        result_source: &secure::PublicKey,
+        closer_peers: impl IntoIterator<Item = secure::PublicKey>,
+    ) {
+        // Mark the peer as succeeded.
+        for (peer_id, state) in self.closest_peers.iter_mut() {
+            if peer_id == result_source {
+                if let state @ QueryPeerState::InProgress(_) = state {
+                    *state = QueryPeerState::Succeeded;
+                }
+            }
+        }
+
+        // Add the entries in `closest_peers`.
+        if let QueryStage::Iterating {
+            ref mut no_closer_in_a_row,
+        } = self.stage
+        {
+            // We increment now, and reset to 0 if we find a closer node.
+            *no_closer_in_a_row += 1;
+
+            for elem_to_add in closer_peers {
+                let target = &self.target;
+                let elem_to_add_distance = target
+                    .as_hash()
+                    .distance_with(&elem_to_add.into_multihash());
+                let insert_pos_start = self.closest_peers.iter().position(|(id, _)| {
+                    target.as_hash().distance_with(&id.into_multihash()) >= elem_to_add_distance
+                });
+
+                if let Some(insert_pos_start) = insert_pos_start {
+                    // We need to insert the element between `insert_pos_start` and
+                    // `insert_pos_start + insert_pos_size`.
+                    let insert_pos_size = self
+                        .closest_peers
+                        .iter()
+                        .skip(insert_pos_start)
+                        .position(|(id, _)| {
+                            target.as_hash().distance_with(&id.into_multihash())
+                                > elem_to_add_distance
+                        });
+
+                    // Make sure we don't insert duplicates.
+                    let duplicate = if let Some(insert_pos_size) = insert_pos_size {
+                        self.closest_peers
+                            .iter()
+                            .skip(insert_pos_start)
+                            .take(insert_pos_size)
+                            .any(|e| e.0 == elem_to_add)
+                    } else {
+                        self.closest_peers
+                            .iter()
+                            .skip(insert_pos_start)
+                            .any(|e| e.0 == elem_to_add)
+                    };
+
+                    if !duplicate {
+                        if insert_pos_start == 0 {
+                            *no_closer_in_a_row = 0;
+                        }
+                        debug_assert!(self.closest_peers.iter().all(|e| e.0 != elem_to_add));
+                        self.closest_peers.insert(
+                            insert_pos_start,
+                            (elem_to_add, QueryPeerState::NotContacted),
+                        );
+                    }
+                } else if self.closest_peers.len() < self.num_results {
+                    debug_assert!(self.closest_peers.iter().all(|e| e.0 != elem_to_add));
+                    self.closest_peers
+                        .push((elem_to_add, QueryPeerState::NotContacted));
+                }
+            }
+        }
+
+        // Check for duplicates in `closest_peers`.
+        debug_assert!(self.closest_peers.windows(2).all(|w| w[0].0 != w[1].0));
+
+        // Handle if `no_closer_in_a_row` is too high.
+        let freeze = if let QueryStage::Iterating { no_closer_in_a_row } = self.stage {
+            no_closer_in_a_row >= self.parallelism
+        } else {
+            false
+        };
+        if freeze {
+            self.stage = QueryStage::Frozen;
+        }
+    }
+
+    /// Returns true if we are waiting for a query answer from that peer.
+    ///
+    /// After `poll()` returned `SendRpc`, this function will return `true`.
+    pub fn is_waiting(&self, id: &secure::PublicKey) -> bool {
+        let state = self
+            .closest_peers
+            .iter()
+            .filter_map(
+                |(node_id, state)| {
+                    if node_id == id {
+                        Some(state)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .next();
+
+        match state {
+            Some(&QueryPeerState::InProgress(_)) => true,
+            Some(&QueryPeerState::NotContacted) => false,
+            Some(&QueryPeerState::Succeeded) => false,
+            Some(&QueryPeerState::Failed) => false,
+            None => false,
+        }
+    }
+
+    /// After `poll()` returned `SendRpc`, this function should be called if we were unable to
+    /// reach the peer, or if an error of some sort happened.
+    ///
+    /// Has no effect if the peer ID is not relevant to the query, so feel free to call this
+    /// function whenever an error happens on the network.
+    ///
+    /// After this function returns, you should call `poll()` again.
+    pub fn inject_rpc_error(&mut self, id: &secure::PublicKey) {
+        let state = self
+            .closest_peers
+            .iter_mut()
+            .filter_map(
+                |(node_id, state)| {
+                    if node_id == id {
+                        Some(state)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .next();
+
+        match state {
+            Some(state @ &mut QueryPeerState::InProgress(_)) => *state = QueryPeerState::Failed,
+            Some(&mut QueryPeerState::NotContacted) => (),
+            Some(&mut QueryPeerState::Succeeded) => (),
+            Some(&mut QueryPeerState::Failed) => (),
+            None => (),
+        }
+    }
+
+    /// Polls this individual query.
+    pub fn poll(&mut self) -> Async<QueryStatePollOut<'_>> {
+        // While iterating over peers, count the number of queries currently being processed.
+        // This is used to not go over the limit of parallel requests.
+        // If this is still 0 at the end of the function, that means the query is finished.
+        let mut active_counter = 0;
+
+        // While iterating over peers, count the number of queries in a row (from closer to further
+        // away from target) that are in the succeeded in state.
+        // Contains `None` if the chain is broken.
+        let mut succeeded_counter = Some(0);
+
+        // Extract `self.num_results` to avoid borrowing errors with closures.
+        let num_results = self.num_results;
+
+        for &mut (ref node_id, ref mut state) in self.closest_peers.iter_mut() {
+            // Start by "killing" the query if it timed out.
+            {
+                let timed_out = match state {
+                    QueryPeerState::InProgress(timeout) => match timeout.poll() {
+                        Ok(Async::Ready(_)) | Err(_) => true,
+                        Ok(Async::NotReady) => false,
+                    },
+                    _ => false,
+                };
+                if timed_out {
+                    *state = QueryPeerState::Failed;
+                    return Async::Ready(QueryStatePollOut::CancelRpc { node_id });
+                }
+            }
+
+            // Increment the local counters.
+            match state {
+                QueryPeerState::InProgress(_) => {
+                    active_counter += 1;
+                }
+                QueryPeerState::Succeeded => {
+                    if let Some(ref mut c) = succeeded_counter {
+                        *c += 1;
+                    }
+                }
+                _ => (),
+            };
+
+            // We have enough results; the query is done.
+            if succeeded_counter
+                .as_ref()
+                .map(|&c| c >= num_results)
+                .unwrap_or(false)
+            {
+                return Async::Ready(QueryStatePollOut::Finished);
+            }
+
+            // Dial the node if it needs dialing.
+            let need_connect = match state {
+                QueryPeerState::NotContacted => match self.stage {
+                    QueryStage::Iterating { .. } => active_counter < self.parallelism,
+                    QueryStage::Frozen => match self.target {
+                        QueryTarget::FindPeer(_) => true,
+                        QueryTarget::GetProviders(_) => false,
+                    },
+                },
+                _ => false,
+            };
+
+            if need_connect {
+                let delay = Delay::new(Instant::now() + self.rpc_timeout);
+                *state = QueryPeerState::InProgress(delay);
+                debug!(target: "stegos_network::kad", "query wants to connect: target={}, node_id={}",
+                    u8v_to_hexstr(self.target.as_hash().as_bytes()), node_id);
+                return Async::Ready(QueryStatePollOut::SendRpc {
+                    node_id,
+                    query_target: &self.target,
+                });
+            }
+        }
+
+        // If we don't have any query in progress, return `Finished` as we don't have anything more
+        // we can do.
+        if active_counter > 0 {
+            Async::NotReady
+        } else {
+            Async::Ready(QueryStatePollOut::Finished)
+        }
+    }
+
+    /// Consumes the query and returns the known closest peers.
+    ///
+    /// > **Note**: This can be called at any time, but you normally only do that once the query
+    /// >           is finished.
+    pub fn into_closest_peers(self) -> impl Iterator<Item = secure::PublicKey> {
+        self.closest_peers
+            .into_iter()
+            .filter_map(|(node_id, state)| {
+                if let QueryPeerState::Succeeded = state {
+                    Some(node_id)
+                } else {
+                    None
+                }
+            })
+            .take(self.num_results)
+    }
+}
+
+/// Outcome of polling a query.
+#[derive(Debug, Clone)]
+pub enum QueryStatePollOut<'a> {
+    /// The query is finished.
+    ///
+    /// If this is a `FindValue` query, the user is supposed to extract the record themselves from
+    /// any RPC result sent by a remote. If the query finished without that happening, this means
+    /// that we didn't find any record.
+    /// Similarly, if this is a `GetProviders` query, the user is supposed to extract the providers
+    /// from any RPC result sent by a remote.
+    ///
+    /// If this is a `FindNode` query, you can call `into_closest_peers` in order to obtain the
+    /// result.
+    Finished,
+
+    /// We need to send an RPC query to the given peer.
+    ///
+    /// The RPC query to send can be derived from the target of the query.
+    ///
+    /// After this has been returned, you should call either `inject_rpc_result` or
+    /// `inject_rpc_error` at a later point in time.
+    SendRpc {
+        /// The peer to send the RPC query to.
+        node_id: &'a secure::PublicKey,
+        /// A reminder of the query target. Same as what you obtain by calling `target()`.
+        query_target: &'a QueryTarget,
+    },
+
+    /// We no longer need to send a query to this specific node.
+    ///
+    /// It is guaranteed that an earlier polling returned `SendRpc` with this peer id.
+    CancelRpc {
+        /// The target.
+        node_id: &'a secure::PublicKey,
+    },
+}
+
+/// What we're aiming for with our query.
+#[derive(Debug, Clone)]
+pub enum QueryTarget {
+    /// Finding a peer.
+    FindPeer(Multihash),
+    /// Find the peers that provide a certain value.
+    GetProviders(Multihash),
+}
+
+impl QueryTarget {
+    /// Creates the corresponding RPC request to send to remote.
+    #[inline]
+    pub fn to_rpc_request<TUserData>(&self, user_data: TUserData) -> KademliaHandlerIn<TUserData> {
+        self.clone().into_rpc_request(user_data)
+    }
+
+    /// Creates the corresponding RPC request to send to remote.
+    pub fn into_rpc_request<TUserData>(self, user_data: TUserData) -> KademliaHandlerIn<TUserData> {
+        match self {
+            QueryTarget::FindPeer(key) => KademliaHandlerIn::FindNodeReq { key, user_data },
+            QueryTarget::GetProviders(key) => KademliaHandlerIn::GetProvidersReq { key, user_data },
+        }
+    }
+
+    /// Returns the hash of the thing we're looking for.
+    pub fn as_hash(&self) -> Multihash {
+        match self {
+            QueryTarget::FindPeer(key) => key.clone(),
+            QueryTarget::GetProviders(key) => key.clone(),
+        }
+    }
+}
+
+/// State of peer in the context of a query.
+#[derive(Debug)]
+enum QueryPeerState {
+    /// We haven't tried contacting the node.
+    NotContacted,
+    /// Waiting for an answer from the node to our RPC query. Includes a timeout.
+    InProgress(Delay),
+    /// We successfully reached the node.
+    Succeeded,
+    /// We tried to reach the node but failed.
+    Failed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QueryConfig, QueryState, QueryStatePollOut, QueryTarget};
+    use futures::{self, prelude::*, try_ready};
+    use libp2p::multihash::{Hash, Multihash};
+    use std::{iter, sync::Arc, sync::Mutex, thread, time::Duration};
+    use stegos_crypto::pbc::secure;
+    use tokio;
+
+    #[test]
+    fn start_by_sending_rpc_to_known_peers() {
+        let (_, random_id, _) = secure::make_random_keys();
+        let random_target = Multihash::random(Hash::SHA3512);
+
+        let target = QueryTarget::FindPeer(random_target);
+
+        let mut query = QueryState::new(QueryConfig {
+            target,
+            known_closest_peers: iter::once(random_id.clone()),
+            parallelism: 3,
+            num_results: 100,
+            rpc_timeout: Duration::from_secs(10),
+        });
+
+        tokio::run(futures::future::poll_fn(move || {
+            match try_ready!(Ok(query.poll())) {
+                QueryStatePollOut::SendRpc { node_id, .. } if node_id == &random_id => {
+                    Ok(Async::Ready(()))
+                }
+                _ => panic!(),
+            }
+        }));
+    }
+
+    #[test]
+    fn continue_second_result() {
+        let (_, random_id, _) = secure::make_random_keys();
+        let (_, random_id2, _) = secure::make_random_keys();
+        let random_target = Multihash::random(Hash::SHA3512);
+        let target = QueryTarget::FindPeer(random_target);
+
+        let query = Arc::new(Mutex::new(QueryState::new(QueryConfig {
+            target,
+            known_closest_peers: iter::once(random_id.clone()),
+            parallelism: 3,
+            num_results: 100,
+            rpc_timeout: Duration::from_secs(10),
+        })));
+
+        // Let's do a first polling round to obtain the `SendRpc` request.
+        tokio::run(futures::future::poll_fn({
+            let random_id = random_id.clone();
+            let query = query.clone();
+            move || match try_ready!(Ok(query.lock().unwrap().poll())) {
+                QueryStatePollOut::SendRpc { node_id, .. } if node_id == &random_id => {
+                    Ok(Async::Ready(()))
+                }
+                _ => panic!(),
+            }
+        }));
+
+        // Send the reply.
+        query
+            .lock()
+            .unwrap()
+            .inject_rpc_result(&random_id, iter::once(random_id2.clone()));
+
+        // Second polling round to check the second `SendRpc` request.
+        tokio::run(futures::future::poll_fn({
+            let query = query.clone();
+            move || match try_ready!(Ok(query.lock().unwrap().poll())) {
+                QueryStatePollOut::SendRpc { node_id, .. } if node_id == &random_id2 => {
+                    Ok(Async::Ready(()))
+                }
+                _ => panic!(),
+            }
+        }));
+    }
+
+    #[test]
+    fn timeout_works() {
+        let (_, random_id, _) = secure::make_random_keys();
+        let random_target = Multihash::random(Hash::SHA3512);
+        let target = QueryTarget::FindPeer(random_target);
+
+        let query = Arc::new(Mutex::new(QueryState::new(QueryConfig {
+            target,
+            known_closest_peers: iter::once(random_id.clone()),
+            parallelism: 3,
+            num_results: 100,
+            rpc_timeout: Duration::from_millis(100),
+        })));
+
+        // Let's do a first polling round to obtain the `SendRpc` request.
+        tokio::run(futures::future::poll_fn({
+            let random_id = random_id.clone();
+            let query = query.clone();
+            move || match try_ready!(Ok(query.lock().unwrap().poll())) {
+                QueryStatePollOut::SendRpc { node_id, .. } if node_id == &random_id => {
+                    Ok(Async::Ready(()))
+                }
+                _ => panic!(),
+            }
+        }));
+
+        // Wait for a bit.
+        thread::sleep(Duration::from_millis(200));
+
+        // Second polling round to check the timeout.
+        tokio::run(futures::future::poll_fn({
+            let query = query.clone();
+            move || match try_ready!(Ok(query.lock().unwrap().poll())) {
+                QueryStatePollOut::CancelRpc { node_id, .. } if node_id == &random_id => {
+                    Ok(Async::Ready(()))
+                }
+                _ => panic!(),
+            }
+        }));
+
+        // Third polling round for finished.
+        tokio::run(futures::future::poll_fn({
+            let query = query.clone();
+            move || match try_ready!(Ok(query.lock().unwrap().poll())) {
+                QueryStatePollOut::Finished => Ok(Async::Ready(())),
+                _ => panic!(),
+            }
+        }));
+    }
+}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -23,11 +23,14 @@
 #![allow(dead_code)]
 
 mod config;
+mod discovery;
 mod gatekeeper;
+mod kad;
 mod libp2p_network;
 pub mod loopback;
 mod ncp;
 mod pubsub;
+mod utils;
 
 use failure::{Error, Fail};
 use futures::sync::mpsc;
@@ -36,6 +39,7 @@ use stegos_crypto::pbc::secure;
 
 pub use self::config::*;
 pub use self::libp2p_network::Libp2pNetwork;
+pub use self::utils::IntoMultihash;
 
 pub type Network = Box<dyn NetworkProvider + Send>;
 

--- a/network/src/utils/mod.rs
+++ b/network/src/utils/mod.rs
@@ -21,4 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-include!(concat!(env!("OUT_DIR"), "/ncp_proto/mod.rs"));
+mod multihash;
+
+pub use self::multihash::IntoMultihash;

--- a/network/src/utils/multihash.rs
+++ b/network/src/utils/multihash.rs
@@ -21,4 +21,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-include!(concat!(env!("OUT_DIR"), "/ncp_proto/mod.rs"));
+use libp2p::core::PeerId;
+use libp2p::multihash::{encode, Hash::SHA3512, Multihash};
+use stegos_crypto::pbc::secure;
+
+pub trait IntoMultihash {
+    fn into_multihash(self) -> Multihash;
+}
+
+impl IntoMultihash for secure::PublicKey {
+    fn into_multihash(self) -> Multihash {
+        encode(SHA3512, &self.to_bytes()).expect("should never fail")
+    }
+}
+
+impl IntoMultihash for PeerId {
+    fn into_multihash(self) -> Multihash {
+        std::convert::Into::into(self)
+    }
+}
+
+impl IntoMultihash for Multihash {
+    fn into_multihash(self) -> Multihash {
+        self
+    }
+}


### PR DESCRIPTION
* re-worked original libp2p Kadelia implementation to work with pbc::secure::PublicKeys as node windows
* used SHA3-512 as internal hash for DHT keys
* implemented DHT-based network discovery

This is rough initial iplementation and needs more work on stability improvement and code cleanup, but it lets
us proceed to actuall message routing