### PR TITLE
Hashcash integration is complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arc-swap"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -110,8 +110,8 @@ name = "asn1_der_derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ dependencies = [
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -203,7 +203,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -224,7 +224,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -299,6 +299,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "build_const"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bumpalo"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -617,8 +622,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -704,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "h2"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,13 +790,13 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.25"
+version = "0.12.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -918,7 +923,7 @@ dependencies = [
  "parity-multihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -942,7 +947,7 @@ dependencies = [
  "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -964,8 +969,8 @@ name = "libp2p-core-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -992,7 +997,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,7 +1017,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1039,7 +1044,7 @@ dependencies = [
  "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1160,13 +1165,13 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rw-stream-sink 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1263,7 +1268,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "arc-swap 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1686,31 +1691,31 @@ dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1725,7 +1730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1891,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1899,7 +1904,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1910,7 +1915,7 @@ dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2006,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2118,8 +2123,8 @@ version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2153,7 +2158,7 @@ name = "sha2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2164,7 +2169,7 @@ name = "sha3"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2229,14 +2234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stdweb"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb-derive 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb-internal-macros 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb-internal-runtime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb-internal-macros 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb-internal-runtime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2245,30 +2251,30 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stdweb-internal-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base-x 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stdweb-internal-runtime"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2282,12 +2288,12 @@ dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolve 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2339,7 +2345,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2361,7 +2367,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_blockchain 0.2.0",
@@ -2382,7 +2388,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2428,7 +2434,7 @@ dependencies = [
  "lru_time_cache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2458,7 +2464,7 @@ dependencies = [
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2478,8 +2484,8 @@ name = "stegos_serialization"
 version = "0.2.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen-pure 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen-pure 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2491,7 +2497,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-stream-select-all-send 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_blockchain 0.2.0",
  "stegos_crypto 0.2.0",
  "stegos_keychain 0.2.0",
@@ -2509,7 +2515,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-stream-select-all-send 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2552,11 +2558,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.30"
+version = "0.15.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2566,8 +2572,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2648,7 +2654,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2666,7 +2672,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2684,7 +2690,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3086,6 +3092,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "websocket"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,7 +3269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aio-limited 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f10b352bc3fc08ae24dc5d2d3ddcac153678533986122dc283d747b12071000"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-"checksum arc-swap 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcee9b73d8a058eebb0b567fd3687f6761fb232049f92c23bdd2c82b6fe0c0cc"
+"checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
@@ -3237,11 +3291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitvector 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5cf5597d7009ed5b750dc54a9c54efbb1858ed8b16e533f72715d5e3bad8c35"
 "checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
+"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+"checksum bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6a6bc2ba935b1e2f810787ceba8dfe86cbc164cee55925cae715541186673c4"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
@@ -3292,7 +3347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "910a5e7be6283a9c91b3982fa5188368c8719cce2a3cf3b86048673bf9d9c36b"
+"checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"
@@ -3300,7 +3355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c"
-"checksum hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5b6658b016965ae301fa995306db965c93677880ea70765a84235a96eae896"
+"checksum hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4f2777434f26af6e4ce4fdcdccd3bed9d861d11e87bcbe72c0f51ddaca8ff848"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -3382,12 +3437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pnet_transport 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5faa55dcf725487a699adcff88dfea8f17ea34fa2640528866d9acbb4e3a104f"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48e3f33ff50a88c73ad8458fa6c22931aa7a6e19bb4a95d62816618c153b3f02"
-"checksum protobuf 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "524d165d95627ddebba768db728216c4429bbb62882f7e6ab1a6c3c54a7ed830"
-"checksum protobuf-codegen 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e142c5972a0736674d647714ac7a454f20aef31b09902d330583b8d8a96401a1"
-"checksum protobuf-codegen-pure 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1178f17075b726571f3a7ee8e96e84d71dd791c0c270f8da24cd65a0fa27d619"
+"checksum protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc7badf647ae2fa27ba51c218e347386c88cc604fcfe71f2aba0ad017f3f2b75"
+"checksum protobuf-codegen 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1be75a48019eb5143bd971a904cd99e58ffd25042f36361460b5b21e1de80487"
+"checksum protobuf-codegen-pure 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "14fd83f63c98c680d438fa54f745459ae6ee3cc65564e46985000985a2b7b5fd"
 "checksum quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb6ccf8db7bbcb9c2eae558db5ab4f3da1c2a87e4e597ed394726bc8ea6ca1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
@@ -3404,7 +3459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.53 (registry+https://github.com/rust-lang/crates.io-index)" = "53848511b7ee6eb9d5c3db48481aaa5779b38fc0131bc133c98cb4f2b2411928"
+"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
@@ -3416,7 +3471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ddf28998d5730b96a9fe188557953de503d77ff403ae175ad1417921e5d906"
 "checksum rust-libpbc 0.1.0 (git+https://github.com/stegos/rust-pbcintf.git)" = "<none>"
-"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustyline 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6010155119d53aac4f5b987cb8f6ea913d0d64d9b237da36f8f96a90cb3f5385"
@@ -3445,16 +3500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "92a7e0c5e3dfb52e8fbe0e63a1b947bbb17b4036408b151353c4491374931362"
-"checksum stdweb 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a3edad410e603184d656e2abded5fd4d3d6e93d5763d21130dbaf99795db74eb"
+"checksum stdweb 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c1d5ac2f828b2877a6be60a51b8e3ebb57b56862b10be1a72676ca8900b69d"
 "checksum stdweb-derive 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e21ebd9179de08f2300a65454268a17ea3de204627458588c84319c4def3930"
-"checksum stdweb-internal-macros 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1635afd059cbfac7d5b1274f0c44cec110c1e013c48e8bbc22e07e52696cf887"
-"checksum stdweb-internal-runtime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a2a2f4a2eb556337b2d1a302630bbddf989ae383c70393e89b48152b9896cbda"
+"checksum stdweb-internal-macros 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e68f7d08b76979a43e93fe043b66d2626e35d41d68b0b85519202c6dd8ac59fa"
+"checksum stdweb-internal-runtime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d52317523542cc0af5b7e31017ad0f7d1e78da50455e38d5657cd17754f617da"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "702662512f3ddeb74a64ce2fbbf3707ee1b6bb663d28bb054e0779bbc720d926"
-"checksum syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)" = "66c8865bf5a7cbb662d8b011950060b3c8743dca141b054bf7195b20d314d8e2"
+"checksum syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)" = "846620ec526c1599c070eff393bfeeeb88a93afa2513fc3b49f1fea84cf7b0ed"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317"
 "checksum syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
@@ -3513,6 +3568,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
+"checksum wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ffde3534e5fa6fd936e3260cd62cd644b8656320e369388f9303c955895e35d4"
+"checksum wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "40c0543374a7ae881cdc5d32d19de28d1d1929e92263ffa7e31712cc2d53f9f1"
+"checksum wasm-bindgen-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "f914c94c2c5f4c9364510ca2429e59c92157ec89429243bcc245e983db990a71"
+"checksum wasm-bindgen-macro-support 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9168c413491e4233db7b6884f09a43beb00c14d11d947ffd165242daa48a2385"
+"checksum wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "326c32126e1a157b6ced7400061a84ac5b11182b2cda6edad7314eb3ae9ac9fe"
 "checksum websocket 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7cc2d74d89f9df981ab41ae624e33cf302fdf456b93455c6a31911a99c9f0bb8"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/crypto/src/hashcash/mod.rs
+++ b/crypto/src/hashcash/mod.rs
@@ -35,6 +35,7 @@
 /// --------------------------------------------------------------------------
 use crate::hash::*;
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct HashCashProof {
     pub nbits: usize,
     pub seed: Vec<u8>,

--- a/network/protos/gatekeeper_proto.proto
+++ b/network/protos/gatekeeper_proto.proto
@@ -1,32 +1,32 @@
 syntax = "proto3";
 package gatekeeper.pb;
 
-enum ConnectionType {
-    FULL_NODE = 0;      // Blockchain protocols + Routing + Query
-    ROUTING = 1;        // Route unicast messages
-    QUERY = 2;          // Allow discovery queris
-    NONE = 4;           // No communications allowed
+message HashcashProof {
+    bytes seed = 1;
+    uint32 nbits = 2;
+    sint64 count = 3;
 }
 
-message HelloRequest {
-    // desired connection type
-    ConnectionType conn_type = 1;
-    // PBC PublicKey
-    bytes node_id = 2;
+message UnlockRequest {
+    // Optional proof
+    HashcashProof proof = 1;
 }
 
-message HelloReply {
-    // enabled connection type
-    ConnectionType conn_type = 1;
-    // PBC PublicKey
-    bytes node_id = 2;
-    // List of IPs of other nodes to try to connect to
-    repeated bytes other_nodes = 3;
+message ChallengeReply {
+    // Puzzle seed
+    bytes seed = 1;
+    // Number of bits to calculate
+    uint32 nbits = 2;
+}
+
+message PermitReply {
+    bool connection_allowed = 1;
 }
 
 message Message {
     oneof typ {
-        HelloRequest request = 1;
-        HelloReply reply = 2;
+        UnlockRequest unlock_request = 1;
+        ChallengeReply challenge_reply = 3;
+        PermitReply permit_reply = 4;
     }
 }

--- a/network/src/gatekeeper/behavior.rs
+++ b/network/src/gatekeeper/behavior.rs
@@ -22,24 +22,43 @@
 // SOFTWARE.
 
 use futures::prelude::*;
+use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use libp2p::core::{
     protocols_handler::ProtocolsHandler,
     swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters},
     Multiaddr, PeerId,
 };
 use log::*;
+use lru_time_cache::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
+use std::time::{Duration, SystemTime};
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     marker::PhantomData,
+    thread,
 };
+use stegos_crypto::hashcash::{self, HashCashProof};
 use stegos_crypto::pbc::secure;
 use stegos_keychain::KeyChain;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::handler::{GatekeeperHandler, GatekeeperSendEvent};
-use super::protocol::{ConnectionType, GatekeeperMessage};
+use super::protocol::GatekeeperMessage;
 use crate::config::NetworkConfig;
+use crate::utils::{ExpiringQueue, PeerIdKey};
+
+// Dialout timeout
+const DIAL_TIMEOUT: Duration = Duration::from_secs(60);
+// How long to wait for remote peer to connect
+const HASH_CASH_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+// How long proof/puzzle are considered valid
+const HASH_CASH_PROOF_TTL: Duration = Duration::from_secs(365 * 24 * 60 * 60);
+// How long to wait for next event
+const HANDSHAKE_STEP_TIMEOUT: Duration = Duration::from_secs(30);
+// Complexity of HasCash puzzles.
+const HASH_CASH_NBITS: usize = 24;
+// Nuber of concurrent solver threads
+const SOLVER_THREADS: usize = 4;
 
 /// Network behavior to handle initial nodes handshake
 pub struct Gatekeeper<TSubstream> {
@@ -53,43 +72,44 @@ pub struct Gatekeeper<TSubstream> {
     connecting_peers: HashSet<PeerId>,
     /// Addresses we are trying to connect to
     connecting_addresses: HashSet<Multiaddr>,
-    /// Negotiating peers
-    negotiating: HashMap<PeerId, (PeerKind, NegotiateState)>,
+    /// Peers we are trying to negotiate with
+    pending_out_peers: ExpiringQueue<PeerId, DialerPeerState>,
+    /// Incoming peers tring to negotiate with us
+    pending_in_peers: ExpiringQueue<PeerId, ListenerPeerState>,
+    /// Unlocked peers (passed HashCash handshake)
+    unlocked_peers: LruCache<PeerIdKey, ()>,
+    /// HshCash puzzle geneated by us
+    our_puzzles: LruCache<PeerIdKey, HashCashPuzzle>,
+    /// Incommming puzzles (with solutions)
+    input_puzzles: LruCache<PeerIdKey, (HashCashPuzzle, Option<i64>)>,
     /// Upstream events when Dialer/Listeners are ready
-    protocol_updates: VecDeque<(PeerId, ProtocolUpdateEvent)>,
+    protocol_updates: VecDeque<PeerEvent>,
+    /// Channel used to send solutions for HashCash puzzles
+    solution_sink: UnboundedSender<Solution>,
+    /// Output channel with HashCash solutions
+    solution_stream: UnboundedReceiver<Solution>,
+    /// Solvers - set of currently running solvers
+    solvers: HashSet<PeerId>,
+    /// Queue of puzzles, waiting to be solved
+    puzzles_queue: VecDeque<PeerId>,
     /// Marker to pin the generics.
     marker: PhantomData<TSubstream>,
 }
 
-#[derive(Debug, PartialEq)]
-enum PeerKind {
-    Dialer,
-    Listener,
-}
-
-#[derive(Debug)]
-enum NegotiateState {
-    PreparingListener,
-    PreparingDialer,
-    WaitingHello,
-    WaitingReply,
-    Connected,
-}
-
 impl<TSubstream> Gatekeeper<TSubstream> {
-    /// Creates a NetworkBehaviour for NCP.
+    /// Creates a NetworkBehaviour for Gatekeeper.
     pub fn new(config: &NetworkConfig, keychain: &KeyChain) -> Self {
         let mut connecting_addresses: HashSet<Multiaddr> = HashSet::new();
         let mut events: VecDeque<NetworkBehaviourAction<GatekeeperSendEvent, GatekeeperOutEvent>> =
             VecDeque::new();
 
-        // Randmoize seed nodes array
+        // Randomize seed nodes array
         let mut rng = thread_rng();
         let mut addrs = config.seed_nodes.clone();
         addrs.shuffle(&mut rng);
 
         for addr in addrs.iter() {
-            debug!(target: "stegos_network::ncp", "dialing peer with address {}", addr);
+            debug!(target: "stegos_network::gatekeeper", "dialing peer with address {}", addr);
             match addr.parse::<Multiaddr>() {
                 Ok(maddr) => {
                     events.push_back(NetworkBehaviourAction::DialAddress {
@@ -98,10 +118,12 @@ impl<TSubstream> Gatekeeper<TSubstream> {
                     connecting_addresses.insert(maddr);
                 }
                 Err(e) => {
-                    error!(target: "stegos_network::ncp", "failed to parse address: {}, error: {}", addr, e)
+                    error!(target: "stegos_network::gatekeeper", "failed to parse address: {}, error: {}", addr, e)
                 }
             }
         }
+
+        let (solution_sink, solution_stream) = unbounded::<Solution>();
 
         Gatekeeper {
             events,
@@ -109,8 +131,21 @@ impl<TSubstream> Gatekeeper<TSubstream> {
             my_pkey: keychain.network_pkey.clone(),
             connecting_peers: HashSet::new(),
             connecting_addresses,
-            negotiating: HashMap::new(),
+            pending_out_peers: ExpiringQueue::new(HANDSHAKE_STEP_TIMEOUT),
+            pending_in_peers: ExpiringQueue::new(HANDSHAKE_STEP_TIMEOUT),
+            unlocked_peers: LruCache::<PeerIdKey, ()>::with_expiry_duration(HASH_CASH_PROOF_TTL),
+            our_puzzles: LruCache::<PeerIdKey, HashCashPuzzle>::with_expiry_duration(
+                HASH_CASH_PROOF_TTL,
+            ),
+            input_puzzles:
+                LruCache::<PeerIdKey, (HashCashPuzzle, Option<i64>)>::with_expiry_duration(
+                    HASH_CASH_PROOF_TTL,
+                ),
             protocol_updates: VecDeque::new(),
+            solution_sink,
+            solution_stream,
+            solvers: HashSet::new(),
+            puzzles_queue: VecDeque::new(),
             marker: PhantomData,
         }
     }
@@ -134,8 +169,120 @@ impl<TSubstream> Gatekeeper<TSubstream> {
             .push_back(NetworkBehaviourAction::DialAddress { address });
     }
 
-    pub fn notify(&mut self, peer_id: &PeerId, event: ProtocolUpdateEvent) {
-        self.protocol_updates.push_back((peer_id.clone(), event));
+    pub fn notify(&mut self, event: PeerEvent) {
+        self.protocol_updates.push_back(event);
+    }
+
+    fn send_new_puzlle(&mut self, peer_id: PeerId) {
+        let seed = generate_puzzle(&peer_id);
+        self.our_puzzles.insert(
+            peer_id.clone().into(),
+            HashCashPuzzle {
+                seed: seed.clone(),
+                nbits: HASH_CASH_NBITS,
+            },
+        );
+        self.pending_in_peers
+            .insert(peer_id.clone(), ListenerPeerState::WaitingProof);
+        self.events.push_back(NetworkBehaviourAction::SendEvent {
+            peer_id,
+            event: GatekeeperSendEvent::Send(GatekeeperMessage::ChallengeReply {
+                seed,
+                nbits: HASH_CASH_NBITS,
+            }),
+        })
+    }
+
+    fn handle_unlock_request(&mut self, peer_id: PeerId, proof: Option<HashCashProof>) {
+        if self.unlocked_peers.contains_key(&peer_id.clone().into()) {
+            debug!(target: "stegos_network::gatekeeper", "unlock request from already unlocked peer: peer_id={}", peer_id.to_base58());
+            self.pending_in_peers
+                .insert(peer_id.clone(), ListenerPeerState::WaitingDialer);
+            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
+                GatekeeperOutEvent::PrepareDialer { peer_id },
+            ));
+            return;
+        }
+
+        if self.pending_out_peers.contains_key(&peer_id) {
+            debug!(target: "stegos_network::gatekeeper", "unlock request from the peer we are interested in, let in without puzzle solving: peer_id={}", peer_id.to_base58());
+            self.pending_in_peers
+                .insert(peer_id.clone(), ListenerPeerState::WaitingDialer);
+            self.unlocked_peers.insert(peer_id.clone().into(), ());
+            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
+                GatekeeperOutEvent::PrepareDialer { peer_id },
+            ));
+            return;
+        }
+
+        let proof = match proof {
+            Some(p) => p,
+            None => {
+                debug!(target: "stegos_network::gatekeeper", "unlock request without proof: peer_id={}", peer_id.to_base58());
+                self.send_new_puzlle(peer_id);
+                return;
+            }
+        };
+
+        let puzzle = match self.our_puzzles.get(&peer_id.clone().into()) {
+            Some(p) => p,
+            None => {
+                debug!(target: "stegos_network::gatekeeper", "unlock request with proof, but no puzzle, sending new puzzle: peer_id={}", peer_id.to_base58());
+                self.send_new_puzlle(peer_id);
+                return;
+            }
+        };
+
+        if proof.seed == puzzle.seed && proof.nbits == puzzle.nbits && local_check_proof(&proof) {
+            debug!(target: "stegos_network::gatekeeper", "unlock request with valid proof, peer_id={}", peer_id.to_base58());
+            self.unlocked_peers.insert(peer_id.clone().into(), ());
+            self.pending_in_peers
+                .insert(peer_id.clone(), ListenerPeerState::WaitingDialer);
+            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
+                GatekeeperOutEvent::PrepareDialer { peer_id },
+            ));
+            return;
+        } else {
+            debug!(target: "stegos_network::gatekeeper", "unlock request with invalid proof, sending new puzzle: peer_id={}", peer_id.to_base58());
+            self.send_new_puzlle(peer_id);
+        }
+    }
+
+    fn handle_challenge_reply(&mut self, peer_id: PeerId, seed: Vec<u8>, nbits: usize) {
+        debug!(target: "stegos_network::gatekeeper", "received puzzle: peer_id={}", peer_id.to_base58());
+        if !self.pending_out_peers.contains_key(&peer_id) {
+            debug!(target: "stegos_network::gatekeeper", "puzzle from peer we are not going to connect to, ignoring: peer_id={}", peer_id.to_base58());
+            return;
+        }
+        let puzzle = HashCashPuzzle {
+            seed: seed.clone(),
+            nbits,
+        };
+        if let Some(p) = self.input_puzzles.get(&peer_id.clone().into()) {
+            if p.0.seed == seed && p.1.is_some() {
+                // Already solved this puzzle
+                let proof = HashCashProof {
+                    seed: p.0.seed.clone(),
+                    nbits: p.0.nbits,
+                    count: p.1.expect("checked for Some earlier"),
+                };
+                self.events.push_back(NetworkBehaviourAction::SendEvent {
+                    peer_id: peer_id.clone(),
+                    event: GatekeeperSendEvent::Send(GatekeeperMessage::UnlockRequest {
+                        proof: Some(proof),
+                    }),
+                });
+                self.pending_out_peers
+                    .insert(peer_id, DialerPeerState::UnlockRequestSent);
+                return;
+            }
+        }
+        self.input_puzzles
+            .insert(peer_id.clone().into(), (puzzle.clone(), None));
+        self.pending_out_peers
+            .insert(peer_id.clone(), DialerPeerState::SolvingPuzzle);
+        // put peer into the queue to be solved.
+        self.puzzles_queue.push_back(peer_id);
     }
 }
 
@@ -157,43 +304,31 @@ where
     fn inject_connected(&mut self, id: PeerId, cp: ConnectedPoint) {
         debug!(target: "stegos_network::gatekeeper", "peer connected: peer_id={}", id.to_base58());
         self.connected_peers.insert(id.clone());
+        // FIXME: use LRU cache for dialing addresses/peers
         if let ConnectedPoint::Dialer { address } = cp {
-            // We are dialing, so if we have dialed peer/address in queue, start negotiaions
-            if self.connecting_peers.remove(&id) | self.connecting_addresses.remove(&address) {
-                self.negotiating.insert(
-                    id.clone(),
-                    (PeerKind::Dialer, NegotiateState::PreparingListener),
-                );
-                self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                    GatekeeperOutEvent::PrepareListener { peer_id: id },
-                ));
-            } else {
-                // For now let all connections be full node
-                // TODO: handle different kinds of connections properly
-                self.events.push_back(NetworkBehaviourAction::SendEvent {
-                    peer_id: id,
-                    event: GatekeeperSendEvent::Send(GatekeeperMessage::Request {
-                        conn_type: ConnectionType::None,
-                        node_id: self.my_pkey.clone(),
-                    }),
-                })
+            if self.connecting_addresses.remove(&address) {
+                self.connecting_peers.remove(&id);
+                self.pending_out_peers
+                    .insert(id.clone().into(), DialerPeerState::Connected);
+                self.protocol_updates
+                    .push_back(PeerEvent::Connected { peer_id: id });
+                return;
             }
-        } else {
-            if self.connecting_peers.remove(&id) {
-                // Let dialing peer decide what to do...
-                debug!(target: "stegos_network::gatekeeper", "Got incoming connect from peer we are trying to connect: peer_id={}", id.to_base58());
-            }
-            self.negotiating.insert(
-                id.clone(),
-                (PeerKind::Listener, NegotiateState::WaitingHello),
-            );
+        }
+
+        if self.connecting_peers.remove(&id) {
+            self.pending_out_peers
+                .insert(id.clone().into(), DialerPeerState::Connected);
+            self.protocol_updates
+                .push_back(PeerEvent::Connected { peer_id: id });
         }
     }
 
-    fn inject_disconnected(&mut self, id: &PeerId, _: ConnectedPoint) {
+    fn inject_disconnected(&mut self, id: &PeerId, _cp: ConnectedPoint) {
         debug!(target: "stegos_network::gatekeeper", "peer disconnected: peer_id={}", id.to_base58());
         self.connected_peers.remove(id);
-        self.negotiating.remove(id);
+        self.pending_out_peers.remove(&id.clone().into());
+        self.pending_in_peers.remove(&id.clone().into());
         self.events.push_back(NetworkBehaviourAction::GenerateEvent(
             GatekeeperOutEvent::Disconnected {
                 peer_id: id.clone(),
@@ -202,35 +337,27 @@ where
     }
 
     fn inject_node_event(&mut self, propagation_source: PeerId, event: GatekeeperMessage) {
-        // Process received NCP message (passed from Handler as Custom(message))
+        // Process received Gatekeeper message (passed from Handler as Custom(message))
         debug!(target: "stegos_network::gatekeeper", "Received a message: {:?}", event);
         match event {
-            GatekeeperMessage::Request {
-                conn_type: _,
-                node_id: _,
-            } => {
-                // TODO: validate node/peer
-                if let Some((kind, state)) = self.negotiating.get_mut(&propagation_source) {
-                    debug_assert_eq!(*kind, PeerKind::Listener);
-                    *state = NegotiateState::PreparingListener;
-                    self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                        GatekeeperOutEvent::PrepareListener {
-                            peer_id: propagation_source.clone(),
-                        },
-                    ));
-                }
+            GatekeeperMessage::UnlockRequest { proof } => {
+                self.handle_unlock_request(propagation_source, proof)
             }
-            GatekeeperMessage::Reply { conn_type, .. } => {
-                if let Some((kind, state)) = self.negotiating.get_mut(&propagation_source) {
-                    // TODO: handle refusals
-                    debug_assert_eq!(*kind, PeerKind::Dialer);
-                    debug_assert_eq!(conn_type, ConnectionType::FullNode);
-                    *state = NegotiateState::PreparingDialer;
+            GatekeeperMessage::ChallengeReply { seed, nbits } => {
+                self.handle_challenge_reply(propagation_source, seed, nbits)
+            }
+            GatekeeperMessage::PermitReply { connection_allowed } => {
+                if connection_allowed {
+                    debug!(target: "stegos_network::gatekeeper", "succesfully negotiated hashcash: peer_id={}", propagation_source.to_base58());
+                    self.unlocked_peers
+                        .insert(propagation_source.clone().into(), ());
+                    self.pending_out_peers
+                        .insert(propagation_source.clone(), DialerPeerState::WaitingDialer);
                     self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                        GatekeeperOutEvent::PrepareDialer {
-                            peer_id: propagation_source.clone(),
+                        GatekeeperOutEvent::Finished {
+                            peer_id: propagation_source,
                         },
-                    ));
+                    ))
                 }
             }
         }
@@ -245,64 +372,171 @@ where
             Self::OutEvent,
         >,
     > {
-        if let Some((peer_id, event)) = self.protocol_updates.pop_front() {
-            match event {
-                ProtocolUpdateEvent::EnabledListener => {
-                    if let Some((kind, state)) = self.negotiating.get_mut(&peer_id) {
-                        if *kind == PeerKind::Dialer {
-                            *state = NegotiateState::WaitingReply;
-                            debug!(target: "stegos_network::gatekeeper", "dialer: enabled listener for peer: peer_id={}", peer_id.to_base58());
-                            self.events.push_back(NetworkBehaviourAction::SendEvent {
-                                peer_id,
-                                event: GatekeeperSendEvent::Send(GatekeeperMessage::Request {
-                                    conn_type: ConnectionType::FullNode,
-                                    node_id: self.my_pkey.clone(),
-                                }),
-                            });
-                        } else {
-                            *state = NegotiateState::PreparingDialer;
-                            debug!(target: "stegos_network::gatekeeper", "listener: enabled listener for peer: peer_id={}", peer_id.to_base58());
-                            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                                GatekeeperOutEvent::PrepareDialer { peer_id },
-                            ));
+        match self.solution_stream.poll() {
+            Ok(Async::Ready(Some((peer_id, proof, duration)))) => {
+                debug!(target: "stegos_network::gatekeeper", "solved puzzle: peer_id={}, duration={}.{}sec", peer_id.to_base58(), duration.as_secs(), duration.subsec_millis());
+                self.solvers.remove(&peer_id);
+                self.protocol_updates.push_back(PeerEvent::PuzzleSolved {
+                    peer_id: peer_id.clone(),
+                    answer: proof.count,
+                });
+            }
+            Ok(Async::Ready(None)) => {
+                debug!(target: "stegos_network::gatekeeper", "solution stream gone!");
+            }
+            Ok(Async::NotReady) => {}
+            Err(_e) => {
+                debug!(target: "stegos_network::gatekeeper", "error pollion solution_stream channel!");
+            }
+        }
+
+        if self.solvers.len() < SOLVER_THREADS && self.puzzles_queue.len() > 0 {
+            loop {
+                if self.puzzles_queue.is_empty() {
+                    break;
+                }
+                let peer_id = self.puzzles_queue.pop_front().unwrap();
+                if let Some(puzzle) = self.input_puzzles.get(&peer_id.clone().into()) {
+                    debug!(target: "stegos_network::gatekeeper", "starting thread to solve puzzle: peer_id={}", peer_id.to_base58());
+                    let tx = self.solution_sink.clone();
+                    let p = puzzle.0.clone();
+                    let peer_id = peer_id.clone();
+                    self.solvers.insert(peer_id.clone());
+                    thread::spawn(move || {
+                        let start = SystemTime::now();
+                        let proof = hashcash::delay(p.nbits, &p.seed);
+                        if let Err(e) = tx.unbounded_send((
+                            peer_id,
+                            proof,
+                            start.elapsed().expect("hashcash always takes some time"),
+                        )) {
+                            debug!(target: "stegos_network::gatekeeper", "failed to send hashcash solution to the channel: {}", e);
                         }
+                    });
+                    break;
+                }
+            }
+        }
+
+        if let Some(event) = self.protocol_updates.pop_front() {
+            match event {
+                PeerEvent::Connected { peer_id } => {
+                    debug!(target: "stegos_network::gatekeeper", "peer is connected, enabling listener: peer_id={}", peer_id.to_base58());
+                    self.pending_out_peers
+                        .insert(peer_id.clone().into(), DialerPeerState::WaitingListener);
+                    self.events.push_back(NetworkBehaviourAction::GenerateEvent(
+                        GatekeeperOutEvent::PrepareListener { peer_id },
+                    ))
+                }
+                PeerEvent::EnabledListener { peer_id } => {
+                    let puzzle = self.input_puzzles.get(&peer_id.clone().into()).clone();
+                    let proof = match puzzle {
+                        Some((p, Some(count))) => Some(HashCashProof {
+                            seed: p.seed.clone(),
+                            nbits: p.nbits,
+                            count: *count,
+                        }),
+                        Some((_, None)) => None,
+                        None => None,
+                    };
+                    debug!(target: "stegos_network::gatekeeper", "listener enabled, sending unlock request: peer_id={}, with_proof={}", peer_id.to_base58(), proof.is_some());
+                    self.pending_out_peers
+                        .insert(peer_id.clone().into(), DialerPeerState::UnlockRequestSent);
+                    self.events.push_back(NetworkBehaviourAction::SendEvent {
+                        peer_id,
+                        event: GatekeeperSendEvent::Send(GatekeeperMessage::UnlockRequest {
+                            proof,
+                        }),
+                    })
+                }
+                PeerEvent::EnabledDialer { peer_id } => {
+                    if self.pending_in_peers.contains_key(&peer_id) {
+                        debug!(target: "stegos_network::gatekeeper", "dialer enabled, sending permit reply: peer_id={}", peer_id.to_base58());
+                        self.pending_in_peers.remove(&peer_id);
+                        self.events.push_back(NetworkBehaviourAction::SendEvent {
+                            peer_id,
+                            event: GatekeeperSendEvent::Send(GatekeeperMessage::PermitReply {
+                                connection_allowed: true,
+                            }),
+                        });
+                    } else {
+                        debug!(target: "stegos_network::gatekeeper", "dialer enabled, peer fully negotiated: peer_id={}", peer_id.to_base58());
+                        self.pending_out_peers.remove(&peer_id);
                     }
                 }
-                ProtocolUpdateEvent::EnabledDialer => {
-                    if let Some((kind, state)) = self.negotiating.get_mut(&peer_id) {
-                        if *kind == PeerKind::Dialer {
-                            // Dialout fully negotiated...
-                            *state = NegotiateState::Connected;
-                            debug!(target: "stegos_network::gatekeeper", "dialer: fully negotiated node: {}", peer_id.to_base58());
-                            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                                GatekeeperOutEvent::Connected { peer_id },
-                            ))
-                        } else {
-                            // Our side is fully initialized, send ack to the remote
-                            *state = NegotiateState::Connected;
-                            debug!(target: "stegos_network::gatekeeper", "listener: fully negotiated node: {}", peer_id.to_base58());
+                PeerEvent::PuzzleSolved { peer_id, answer } => {
+                    if let Some(mut puzzle) = self.input_puzzles.get_mut(&peer_id.clone().into()) {
+                        debug!(target: "stegos_network::gatekeeper", "puzzle solved, sending proof: peer_id={}", peer_id.to_base58());
+                        self.pending_out_peers
+                            .insert(peer_id.clone().into(), DialerPeerState::ProofSent);
+                        puzzle.1 = Some(answer);
+                        let proof = HashCashProof {
+                            seed: puzzle.0.seed.clone(),
+                            nbits: puzzle.0.nbits,
+                            count: answer,
+                        };
+                        if self.connected_peers.contains(&peer_id) {
                             self.events.push_back(NetworkBehaviourAction::SendEvent {
-                                peer_id: peer_id.clone(),
-                                event: GatekeeperSendEvent::Send(GatekeeperMessage::Reply {
-                                    conn_type: ConnectionType::FullNode,
-                                    node_id: self.my_pkey.clone(),
-                                    others: Vec::new(),
-                                }),
-                            });
-                            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
-                                GatekeeperOutEvent::Connected { peer_id },
-                            ))
+                                peer_id,
+                                event: GatekeeperSendEvent::Send(
+                                    GatekeeperMessage::UnlockRequest { proof: Some(proof) },
+                                ),
+                            })
+                        } else {
+                            debug!(target: "stegos_network::gatekeeper", "peer already gone, trying to reconnect: peer_id={}", peer_id.to_base58());
+                            self.dial_peer(peer_id);
                         }
+                    } else {
+                        debug!(target: "stegos_network::gatekeeper", "got answer, but puzzle not found: peer_id={}", peer_id.to_base58());
                     }
                 }
             }
         }
+
+        // Expire outbound peer negotiations
+        loop {
+            match self.pending_out_peers.poll() {
+                Ok(Async::Ready(ref entry)) => {
+                    debug!(target: "stegos_network::gatekeeper", "peer hashcash expired: peer_id={}", entry.clone().0.to_base58());
+                    // Do cleanup
+                }
+                Ok(Async::NotReady) => break,
+                Err(e) => {
+                    error!(target: "stegos_network::delivery", "dial_queue timer error: {}", e);
+                    break;
+                }
+            }
+        }
+        // Expire inbound peers negotiations
+        loop {
+            match self.pending_in_peers.poll() {
+                Ok(Async::Ready(ref entry)) => {
+                    debug!(target: "stegos_network::gatekeeper", "peer hashcash expired: peer_id={}", entry.clone().0.to_base58());
+                    // Do cleanup
+                }
+                Ok(Async::NotReady) => break,
+                Err(e) => {
+                    error!(target: "stegos_network::delivery", "dial_queue timer error: {}", e);
+                    break;
+                }
+            }
+        }
+
         if let Some(event) = self.events.pop_front() {
             return Async::Ready(event);
         }
 
         Async::NotReady
     }
+}
+
+fn local_check_proof(proof: &HashCashProof) -> bool {
+    hashcash::check_proof(proof, HASH_CASH_NBITS)
+}
+
+fn generate_puzzle(_peer_id: &PeerId) -> Vec<u8> {
+    let key = (0..256).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
+    key
 }
 
 // to be extended?
@@ -324,10 +558,43 @@ pub enum GatekeeperOutEvent {
     Disconnected {
         peer_id: PeerId,
     },
+    Solve {
+        peer_id: PeerId,
+        seed: Vec<u8>,
+        nbits: usize,
+    },
+    Finished {
+        peer_id: PeerId,
+    },
 }
 
-#[derive(Debug)]
-pub enum ProtocolUpdateEvent {
-    EnabledListener,
-    EnabledDialer,
+type Solution = (PeerId, HashCashProof, Duration);
+
+#[derive(Clone)]
+struct HashCashPuzzle {
+    seed: Vec<u8>,
+    nbits: usize,
+}
+
+pub enum PeerEvent {
+    Connected { peer_id: PeerId },
+    EnabledListener { peer_id: PeerId },
+    PuzzleSolved { peer_id: PeerId, answer: i64 },
+    EnabledDialer { peer_id: PeerId },
+}
+
+pub enum DialerPeerState {
+    Connected,
+    WaitingListener,
+    WaitingDialer,
+    UnlockRequestSent,
+    SolvingPuzzle,
+    ProofSent,
+    Unlocked,
+}
+
+pub enum ListenerPeerState {
+    WaitingDialer,
+    WaitingProof,
+    Unlocked,
 }

--- a/network/src/gatekeeper/mod.rs
+++ b/network/src/gatekeeper/mod.rs
@@ -21,9 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-pub mod behavior;
+mod behavior;
 mod handler;
 mod proto;
 mod protocol;
 
-pub use behavior::{Gatekeeper, GatekeeperOutEvent, ProtocolUpdateEvent};
+pub use behavior::{Gatekeeper, GatekeeperOutEvent, PeerEvent};

--- a/network/src/ncp/mod.rs
+++ b/network/src/ncp/mod.rs
@@ -27,3 +27,4 @@ mod proto;
 mod protocol;
 
 pub use self::behavior::{Ncp, NcpOutEvent};
+pub use self::protocol::PeerInfo;

--- a/network/src/pubsub/handler.rs
+++ b/network/src/pubsub/handler.rs
@@ -100,8 +100,8 @@ where
     pub fn new() -> Self {
         FloodsubHandler {
             config: FloodsubConfig::new(),
-            enabled_incoming: true,
-            enabled_outgoing: true,
+            enabled_incoming: false,
+            enabled_outgoing: false,
             substreams: Vec::new(),
             send_queue: SmallVec::new(),
             out_events: VecDeque::new(),
@@ -170,6 +170,7 @@ where
                     .push_back(FloodsubRecvEvent::EnabledIncoming);
             }
             FloodsubSendEvent::EnableOutgoing => {
+                self.enabled_incoming = true;
                 self.enabled_outgoing = true;
                 self.out_events
                     .push_back(FloodsubRecvEvent::EnabledOutgoing);

--- a/network/src/utils/peer_id_key.rs
+++ b/network/src/utils/peer_id_key.rs
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Stegos AG
+// Copyright (c) 2019 Stegos AG
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,12 +21,49 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-mod expiring_queue;
-mod lru_bimap;
-mod multihash;
-mod peer_id_key;
+//! Helper data type to add Ord to libp2p::PeerId
+//!
 
-pub use self::expiring_queue::ExpiringQueue;
-pub use self::lru_bimap::LruBimap;
-pub use self::multihash::IntoMultihash;
-pub use self::peer_id_key::PeerIdKey;
+use libp2p::core::PeerId;
+use std::cmp::Ordering;
+
+#[derive(Clone, Debug)]
+pub struct PeerIdKey(PeerId);
+
+impl PeerIdKey {
+    pub fn new(peer_id: PeerId) -> Self {
+        PeerIdKey(peer_id)
+    }
+}
+
+impl From<PeerId> for PeerIdKey {
+    fn from(p: PeerId) -> Self {
+        PeerIdKey(p)
+    }
+}
+
+impl Into<PeerId> for PeerIdKey {
+    fn into(self) -> PeerId {
+        self.0
+    }
+}
+
+impl Ord for PeerIdKey {
+    fn cmp(&self, other: &PeerIdKey) -> Ordering {
+        self.0.as_bytes().cmp(&other.0.as_bytes())
+    }
+}
+
+impl PartialOrd for PeerIdKey {
+    fn partial_cmp(&self, other: &PeerIdKey) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for PeerIdKey {
+    fn eq(&self, other: &PeerIdKey) -> bool {
+        self.0.as_bytes() == other.0.as_bytes()
+    }
+}
+
+impl Eq for PeerIdKey {}


### PR DESCRIPTION
Now all pubsub connections are protected by "Hashcash" PoW handshake.

Initially, on all established connection, pubsub is disabled, and all attempts to send messages are blocked. To enable communications, originating node sends UnlockRequest message with optional _proof_ field. Remote node checks its list of already generated Puzzles, and if it already has puzzle for originating peer and UnlockRequest contains valid proof, then PubSub communications are enabled over this connection. Otherwise, new Puzzle is generated and sent to the originating node. Originating node than solves received Puzzle and re-attempts UnlockRequest with proper proof. If solution is correct, communications are enabled, otherwise, new Puzzle is generated and proccess repeats, until correct solution is provided.

Closes #761 