### PR TITLE
Fix pubsub 'protocol disabled' errors

### DIFF
--- a/network/src/pubsub/handler.rs
+++ b/network/src/pubsub/handler.rs
@@ -188,11 +188,11 @@ where
     fn inject_dial_upgrade_error(
         &mut self,
         _: Self::OutboundOpenInfo,
-        _: ProtocolsHandlerUpgrErr<
+        e: ProtocolsHandlerUpgrErr<
             <Self::OutboundProtocol as OutboundUpgrade<Self::Substream>>::Error,
         >,
     ) {
-        self.enabled_outgoing = false;
+        trace!(target: "stegos_network::pubsub", "got dial outbound failure: {}", e);
     }
 
     #[inline]


### PR DESCRIPTION
Occasionally on busy nodes timeout could happen on establishing outbound substream connection. Instead of disabling substream, just report the issue and retry later