### PR TITLE
Add generator tx implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stegos"
 version = "0.2.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ stegos_node = { version = "0.2.0", path = "./node" }
 stegos_serialization = { version = "0.2.0", path = "./serialization" }
 stegos_txpool = { version = "0.2.0", path = "./txpool" }
 stegos_wallet = { version = "0.2.0", path = "./wallet" }
+assert_matches = "1.3.0"
 atty = "0.2"
 clap = "2.32"
 dirs = "1.0"

--- a/consensus/src/state.rs
+++ b/consensus/src/state.rs
@@ -409,9 +409,9 @@ impl<Request: Hashable + Clone + Debug + Eq, Proof: Hashable + Clone + Debug>
                 warn!(
                     "{}({}:{}): invalid request_hash: expected_request_hash={:?}, got_request_hash={:?}, msg={:?}",
                     self.state.name(),
-                    self.height,
+                    self.height, self.round,
                     &expected_request_hash,
-                    &msg.request_hash, self.round,
+                    &msg.request_hash,
                     &msg
                 );
                 return Err(ConsensusError::InvalidRequestHash(

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ use std::path::Path;
 use std::result::Result;
 use stegos_api::WebSocketConfig;
 use stegos_blockchain::StorageConfig;
+use stegos_crypto::curve1174::cpt::PublicKey;
 use stegos_keychain::KeyChainConfig;
 use stegos_network::NetworkConfig;
 use stegos_node::ChainConfig;
@@ -84,6 +85,8 @@ pub struct GeneralConfig {
     pub log4rs_config: String,
     /// Prometheus exporter endpoint
     pub prometheus_endpoint: String,
+    /// Start transaction generator to some receivers.
+    pub generate_txs: Vec<PublicKey>,
 }
 
 impl Default for GeneralConfig {
@@ -92,6 +95,7 @@ impl Default for GeneralConfig {
             chain: "testnet".to_string(),
             log4rs_config: "stegos-log4rs.toml".to_string(),
             prometheus_endpoint: "".to_string(),
+            generate_txs: Vec::new(),
         }
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,3 +1,4 @@
+use crate::config::GeneralConfig;
 ///! Console - command-line interface.
 //
 // Copyright (c) 2018 Stegos AG
@@ -20,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 use crate::consts;
+use crate::generator::Generator;
 use dirs;
 use failure::Error;
 use futures::sync::mpsc::UnboundedReceiver;
@@ -73,6 +75,8 @@ pub struct ConsoleService {
     wallet: Wallet,
     /// Node API.
     node: Node,
+    /// Generator.
+    generator: Option<Generator>,
     /// Wallet events.
     wallet_notifications: UnboundedReceiver<WalletNotification>,
     /// Wallet RPC responses.
@@ -89,7 +93,12 @@ pub struct ConsoleService {
 
 impl ConsoleService {
     /// Constructor.
-    pub fn new(network: Network, wallet: Wallet, node: Node) -> Result<ConsoleService, Error> {
+    pub fn new(
+        cfg: &GeneralConfig,
+        network: Network,
+        wallet: Wallet,
+        node: Node,
+    ) -> Result<ConsoleService, Error> {
         let (tx, rx) = channel::<String>(1);
         let wallet_notifications = wallet.subscribe();
         let wallet_response = None;
@@ -97,10 +106,19 @@ impl ConsoleService {
         let stdin_th = thread::spawn(move || Self::readline_thread_f(tx));
         let stdin = rx;
         let unicast_rx = network.subscribe_unicast(CONSOLE_PROTOCOL_ID)?;
-
+        let generator = if !cfg.generate_txs.is_empty() {
+            Some(Generator::new(
+                wallet.clone(),
+                cfg.generate_txs.clone(),
+                true,
+            ))
+        } else {
+            None
+        };
         let service = ConsoleService {
             network,
             wallet,
+            generator,
             wallet_notifications,
             wallet_response,
             node_response,
@@ -174,6 +192,8 @@ impl ConsoleService {
         println!("net publish TOPIC MESSAGE - publish a network message via floodsub");
         println!("net send NETWORK_PUBKEY MESSAGE - send a network message via unicast");
         println!("db pop block - revert the latest block");
+        println!("generator start LIST_OF_WALLETS_ADDRESSES - start transaction generator");
+        println!("generator stop - stop transaction generator");
         println!();
     }
 
@@ -224,6 +244,18 @@ impl ConsoleService {
         println!("Usage: msg WALLET_PUBKEY MESSAGE");
         println!(" - WALLET_PUBKEY recipient's public key in HEX format");
         println!(" - MESSAGE some message");
+        println!();
+    }
+
+    fn help_generator() {
+        println!("Usage: generator SUBCOMMAND");
+        println!(" - start or stop transaction generator");
+        println!(" - SUBCOMMAND can be one of [start, stop]");
+        println!(
+            " - generator start LIST_OF_WALLETS_ADDRESSES - will start generator, \
+             or add new wallet keys to generator list."
+        );
+        println!(" - generator stop will stop generator");
         println!();
     }
 
@@ -402,6 +434,35 @@ impl ConsoleService {
             info!("Unstaking {} STG from escrow", amount);
             let request = WalletRequest::Unstake { amount };
             self.wallet_response = Some(self.wallet.request(request));
+        } else if msg.starts_with("generator ") {
+            let subcommand = &msg[10..];
+            if subcommand.starts_with("stop") {
+                println!("Stoping generator.");
+                self.generator = None;
+            } else if subcommand.starts_with("start ") {
+                let mut keys = Vec::new();
+                let keys_str = &subcommand[6..];
+                for key in keys_str.split(',') {
+                    let recipient = match PublicKey::try_from_hex(key.trim()) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            println!("Invalid wallet public key '{}': {}", key, e);
+                            Self::help_generator();
+                            return true;
+                        }
+                    };
+
+                    keys.push(recipient)
+                }
+                if let Some(ref mut generator) = self.generator {
+                    generator.add_destinations(keys)
+                } else {
+                    self.generator = Some(Generator::new(self.wallet.clone(), keys.clone(), false));
+                }
+            } else {
+                Self::help_generator()
+            }
+            return true;
         } else if msg == "show version" {
             println!(
                 "Stegos {}.{}.{} ({} {})",
@@ -571,6 +632,13 @@ impl Future for ConsoleService {
                 Ok(Async::Ready(None)) => self.on_exit(),
                 Ok(Async::NotReady) => break, // fall through
                 Err(()) => panic!("Unicast failure"),
+            }
+        }
+
+        if let Some(ref mut generator) = self.generator {
+            match generator.poll() {
+                Ok(Async::NotReady) => {}
+                _ => panic!("Generator finished."),
             }
         }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,0 +1,178 @@
+//
+// Copyright (c) 2019 Stegos AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+use assert_matches::assert_matches;
+use futures::sync::mpsc::UnboundedReceiver;
+use futures::sync::oneshot;
+use futures::{Async, Future, Poll, Stream};
+use log::*;
+use rand::seq::SliceRandom;
+use std::time::Duration;
+use stegos_crypto::curve1174::cpt::PublicKey;
+use stegos_wallet::{Wallet, WalletNotification, WalletRequest, WalletResponse};
+use tokio_timer::Delay;
+
+static WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+pub struct Generator {
+    // start generator with specific delay, because our network could be not ready.
+    timeout: Option<Delay>,
+    wallet: Wallet,
+    destinations: Vec<PublicKey>,
+    state: GeneratorState,
+}
+#[derive(Debug)]
+enum GeneratorState {
+    CreateNew,
+    NotInited(UnboundedReceiver<WalletNotification>),
+    WaitForWallet(oneshot::Receiver<WalletResponse>),
+    WaitForConfirmation(UnboundedReceiver<WalletNotification>),
+}
+
+impl Generator {
+    /// Crates new TransactionPool.
+    pub fn new(wallet: Wallet, destinations: Vec<PublicKey>, with_delay: bool) -> Generator {
+        info!("Creating generator with keys = {:?}", destinations);
+        assert!(!destinations.is_empty());
+        let state = GeneratorState::NotInited(wallet.subscribe());
+        let timeout = if with_delay {
+            Delay::new(tokio_timer::clock::now() + WAIT_TIMEOUT).into()
+        } else {
+            None
+        };
+        Generator {
+            timeout,
+            wallet,
+            destinations,
+            state,
+        }
+    }
+    pub fn add_destinations(&mut self, destinations: Vec<PublicKey>) {
+        info!("Adding keys to generator list: keys = {:?}", destinations);
+        self.destinations.extend(destinations)
+    }
+
+    fn handle_wait_creation(&mut self, response: WalletResponse) {
+        match response {
+            WalletResponse::TransactionCreated { tx_hash, .. } => {
+                debug!("Transaction was created: hash = {}", tx_hash);
+                self.state = GeneratorState::WaitForConfirmation(self.wallet.subscribe());
+            }
+            WalletResponse::Error { .. } => {
+                debug!("Error on transaction creation.");
+                self.state = GeneratorState::NotInited(self.wallet.subscribe())
+            }
+            e => warn!("Unexpected WalletResponse = {:?}", e),
+        }
+    }
+
+    /// Process wallet notification, transient to create new transaction.
+    fn handle_wait_confirm(&mut self, info: WalletNotification) {
+        match info {
+            WalletNotification::BalanceChanged { .. } => {
+                debug!("Transaction was processed");
+                self.state = GeneratorState::CreateNew;
+            }
+            _ => {} // we just waiting for concrete notification, ignore other.
+        }
+    }
+
+    /// Process wallet notification, wait for blockchain initialisation.
+    fn handle_wait_init(&mut self, info: WalletNotification) {
+        match info {
+            WalletNotification::BalanceChanged { .. } => {
+                debug!("Wallet inited");
+                self.state = GeneratorState::CreateNew;
+            }
+            _ => {} // we just waiting for concrete notification, ignore other.
+        }
+    }
+
+    /// Start transaction generating, transient to GenerateTx.
+    fn generate_tx(&mut self) {
+        assert_matches!(self.state, GeneratorState::CreateNew);
+        let mut rng = rand::thread_rng();
+
+        let recipient = self.destinations.choose(&mut rng).unwrap().clone();
+        let request = WalletRequest::Payment {
+            comment: "generator".into(),
+            amount: 1,
+            recipient,
+        };
+        debug!("Sending new transaction: request={:?}", request);
+
+        self.state = GeneratorState::WaitForWallet(self.wallet.request(request));
+    }
+}
+
+impl Future for Generator {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let Some(ref mut timer) = self.timeout {
+            match timer.poll() {
+                Ok(Async::Ready(_)) => {
+                    debug!("Delay ended, start generating transactions.");
+                    self.timeout = None;
+                }
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(e) => panic!("failed to poll timer: error={}", e),
+            }
+        }
+        loop {
+            match self.state {
+                GeneratorState::WaitForWallet(ref mut request) => match request.poll() {
+                    Ok(Async::Ready(response)) => {
+                        self.state = GeneratorState::CreateNew;
+                        self.handle_wait_creation(response);
+                    }
+                    Ok(Async::NotReady) => break,
+                    _ => panic!("Wallet disconnected."),
+                },
+                GeneratorState::WaitForConfirmation(ref mut sender) => {
+                    match sender.poll() {
+                        Ok(Async::Ready(Some(response))) => {
+                            // process all notifications, if receiving balance changed create new tx.
+                            self.handle_wait_confirm(response);
+                        }
+                        Ok(Async::NotReady) => break,
+                        _ => panic!("Node disconnected."),
+                    }
+                }
+                GeneratorState::CreateNew => {
+                    info!("Starting transaction generator.");
+                    self.generate_tx();
+                }
+                GeneratorState::NotInited(ref mut sender) => {
+                    match sender.poll() {
+                        Ok(Async::Ready(Some(response))) => {
+                            // process all notifications, if receiving balance changed create new tx.
+                            self.handle_wait_init(response);
+                        }
+                        Ok(Async::NotReady) => break,
+                        _ => panic!("Node disconnected."),
+                    }
+                }
+            }
+        }
+        Ok(Async::NotReady)
+    }
+}

--- a/src/stegos.rs
+++ b/src/stegos.rs
@@ -22,6 +22,7 @@
 mod config;
 mod console;
 mod consts;
+mod generator;
 
 use atty;
 use clap;
@@ -321,7 +322,8 @@ fn run() -> Result<(), Error> {
     // Don't initialize REPL if stdin is not a TTY device
     if atty::is(atty::Stream::Stdin) {
         // Initialize console
-        let console_service = ConsoleService::new(network.clone(), wallet.clone(), node.clone())?;
+        let console_service =
+            ConsoleService::new(&cfg.general, network.clone(), wallet.clone(), node.clone())?;
         rt.spawn(console_service);
     }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -260,6 +260,7 @@ impl WalletService {
         }
 
         if saved_balance != self.balance {
+            debug!("Balance changed.");
             let balance = self.balance;
             let notification = WalletNotification::BalanceChanged { balance };
             self.subscribers


### PR DESCRIPTION
This pullrequest add transaction generator possibility to stegos node.


To start generator one can simply adds line
```
generate_txs = ["84a7e8b14b66b4567fce12b5589a93f2f6ed4404e86f3adb148ca981fb6c7a54"]
```
to `[general]` config section.

This line will activate generator to `84a7e8b14b66b4567fce12b5589a93f2f6ed4404e86f3adb148ca981fb6c7a54`

Generator will choose random key from `generate_txs` field, and create transaction for it.
One transaction at a time.


For cli usage, one can use `generator` command, with `stop` and `start` subcommands.


To add more key use `generator start NEW_KEY,NEW_KEY2`