### PR TITLE
Refactor keying

### DIFF
--- a/blockchain/benches/election.rs
+++ b/blockchain/benches/election.rs
@@ -61,13 +61,13 @@ fn select_1000_slots_out_of_16(b: &mut Bencher) {
     const STAKE: i64 = 100_000;
 
     let random = Hash::digest("bla");
-    let (skey, _, _) = secure::make_random_keys();
+    let (skey, _pkey) = secure::make_random_keys();
 
     let random = secure::make_VRF(&skey, &random);
 
     let mut stakers = Vec::new();
     for _ in 0..GROUP_SIZE {
-        let (_, pkey, _) = secure::make_random_keys();
+        let (_, pkey) = secure::make_random_keys();
         stakers.push((pkey, STAKE));
     }
 
@@ -83,7 +83,7 @@ fn select_1000_slots_out_of_16(b: &mut Bencher) {
 #[bench]
 fn create_vrf(b: &mut Bencher) {
     let random = Hash::digest("bla");
-    let (skey, _, _) = secure::make_random_keys();
+    let (skey, _pkey) = secure::make_random_keys();
 
     b.iter(|| {
         test::black_box(secure::make_VRF(&skey, &random));
@@ -93,7 +93,7 @@ fn create_vrf(b: &mut Bencher) {
 #[bench]
 fn verify_vrf(b: &mut Bencher) {
     let random = Hash::digest("bla");
-    let (skey, pkey, _) = secure::make_random_keys();
+    let (skey, pkey) = secure::make_random_keys();
     let vrf = secure::make_VRF(&skey, &random);
 
     b.iter(|| {

--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -413,9 +413,9 @@ pub mod tests {
 
     #[test]
     fn create_validate_monetary_block() {
-        let (skey0, _pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (_skey2, pkey2, _sig2) = make_random_keys();
+        let (skey0, _pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (_skey2, pkey2) = make_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;
@@ -462,7 +462,7 @@ pub mod tests {
 
     #[test]
     fn validate_pruned_monetary_block() {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;
@@ -498,9 +498,9 @@ pub mod tests {
 
     #[test]
     fn create_validate_monetary_block_with_escrow() {
-        let (skey0, _pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (secure_skey1, secure_pkey1, _secure_sig1) = make_secure_random_keys();
+        let (skey0, _pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (secure_skey1, secure_pkey1) = make_secure_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;
@@ -631,7 +631,7 @@ pub mod tests {
     }
 
     fn create_burn_money(input_amount: i64, output_amount: i64) {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -598,7 +598,7 @@ impl Blockchain {
                         BlockError::MoreThanOneSignatureAtPropose(height, block_hash).into(),
                     );
                 }
-                if !secure::check_hash(&block_hash, &block.body.multisig, &leader) {
+                if let Err(_e) = secure::check_hash(&block_hash, &block.body.multisig, &leader) {
                     return Err(BlockError::InvalidLeaderSignature(height, block_hash).into());
                 }
             } else {
@@ -810,7 +810,7 @@ impl Blockchain {
                     .into());
                 }
             };
-            if !secure::check_hash(&block_hash, &block.body.sig, &leader) {
+            if let Err(_e) = secure::check_hash(&block_hash, &block.body.sig, &leader) {
                 return Err(BlockError::InvalidLeaderSignature(height, block_hash).into());
             }
         }

--- a/blockchain/src/election.rs
+++ b/blockchain/src/election.rs
@@ -286,7 +286,7 @@ mod test {
     /// Check if group size actually depends on limit.
     #[test]
     fn test_group_size() {
-        let (skey, _, _) = secure::make_random_keys();
+        let (skey, _pkey) = secure::make_random_keys();
         let key = secure::PublicKey::dum();
         let keys = vec![(key, 1), (key, 2), (key, 3), (key, 4)];
         let rand = secure::make_VRF(&skey, &Hash::zero());

--- a/blockchain/src/multisignature.rs
+++ b/blockchain/src/multisignature.rs
@@ -127,7 +127,7 @@ pub fn check_multi_signature(
 
     // The hash must match the signature.
     let multipkey: secure::PublicKey = multisigpkey.into();
-    if !secure::check_hash(&hash, &multisig, &multipkey) {
+    if let Err(_e) = secure::check_hash(&hash, &multisig, &multipkey) {
         return Err(MultisignatureError::InvalidSignature(*hash));
     }
     Ok(())
@@ -184,7 +184,7 @@ mod tests {
         let mut validators = Vec::new();
         const NUM_VALIDATORS: usize = 1;
         for _i in 0..NUM_VALIDATORS {
-            let (s, p, _) = secure::make_random_keys();
+            let (s, p) = secure::make_random_keys();
             validators.push((p, 1));
             skeys.push(s);
         }
@@ -195,7 +195,7 @@ mod tests {
         for i in 0..NUM_VALIDATORS {
             let sign = secure::sign_hash(hash, &skeys[i]);
             signatures.push((sign, i as u32));
-            assert!(secure::check_hash(hash, &signatures[i].0, &validators[i].0))
+            secure::check_hash(hash, &signatures[i].0, &validators[i].0).unwrap();
         }
 
         let multisig = create_multi_signature_index(signatures.iter().map(|p| (p.1, &p.0)));

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -541,7 +541,7 @@ impl StakeOutput {
         self.recipient.hash(&mut state);
         self.payload.hash(&mut state);
         let h = state.result();
-        if !secure::check_hash(&h, &self.signature, &self.validator) {
+        if let Err(_e) = secure::check_hash(&h, &self.signature, &self.validator) {
             let output_hash = Hash::digest(&self);
             return Err(OutputError::InvalidStakeSignature(output_hash).into());
         }
@@ -648,7 +648,7 @@ pub mod tests {
             assert_eq!(payload, &payload2);
         }
 
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
 
         // With empty comment.
         let gamma: Fr = Fr::random();
@@ -802,7 +802,7 @@ pub mod tests {
             assert_eq!(payload, &payload2);
         }
 
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let output_hash = Hash::digest("test");
 
         // Basic.
@@ -847,8 +847,8 @@ pub mod tests {
     ///
     #[test]
     pub fn payment_encrypt_decrypt() {
-        let (skey1, _pkey1, _sig1) = make_random_keys();
-        let (skey2, pkey2, _sig2) = make_random_keys();
+        let (skey1, _pkey1) = make_random_keys();
+        let (skey2, pkey2) = make_random_keys();
 
         let timestamp = SystemTime::now();
         let amount: i64 = 100500;
@@ -878,9 +878,9 @@ pub mod tests {
     ///
     #[test]
     pub fn stake_encrypt_decrypt() {
-        let (skey1, _pkey1, _sig1) = make_random_keys();
-        let (skey2, pkey2, _sig2) = make_random_keys();
-        let (secure_skey1, secure_pkey1, _secure_sig1) = secure::make_random_keys();
+        let (skey1, _pkey1) = make_random_keys();
+        let (skey2, pkey2) = make_random_keys();
+        let (secure_skey1, secure_pkey1) = secure::make_random_keys();
 
         let timestamp = SystemTime::now();
         let amount: i64 = 100500;
@@ -911,7 +911,7 @@ pub mod tests {
 
     #[test]
     pub fn unencrypted_payload() {
-        let (skey, pkey, _) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let amount: i64 = 0x1234567;
 
         let (output, gamma) =

--- a/blockchain/src/protos.rs
+++ b/blockchain/src/protos.rs
@@ -526,9 +526,9 @@ mod tests {
 
     #[test]
     fn outputs() {
-        let (skey0, _pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (secure_skey1, secure_pkey1, _secure_sig1) = make_secure_random_keys();
+        let (skey0, _pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (secure_skey1, secure_pkey1) = make_secure_random_keys();
 
         let amount = 1_000_000;
         let timestamp = SystemTime::now();
@@ -554,9 +554,9 @@ mod tests {
     }
 
     fn mktransaction() -> Transaction {
-        let (skey0, _pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (_skey2, pkey2, _sig2) = make_random_keys();
+        let (skey0, _pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (_skey2, pkey2) = make_random_keys();
 
         let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
@@ -608,7 +608,7 @@ mod tests {
 
     #[test]
     fn key_blocks() {
-        let (skey0, _pkey0, _sig0) = make_secure_random_keys();
+        let (skey0, _pkey0) = make_secure_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;
@@ -641,9 +641,9 @@ mod tests {
 
     #[test]
     fn monetary_blocks() {
-        let (skey0, _pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (_skey2, pkey2, _sig2) = make_random_keys();
+        let (skey0, _pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (_skey2, pkey2) = make_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;

--- a/blockchain/src/storage.rs
+++ b/blockchain/src/storage.rs
@@ -124,7 +124,7 @@ mod test {
     use stegos_crypto::pbc::secure;
 
     fn create_block(previous: Hash) -> Block {
-        let (skey0, _pkey0, _sig0) = secure::make_random_keys();
+        let (skey0, _pkey0) = secure::make_random_keys();
         let version: u64 = 1;
         let epoch: u64 = 1;
         let timestamp = SystemTime::now();

--- a/blockchain/src/transaction.rs
+++ b/blockchain/src/transaction.rs
@@ -435,7 +435,7 @@ pub mod tests {
     ///
     #[test]
     pub fn no_inputs() {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
         let fee: i64 = amount;
@@ -454,7 +454,7 @@ pub mod tests {
     #[test]
     pub fn no_outputs() {
         // No outputs
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let (tx, inputs, _outputs) =
             Transaction::new_test(&skey, &pkey, 100, 1, 0, 0, 100).expect("transaction is valid");
         tx.validate(&inputs).expect("transaction is valid");
@@ -465,9 +465,9 @@ pub mod tests {
     ///
     #[test]
     pub fn payment_utxo() {
-        let (skey0, pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (_skey2, pkey2, _sig2) = make_random_keys();
+        let (skey0, pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (_skey2, pkey2) = make_random_keys();
 
         let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
@@ -638,9 +638,9 @@ pub mod tests {
     ///
     #[test]
     pub fn stake_utxo() {
-        let (skey0, _pkey0, _sig0) = make_random_keys();
-        let (skey1, pkey1, _sig1) = make_random_keys();
-        let (secure_skey1, secure_pkey1, _secure_sig1) = secure::make_random_keys();
+        let (skey0, _pkey0) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (secure_skey1, secure_pkey1) = secure::make_random_keys();
 
         let timestamp = SystemTime::now();
         let amount: i64 = 1_000_000;
@@ -774,9 +774,9 @@ pub mod tests {
 
     #[test]
     fn test_supertransaction() {
-        let (skey1, pkey1, _) = make_random_keys();
-        let (skey2, pkey2, _) = make_random_keys();
-        let (skey3, pkey3, _) = make_random_keys();
+        let (skey1, pkey1) = make_random_keys();
+        let (skey2, pkey2) = make_random_keys();
+        let (skey3, pkey3) = make_random_keys();
         let timestamp = SystemTime::now();
         let err_utxo = "Can't construct UTXO";
         let iamt1 = 101;

--- a/consensus/src/message.rs
+++ b/consensus/src/message.rs
@@ -125,7 +125,7 @@ impl<Request: Hashable, Proof: Hashable> ConsensusMessage<Request, Proof> {
         self.request_hash.hash(&mut hasher);
         self.body.hash(&mut hasher);
         let hash = hasher.result();
-        if !secure::check_hash(&hash, &self.sig, &self.pkey) {
+        if let Err(_e) = secure::check_hash(&hash, &self.sig, &self.pkey) {
             return Err(ConsensusError::InvalidMessageSignature);
         }
         match &self.body {

--- a/consensus/src/optimistic.rs
+++ b/consensus/src/optimistic.rs
@@ -58,7 +58,7 @@ impl ViewChangeMessage {
         }
         let hash = Hash::digest(&self.chain);
         let author = blockchain.validators()[validator_id as usize].0;
-        if !secure::check_hash(&hash, &self.signature, &author) {
+        if let Err(_e) = secure::check_hash(&hash, &self.signature, &author) {
             return Err(ConsensusError::InvalidViewChangeSignature);
         }
         Ok(())

--- a/consensus/src/protos.rs
+++ b/consensus/src/protos.rs
@@ -141,6 +141,7 @@ mod tests {
     use std::time::SystemTime;
     use stegos_crypto::hash::Hashable;
     use stegos_crypto::pbc::secure::make_random_keys as make_secure_random_keys;
+    use stegos_crypto::pbc::secure::sign_hash as secure_sign_hash;
 
     fn roundtrip<T>(x: &T) -> T
     where
@@ -153,7 +154,7 @@ mod tests {
 
     #[test]
     fn consensus() {
-        let (network_skey, network_pkey, network_sig) = make_secure_random_keys();
+        let (network_skey, network_pkey) = make_secure_random_keys();
 
         let body = ConsensusMessageBody::Prevote {};
         let msg = ConsensusMessage::new(
@@ -166,9 +167,8 @@ mod tests {
         );
         roundtrip(&msg);
 
-        let body = ConsensusMessageBody::Precommit {
-            request_hash_sig: network_sig,
-        };
+        let request_hash_sig = secure_sign_hash(&Hash::digest("test"), &network_skey);
+        let body = ConsensusMessageBody::Precommit { request_hash_sig };
         let msg = ConsensusMessage::new(
             1,
             1,
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn key_blocks() {
-        let (skey0, _pkey0, _sig0) = make_secure_random_keys();
+        let (skey0, _pkey0) = make_secure_random_keys();
 
         let version: u64 = 1;
         let height: u64 = 0;

--- a/consensus/src/state.rs
+++ b/consensus/src/state.rs
@@ -561,7 +561,7 @@ impl<Request: Hashable + Clone + Debug + Eq, Proof: Hashable + Clone + Debug>
 
                 // Check signature.
                 let request_hash = Hash::digest(self.request.as_ref().unwrap());
-                if !secure::check_hash(&request_hash, &request_hash_sig, &msg.pkey) {
+                if let Err(_e) = secure::check_hash(&request_hash, &request_hash_sig, &msg.pkey) {
                     error!(
                         "{}({}:{}): a pre-commit signature is not valid: from={:?}",
                         self.state.name(),

--- a/crypto/examples/pbc.rs
+++ b/crypto/examples/pbc.rs
@@ -35,11 +35,9 @@ fn main() {
     println!("rand Zr = {}", secure::Zr::random().to_hex());
 
     // test keying...
-    let (_skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
-    println!("pkey = {:?}", pkey);
-    println!("sig  = {:?}", sig);
-    assert!(secure::check_keying(&pkey, &sig));
-    println!("");
+    let (skey, pkey) = secure::make_deterministic_keys(b"Testing");
+    secure::check_keying(&skey, &pkey).unwrap();
+    println!();
 
     // -------------------------------------
     // on Fast pairings
@@ -59,13 +57,9 @@ fn main() {
     println!("chk Zr: -1 -> {:?}", fast::Zr::from(-1));
     println!("chk Zr: -1 + 1 -> {:?}", fast::Zr::from(-1) + 1);
 
-    let (_skey, pkey, sig) = secure::make_deterministic_keys(b"dev");
-    println!("pkey = {:?}", pkey);
-    println!("sig = {:?}", sig);
-
     // -----------------------------------------
-    let (skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
-    assert!(secure::check_keying(&pkey, &sig));
+    let (skey, pkey) = secure::make_deterministic_keys(b"Testing");
+    secure::check_keying(&skey, &pkey).unwrap();
     let hseed = Hash::from_str("VRF_Seed");
     let vrf = secure::make_VRF(&skey, &hseed);
     println!("VRF Rand: {:?}", vrf.rand);

--- a/crypto/protos/crypto.proto
+++ b/crypto/protos/crypto.proto
@@ -47,6 +47,11 @@ message EncryptedPayload {
     bytes ctxt = 2;
 }
 
+message EncryptedKey {
+    EncryptedPayload payload = 1;
+    SchnorrSig sig = 2;
+}
+
 message LR {
     Pt l = 2;
     Pt r = 3;

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -240,17 +240,14 @@ mod tests {
             secure::PublicKey::try_from_hex(&SIG_PKEY).expect("Invalid hexstr: SIG_PKEY");
         let sig = secure::Signature::try_from_hex(&SIG_1174).expect("Invalid hexstr: SIG_1174");
         let h = Hash::try_from_hex(&HASH_CONSTS).expect("Invalid hexstr: HASH_CONSTS");
-        assert!(
-            secure::check_hash(&h, &sig, &sig_pkey),
-            "Invalid Curve1174 init constants"
-        );
+        secure::check_hash(&h, &sig, &sig_pkey).expect("Invalid Curve1174 init contants");
     }
 
     #[test]
     fn chk_encryption() {
         use crate::hash;
-        let (skey, pkey, sig) = make_random_keys();
-        check_keying(&pkey, &sig).expect("Random keying failed");
+        let (skey, pkey) = make_random_keys();
+        check_keying(&skey, &pkey).expect("Random keying failed");
         let msg = hash::hash_nbytes(72, b"This is a test");
         let mchk = Hash::from_vector(&msg);
         let payload = aes_encrypt(&msg, &pkey).expect("AES Encryption failed");
@@ -340,8 +337,8 @@ pub fn curve1174_tests() {
     println!("hash -> {:?}", ept2);
 
     // ---------------------------------------------------------------
-    let (skey, pkey, sig) = make_deterministic_keys(b"Testing");
-    check_keying(&pkey, &sig).expect("Bad keying");
+    let (skey, pkey) = make_deterministic_keys(b"Testing");
+    check_keying(&skey, &pkey).expect("Bad keying");
     println!("pkey = {:?}", pkey);
 
     let delta = Fr::random();

--- a/crypto/src/dicemix/mod.rs
+++ b/crypto/src/dicemix/mod.rs
@@ -789,9 +789,9 @@ mod tests {
 
     #[test]
     fn tst_sheet_gen() {
-        let (sk1, pk1, _) = pbc::secure::make_deterministic_keys(b"User1");
-        let (sk2, pk2, _) = pbc::secure::make_deterministic_keys(b"User2");
-        let (sk3, pk3, _) = pbc::secure::make_deterministic_keys(b"User3");
+        let (sk1, pk1) = pbc::secure::make_deterministic_keys(b"User1");
+        let (sk2, pk2) = pbc::secure::make_deterministic_keys(b"User2");
+        let (sk3, pk3) = pbc::secure::make_deterministic_keys(b"User3");
         let all_participants = vec![pk1, pk2, pk3];
         dbg!(&all_participants);
 
@@ -800,9 +800,9 @@ mod tests {
         let participants_3 = vec![pk1, pk2];
 
         let sess = Hash::from_str("session1");
-        let (sess_sk1, sess_pk1, _) = curve1174::cpt::make_deterministic_keys(b"User1-session1");
-        let (sess_sk2, sess_pk2, _) = curve1174::cpt::make_deterministic_keys(b"User2-session1");
-        let (sess_sk3, sess_pk3, _) = curve1174::cpt::make_deterministic_keys(b"User3-session1");
+        let (sess_sk1, sess_pk1) = curve1174::cpt::make_deterministic_keys(b"User1-session1");
+        let (sess_sk2, sess_pk2) = curve1174::cpt::make_deterministic_keys(b"User2-session1");
+        let (sess_sk3, sess_pk3) = curve1174::cpt::make_deterministic_keys(b"User3-session1");
 
         let mut npk1 = HashMap::new();
         npk1.insert(pk2, sess_pk2);
@@ -1045,7 +1045,7 @@ mod tests {
         let mut participants = Vec::<ParticipantID>::new();
         for ix in 0..nparts {
             let seed = format!("User_{}", ix).into_bytes();
-            let (sk, pk, _) = pbc::secure::make_deterministic_keys(&seed);
+            let (sk, pk) = pbc::secure::make_deterministic_keys(&seed);
             // skeys.push(sk);
             participants.push(pk);
         }
@@ -1062,7 +1062,7 @@ mod tests {
         let mut sess_skeys = HashMap::new();
         for ix in 0..nparts {
             let seed = format!("User_{}_Session_Key", ix).into_bytes();
-            let (sk, pk, _) = curve1174::cpt::make_deterministic_keys(&seed);
+            let (sk, pk) = curve1174::cpt::make_deterministic_keys(&seed);
             let p = participants[ix];
             sess_pkeys.insert(p, pk);
             sess_skeys.insert(p, sk);

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -247,30 +247,24 @@ pub mod tests {
         let h = Hash::try_from_hex(&HASH_AR160).expect("Invalid hexstring: HASH_AR160");
         let sig =
             secure::Signature::try_from_hex(&SIG_AR160).expect("Invalid hexstring: SIG_AR160");
-        assert!(
-            secure::check_hash(&h, &sig, &sig_pkey),
-            "Invalid curve constants for AR160"
-        );
+        secure::check_hash(&h, &sig, &sig_pkey).expect("valid curve constants for AR160");
 
         let h = Hash::try_from_hex(&HASH_FR256).expect("Invalid hexstring: HASH_FR256");
         let sig = secure::Signature::try_from_hex(SIG_FR256).expect("Invalid hexstring: SIG_FR256");
-        assert!(
-            secure::check_hash(&h, &sig, &sig_pkey),
-            "Invalid curve constants for FR256"
-        );
+        secure::check_hash(&h, &sig, &sig_pkey).expect("Invalid curve constants for FR256");
 
         // check to be sure make_deterministic_keys() stil works properly
         let mut rng: ThreadRng = thread_rng();
         let seed = rng.gen::<[u8; 32]>();
-        let (_skey, pkey, sig) = secure::make_deterministic_keys(&seed);
-        assert!(secure::check_keying(&pkey, &sig), "Invalid keying");
+        let (skey, pkey) = secure::make_deterministic_keys(&seed);
+        secure::check_keying(&skey, &pkey).expect("Invalid keying");
         fast::G2::generator();
     }
 
     #[test]
     fn check_vrf() {
-        let (skey, pkey, sig) = secure::make_deterministic_keys(b"Testing");
-        assert!(secure::check_keying(&pkey, &sig));
+        let (skey, pkey) = secure::make_deterministic_keys(b"Testing");
+        secure::check_keying(&skey, &pkey).unwrap();
         let hseed = Hash::from_str("VRF_Seed");
         let vrf = secure::make_VRF(&skey, &hseed);
         assert!(secure::validate_VRF_randomness(&vrf));

--- a/network/src/delivery/protocol.rs
+++ b/network/src/delivery/protocol.rs
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn correct_transfer() {
-        let (_, pkey, _) = secure::make_random_keys();
+        let (_, pkey) = secure::make_random_keys();
 
         let msg = DeliveryMessage::UnicastMessage(Unicast {
             to: pkey,
@@ -266,7 +266,7 @@ mod tests {
 
         test_one(msg);
 
-        let (_, node_id, _) = secure::make_random_keys();
+        let (_, node_id) = secure::make_random_keys();
 
         let msg = DeliveryMessage::BroadcastMessage(Broadcast {
             from: node_id,

--- a/network/src/discovery/behavior.rs
+++ b/network/src/discovery/behavior.rs
@@ -390,7 +390,7 @@ where
                 Ok(Async::NotReady) => break,
                 Ok(Async::Ready(_)) => {
                     debug!(target: "stegos_network::discovery", "Shooting at DHT to gather nodes information");
-                    let (_, random_node_id, _) = secure::make_random_keys();
+                    let (_, random_node_id) = secure::make_random_keys();
                     self.kademlia.find_node(random_node_id);
                     // Reset the `Delay` to the next random.
                     self.next_query

--- a/network/src/kad/kbucket.rs
+++ b/network/src/kad/kbucket.rs
@@ -650,8 +650,8 @@ mod tests {
 
     #[test]
     fn pbc_distance_between_keys() {
-        let (_, a, _) = secure::make_random_keys();
-        let (_, b, _) = secure::make_random_keys();
+        let (_, a) = secure::make_random_keys();
+        let (_, b) = secure::make_random_keys();
         assert_eq!(a.distance_with(&a), 0);
         assert!(a.distance_with(&a) < b.distance_with(&a));
         assert!(a.distance_with(&b) > b.distance_with(&b));
@@ -659,8 +659,8 @@ mod tests {
 
     #[test]
     fn pbc_basic_closest() {
-        let (_, my_id, _) = secure::make_random_keys();
-        let (_, other_id, _) = secure::make_random_keys();
+        let (_, my_id) = secure::make_random_keys();
+        let (_, other_id) = secure::make_random_keys();
 
         let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
         table.entry_mut(&other_id);
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn pbc_update_local_id_fails() {
-        let (_, my_id, _) = secure::make_random_keys();
+        let (_, my_id) = secure::make_random_keys();
 
         let mut table = KBucketsTable::<_, ()>::new(my_id.clone(), Duration::from_secs(5));
         assert!(table.entry_mut(&my_id).is_none());
@@ -684,13 +684,13 @@ mod tests {
 
     #[test]
     fn pbc_update_time_last_refresh() {
-        let (_, my_id, _) = secure::make_random_keys();
+        let (_, my_id) = secure::make_random_keys();
         let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
 
         // Generate some other IDs varying by just one bit.
         let other_ids = (0..random::<usize>() % 128)
             .map(|_| {
-                let (_, id, _) = secure::make_random_keys();
+                let (_, id) = secure::make_random_keys();
                 (id, table.bucket_num(&id).unwrap())
             })
             .collect::<Vec<_>>();

--- a/network/src/kad/query.rs
+++ b/network/src/kad/query.rs
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn start_by_sending_rpc_to_known_peers() {
-        let (_, random_id, _) = secure::make_random_keys();
+        let (_, random_id) = secure::make_random_keys();
         let random_target = Multihash::random(Hash::SHA3512);
 
         let target = QueryTarget::FindPeer(random_target);
@@ -516,8 +516,8 @@ mod tests {
 
     #[test]
     fn continue_second_result() {
-        let (_, random_id, _) = secure::make_random_keys();
-        let (_, random_id2, _) = secure::make_random_keys();
+        let (_, random_id) = secure::make_random_keys();
+        let (_, random_id2) = secure::make_random_keys();
         let random_target = Multihash::random(Hash::SHA3512);
         let target = QueryTarget::FindPeer(random_target);
 
@@ -561,7 +561,7 @@ mod tests {
 
     #[test]
     fn timeout_works() {
-        let (_, random_id, _) = secure::make_random_keys();
+        let (_, random_id) = secure::make_random_keys();
         let random_target = Multihash::random(Hash::SHA3512);
         let target = QueryTarget::FindPeer(random_target);
 

--- a/network/src/libp2p_network/mod.rs
+++ b/network/src/libp2p_network/mod.rs
@@ -796,7 +796,7 @@ fn decrypt_message(
     payload.data.hash(&mut hasher);
     let hash = hasher.result();
 
-    if !secure::check_hash(&hash, &signature, &payload.from) {
+    if let Err(_e) = secure::check_hash(&hash, &signature, &payload.from) {
         return Err(format_err!("Bad packet signature."));
     }
 
@@ -816,8 +816,8 @@ mod tests {
 
     #[test]
     fn encode_decode() {
-        let (from_skey, from, _) = secure::make_random_keys();
-        let (to_skey, to, _) = secure::make_random_keys();
+        let (from_skey, from) = secure::make_random_keys();
+        let (to_skey, to) = secure::make_random_keys();
         let protocol_id = "the quick brown fox".to_string();
         let data = random_vec(1024);
 

--- a/network/src/ncp/protocol.rs
+++ b/network/src/ncp/protocol.rs
@@ -236,7 +236,7 @@ mod tests {
     fn correct_transfer() {
         test_one(NcpMessage::GetPeersRequest);
 
-        let (_, node_id, _) = secure::make_random_keys();
+        let (_, node_id) = secure::make_random_keys();
 
         let msg = NcpMessage::GetPeersResponse {
             response: GetPeersResponse {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -466,7 +466,7 @@ impl NodeService {
         // Check signature first.
         let remote_view_change = remote.header.base.view_change;
         let leader = self.chain.select_leader(remote_view_change);
-        if !secure::check_hash(&remote_hash, &remote.body.sig, &leader) {
+        if let Err(_e) = secure::check_hash(&remote_hash, &remote.body.sig, &leader) {
             return Err(BlockError::InvalidLeaderSignature(height, remote_hash).into());
         }
 
@@ -677,7 +677,7 @@ impl NodeService {
                 .map_err(|e| BlockError::InvalidBlockSignature(e, block_height, block_hash))?;
             }
             Block::MonetaryBlock(ref block) => {
-                if !secure::check_hash(&block_hash, &block.body.sig, &leader) {
+                if let Err(_e) = secure::check_hash(&block_hash, &block.body.sig, &leader) {
                     return Err(BlockError::InvalidLeaderSignature(block_height, block_hash).into());
                 }
             }

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -219,7 +219,7 @@ mod test {
 
     #[test]
     fn basic() {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let mut mempool = Mempool::new();
 
         let (tx1, inputs1, outputs1) =
@@ -285,7 +285,7 @@ mod test {
     #[test]
     #[should_panic]
     pub fn inconsistent_pruning1() {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let mut mempool = Mempool::new();
 
         let (tx, inputs, _outputs) =
@@ -298,7 +298,7 @@ mod test {
     #[test]
     #[should_panic]
     pub fn inconsistent_pruning2() {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let mut mempool = Mempool::new();
 
         let (tx, _inputs, outputs) =
@@ -310,7 +310,7 @@ mod test {
 
     #[test]
     fn create_block() {
-        let (skey, pkey, _sig) = make_random_keys();
+        let (skey, pkey) = make_random_keys();
         let mut mempool = Mempool::new();
 
         let (tx1, inputs1, _outputs1) =

--- a/node/src/test/consensus.rs
+++ b/node/src/test/consensus.rs
@@ -107,11 +107,12 @@ fn smoke_test() {
                 request_hash_sig, ..
             } = precommit.body
             {
-                assert!(secure::check_hash(
+                secure::check_hash(
                     &proposal.request_hash,
                     &request_hash_sig,
-                    &node.node_service.keys.network_pkey
-                ));
+                    &node.node_service.keys.network_pkey,
+                )
+                .unwrap();
             } else {
                 panic!("Invalid packet");
             }

--- a/txpool/src/protos.rs
+++ b/txpool/src/protos.rs
@@ -149,8 +149,8 @@ mod tests {
 
     #[test]
     fn pool_info() {
-        let (_, pkey, _) = secure::make_random_keys();
-        let (_, pkey1, _) = secure::make_random_keys();
+        let (_, pkey) = secure::make_random_keys();
+        let (_, pkey1) = secure::make_random_keys();
 
         let session_id = Hash::digest(&1u64);
         let mut participants: Vec<secure::PublicKey> = Vec::new();

--- a/wallet/examples/show_utxo_chunks.rs
+++ b/wallet/examples/show_utxo_chunks.rs
@@ -44,7 +44,7 @@ use stegos_crypto::dicemix::*;
 
 fn main() {
     // Determine number of DiceMix chunks needed to support our UTXO's
-    let (skey, pkey, _) = make_random_keys();
+    let (skey, pkey) = make_random_keys();
     let tstamp = SystemTime::now();
     let data = PaymentPayloadData::Comment("Testing".to_string());
     let (out, gamma) = PaymentOutput::with_payload(tstamp, &skey, &pkey, 1500, data)

--- a/wallet/src/transaction.rs
+++ b/wallet/src/transaction.rs
@@ -458,8 +458,8 @@ pub mod tests {
         assert!(payment_fee > 0 && stake_fee > 0);
         simple_logger::init_with_level(log::Level::Debug).unwrap_or_default();
 
-        let (skey, pkey, _sig0) = make_random_keys();
-        let (validator_skey, validator_pkey, _validator_sig) = secure::make_random_keys();
+        let (skey, pkey) = make_random_keys();
+        let (validator_skey, validator_pkey) = secure::make_random_keys();
 
         let timestamp = SystemTime::now();
         let stake: i64 = 100;

--- a/wallet/src/valueshuffle/mod.rs
+++ b/wallet/src/valueshuffle/mod.rs
@@ -1886,7 +1886,7 @@ fn make_session_key(skey: &SecretKey, sid: &Hash) -> (SecretKey, PublicKey) {
         skey.hash(&mut state);
         state.result()
     };
-    let (skey, pkey, _) = make_deterministic_keys(&seed.to_bytes());
+    let (skey, pkey) = make_deterministic_keys(&seed.to_bytes());
     (skey, pkey)
 }
 

--- a/wallet/src/valueshuffle/protos.rs
+++ b/wallet/src/valueshuffle/protos.rs
@@ -211,7 +211,7 @@ pub mod tests {
 
     #[test]
     fn vs_serialization() {
-        let (_skey, pkey, _) = make_random_keys();
+        let (_skey, pkey) = make_random_keys();
         let sid = Hash::digest("test");
         let ksig = simple_commit(Fr::from(1), Fr::zero()).compress();
         let msg = Message::VsMessage {


### PR DESCRIPTION
- Don't returni the third result (a signature) from make_secure_keys().
  This result is never used.
- Return Result<(), Error> from check_hash().
- Rework check_keying() to work without a signature.
- Add EncryptedKey structure and protobuf definitions.

Needed for #725
Needed for #784