### PR TITLE
Lock stakes by epochs

### DIFF
--- a/blockchain/src/config.rs
+++ b/blockchain/src/config.rs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 use serde_derive::{Deserialize, Serialize};
-use std::time::Duration;
 
 /// Blockchain configuration.
 #[derive(Debug, Clone)]
@@ -31,8 +30,8 @@ pub struct BlockchainConfig {
     pub max_slot_count: i64,
     /// Minimal stake amount.
     pub min_stake_amount: i64,
-    /// Time to lock stakes.
-    pub bonding_time: Duration,
+    /// How many epochs stake is valid.
+    pub stake_epochs: u64,
 }
 
 impl Default for BlockchainConfig {
@@ -40,7 +39,7 @@ impl Default for BlockchainConfig {
         BlockchainConfig {
             max_slot_count: 1000,
             min_stake_amount: 1_000_000_000, // 1000 STG
-            bonding_time: Duration::from_secs(15 * 60),
+            stake_epochs: 1,
         }
     }
 }

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -75,10 +75,10 @@ pub enum OutputError {
     #[fail(display = "Invalid signature on validator pkey: utxo={}", _0)]
     InvalidStakeSignature(Hash),
     #[fail(
-        display = "Stake is locked: utxo={}, validator={}, bonding_time={:?}, current_time={:?}",
+        display = "Stake is locked: utxo={}, validator={}, until_epoch={}, current_epoch={}",
         _0, _1, _2, _3
     )]
-    StakeIsLocked(Hash, secure::PublicKey, SystemTime, SystemTime),
+    StakeIsActive(Hash, secure::PublicKey, u64, u64),
 }
 
 /// Payment UTXO.

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -36,7 +36,7 @@ pub struct ChainConfig {
     /// How long wait for the keu blocks.
     pub key_block_timeout: Duration,
     /// Time to lock stakes.
-    pub bonding_time: Duration,
+    pub stake_epochs: u64,
     /// The number of blocks per epoch.
     pub blocks_in_epoch: u64,
     /// The maximal number of inputs + outputs in a transaction.
@@ -73,7 +73,7 @@ impl Default for ChainConfig {
             tx_wait_timeout,
             micro_block_timeout,
             key_block_timeout,
-            bonding_time: blockchain_default.bonding_time,
+            stake_epochs: blockchain_default.stake_epochs,
             blocks_in_epoch: 5,
             max_utxo_in_tx: 10,
             max_utxo_in_block: 1000,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -277,7 +277,7 @@ impl NodeService {
         let blockchain_cfg = BlockchainConfig {
             max_slot_count: cfg.max_slot_count,
             min_stake_amount: cfg.min_stake_amount,
-            bonding_time: cfg.bonding_time,
+            stake_epochs: cfg.stake_epochs,
         };
         let timestamp = SystemTime::now();
         let (outbox, inbox) = unbounded();
@@ -300,7 +300,7 @@ impl NodeService {
         let blockchain_cfg = BlockchainConfig {
             max_slot_count: cfg.max_slot_count,
             min_stake_amount: cfg.min_stake_amount,
-            bonding_time: cfg.bonding_time,
+            stake_epochs: cfg.stake_epochs,
         };
         let timestamp = SystemTime::now();
         let chain = Blockchain::testing(blockchain_cfg, genesis, timestamp);
@@ -1383,7 +1383,7 @@ impl Future for NodeService {
                                     NodeResponse::ElectionInfo(self.chain.election_info())
                                 }
                                 NodeRequest::EscrowInfo {} => {
-                                    NodeResponse::EscrowInfo(self.chain.escrow().info())
+                                    NodeResponse::EscrowInfo(self.chain.escrow_info())
                                 }
                             };
                             tx.send(response).ok(); // ignore errors.


### PR DESCRIPTION
- Replace `bonding_time` with `valid_until_epoch`.
- Rename EscrowInfo[x].total to `active_stake` and `expired_stake`.
- Rename EscrowInfo[x].stakes[y].bonding_timestamp to `valid_until_epoch`.
- Add EscrowInfo[x].stakes[y].is_active.
- Remove unused methods from `struct Escrow`.
- Update all tests.

This patch is breaking change.

Needed for #800