### PR TITLE
Rework synchronization logic

### DIFF
--- a/node/protos/loader.proto
+++ b/node/protos/loader.proto
@@ -5,7 +5,7 @@ import "crypto.proto";
 import "blockchain.proto";
 
 message RequestBlocks {
-    stegos.crypto.Hash start_block = 1;
+    uint64 starting_height = 1;
 }
 
 message ResponseBlocks {

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -48,8 +48,8 @@ pub struct ChainConfig {
     pub max_slot_count: i64,
     /// Minimal stake amount.
     pub min_stake_amount: i64,
-    /// Limit of blocks to download starting from current known blockchain state.
-    pub loader_batch_size: u64,
+    /// Minimal interval between loader runs.
+    pub loader_timeout: Duration,
 }
 
 impl Default for ChainConfig {
@@ -69,7 +69,7 @@ impl Default for ChainConfig {
             stake_fee: 1,
             max_slot_count: 1000,
             min_stake_amount: 1000,
-            loader_batch_size: 100,
+            loader_timeout: Duration::from_secs(5),
         }
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -28,16 +28,10 @@ use std::time::Duration;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct ChainConfig {
-    /// Time delta in which our messages should be delivered, or forgotten.
-    pub message_timeout: Duration,
     /// How long wait for transactions before starting to create a new block.
     pub tx_wait_timeout: Duration,
-    /// Estimated time of the micro block validation.
-    pub micro_block_validation_timeout: Duration,
     /// How long wait for micro blocks.
     pub micro_block_timeout: Duration,
-    /// Estimated time of the key block validation.
-    pub key_block_validation_timeout: Duration,
     /// How long wait for the keu blocks.
     pub key_block_timeout: Duration,
     /// Time to lock stakes.
@@ -60,22 +54,13 @@ pub struct ChainConfig {
 
 impl Default for ChainConfig {
     fn default() -> Self {
-        let message_timeout = Duration::from_secs(1);
-        let tx_wait_timeout = Duration::from_secs(1);
-        // tx_count * verify_tx = 1500 * 20ms.
-        let micro_block_validation_timeout = Duration::from_secs(30);
-        let micro_block_timeout =
-            tx_wait_timeout + message_timeout + micro_block_validation_timeout;
-        let key_block_validation_timeout = Duration::from_millis(5);
-        let key_block_timeout = message_timeout * 3 + // 3 consensus message
-            key_block_validation_timeout * 3; // leader + validators + sealed block.
+        let tx_wait_timeout = Duration::from_secs(10);
+        let micro_block_timeout = Duration::from_secs(30);
+        let key_block_timeout = Duration::from_secs(30);
 
         ChainConfig {
-            message_timeout,
             tx_wait_timeout,
-            micro_block_validation_timeout,
             micro_block_timeout,
-            key_block_validation_timeout,
             key_block_timeout,
             bonding_time: Duration::from_secs(15 * 60),
             blocks_in_epoch: 5,

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -39,12 +39,23 @@ lazy_static! {
         "The number of auto-commits of proposed block"
     )
     .unwrap();
-    pub static ref FORCED_VIEW_CHANGES: IntCounter = register_int_counter!(
-        "stegos_forced_view_changes",
-        "The number of forced view_changes, in case of dead leader."
+    pub static ref KEY_BLOCK_VIEW_CHANGES: IntCounter = register_int_counter!(
+        "stegos_key_block_view_changes",
+        "The number of forced view_changes for the key blocks."
     )
     .unwrap();
-
+    pub static ref MICRO_BLOCK_VIEW_CHANGES: IntCounter = register_int_counter!(
+        "stegos_micro_block_view_changes",
+        "The number of forced view_changes for the micro blocks."
+    )
+    .unwrap();
+    pub static ref FORKS: IntCounter = register_int_counter!(
+        "stegos_forks",
+        "The number of forks detected"
+    )
+    .unwrap();
+    pub static ref SYNCHRONIZED: IntGauge =
+        register_int_gauge!("stegos_synchronized", "Flag that the node is synchornized with the network.").unwrap();
     pub static ref BLOCK_REMOTE_TIMESTAMP: IntGauge =
         register_int_gauge!("stegos_block_remote_timestamp_ms", "The local time at a remote leader when the last block began to be created, i.e it equals to the value of block.header.timestamp.").unwrap();
     pub static ref BLOCK_LOCAL_TIMESTAMP: IntGauge =

--- a/node/src/protos/mod.rs
+++ b/node/src/protos/mod.rs
@@ -24,7 +24,6 @@
 use stegos_serialization::traits::*;
 // link protobuf dependencies
 use stegos_blockchain::protos::*;
-use stegos_crypto::protos::*;
 include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
 
 use crate::loader::{ChainLoaderMessage, RequestBlocks, ResponseBlocks};
@@ -35,12 +34,12 @@ impl ProtoConvert for RequestBlocks {
     type Proto = loader::RequestBlocks;
     fn into_proto(&self) -> Self::Proto {
         let mut proto = loader::RequestBlocks::new();
-        proto.set_start_block(self.start_block.into_proto());
+        proto.set_starting_height(self.starting_height);
         proto
     }
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
-        let start_block = ProtoConvert::from_proto(proto.get_start_block())?;
-        Ok(RequestBlocks { start_block })
+        let starting_height = proto.get_starting_height();
+        Ok(RequestBlocks { starting_height })
     }
 }
 
@@ -108,7 +107,7 @@ mod tests {
 
     #[test]
     fn chain_loader() {
-        let request = ChainLoaderMessage::Request(RequestBlocks::new(Hash::digest("test")));
+        let request = ChainLoaderMessage::Request(RequestBlocks::new(1));
         roundtrip(&request);
     }
 }


### PR DESCRIPTION
- Add synchronization status tracking to Node based on timestamps in the key blocks.
- Invoke loader on a view change for the key && monetary blocks.
 - Throttle loader to 60/5 = 12 requests per minute.
 - Limit the number of blocks in loader's response to blocks_per_epoch.
- Add a stub for the fork resolution.
 - Remove a queue of orphan blocks.

Closes #687