### PR TITLE
Implement re-staking without re-keying

### DIFF
--- a/blockchain/src/config.rs
+++ b/blockchain/src/config.rs
@@ -39,7 +39,7 @@ impl Default for BlockchainConfig {
         BlockchainConfig {
             max_slot_count: 1000,
             min_stake_amount: 1_000_000_000, // 1000 STG
-            stake_epochs: 1,
+            stake_epochs: 2,
         }
     }
 }

--- a/blockchain/src/election.rs
+++ b/blockchain/src/election.rs
@@ -127,7 +127,7 @@ pub fn select_validators_slots(
     random: VRF,
     slot_count: i64,
 ) -> ElectionResult {
-    assert!(!stakers.is_empty());
+    assert!(!stakers.is_empty(), "Have stakes");
     assert!(slot_count > 0);
     // Using BTreeMap to keep order.
     let mut validators = BTreeMap::new();

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -24,6 +24,7 @@
 use crate::view_changes::ViewChangeProof;
 use failure::Fail;
 use stegos_crypto::hash::Hash;
+use stegos_crypto::pbc::secure;
 
 #[derive(Debug, Fail)]
 pub enum BlockchainError {
@@ -33,6 +34,11 @@ pub enum BlockchainError {
         _0, _1, _2
     )]
     IncompatibleChain(u64, Hash, Hash),
+    #[fail(
+        display = "Stake is locked: validator={}, expected_balance={}, minimum_balance={}",
+        _0, _1, _2
+    )]
+    StakeIsLocked(secure::PublicKey, i64, i64),
 }
 
 #[derive(Debug, Fail)]

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -75,11 +75,6 @@ pub enum OutputError {
     NegativeAmount(Hash, i64),
     #[fail(display = "Invalid signature on validator pkey: utxo={}", _0)]
     InvalidStakeSignature(Hash),
-    #[fail(
-        display = "Stake is locked: utxo={}, validator={}, until_epoch={}, current_epoch={}",
-        _0, _1, _2, _3
-    )]
-    StakeIsActive(Hash, secure::PublicKey, u64, u64),
 }
 
 /// Payment UTXO.

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -81,7 +81,7 @@ impl Default for ChainConfig {
             chain_loader_speed_in_epoch: 10,
             block_reward: 60_000_000, // 60 STG
             payment_fee: 1_000,       // 0.001 STG
-            stake_fee: 1_000,         // 0.001 STG
+            stake_fee: 0,             // free
             max_slot_count: blockchain_default.max_slot_count,
             min_stake_amount: blockchain_default.min_stake_amount,
             loader_timeout: Duration::from_millis(500),

--- a/node/src/test/consensus.rs
+++ b/node/src/test/consensus.rs
@@ -34,6 +34,7 @@ fn smoke_test() {
         num_nodes: 3,
         ..Default::default()
     };
+    assert!(config.chain.stake_epochs > 1);
 
     Sandbox::start(config, |mut s| {
         let topic = crate::CONSENSUS_TOPIC;
@@ -164,6 +165,7 @@ fn autocomit() {
         num_nodes: 3,
         ..Default::default()
     };
+    assert!(config.chain.stake_epochs > 1);
 
     Sandbox::start(config, |mut s| {
         let topic = crate::CONSENSUS_TOPIC;
@@ -280,6 +282,7 @@ fn round() {
         num_nodes: 3,
         ..Default::default()
     };
+    assert!(config.chain.stake_epochs > 1);
 
     Sandbox::start(config, |mut s| {
         let topic = crate::CONSENSUS_TOPIC;

--- a/src/console.rs
+++ b/src/console.rs
@@ -185,7 +185,8 @@ impl ConsoleService {
         println!("spay WALLET_PUBKEY AMOUNT [COMMENT] - send money using ValueShuffle");
         println!("msg WALLET_PUBKEY MESSAGE - send a message via blockchain");
         println!("stake AMOUNT - stake money");
-        println!("unstake AMOUNT - unstake money");
+        println!("unstake [AMOUNT] - unstake money");
+        println!("restake - restake all available stakes");
         println!("show version - print version information");
         println!("show keys - print keys");
         println!("show balance - print balance");
@@ -469,6 +470,9 @@ impl ConsoleService {
 
             info!("Unstaking {} STG from escrow", format_money(amount));
             let request = WalletRequest::Unstake { amount };
+            self.wallet_response = Some(self.wallet.request(request));
+        } else if msg == "restake" {
+            let request = WalletRequest::RestakeAll {};
             self.wallet_response = Some(self.wallet.request(request));
         } else if msg.starts_with("generator ") {
             let subcommand = &msg[10..];

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -80,6 +80,7 @@ pub enum WalletRequest {
         amount: i64,
     },
     UnstakeAll {},
+    RestakeAll {},
     KeysInfo {},
     BalanceInfo {},
     UnspentInfo {},

--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -34,4 +34,6 @@ pub enum WalletError {
     IncorrectTXINType,
     #[fail(display = "Incorrect UTXO data")]
     InvalidUTXOData,
+    #[fail(display = "Nothing to re-stake")]
+    NothingToRestake,
 }


### PR DESCRIPTION
- Re-stake expiring stakes automatically.
- Do don't take expired stakes into account during group formation.
- Add API method and CLI command to force re-staking.
- Rework stake locking to check only for minimal staking balance
  instead of locking of individiual UTXOs.

Closes #800