### PR TITLE
Add API call to change Network(PBC) key

### DIFF
--- a/network/src/discovery/behavior.rs
+++ b/network/src/discovery/behavior.rs
@@ -101,6 +101,11 @@ where
         }
     }
 
+    pub fn change_network_key(&mut self, new_pkey: secure::PublicKey) {
+        self.kademlia.change_id(new_pkey.clone());
+        self.my_id = new_pkey;
+    }
+
     /// Sets peer_id to the corresponging node_id
     pub fn set_peer_id(&mut self, node_id: &secure::PublicKey, peer_id: PeerId) {
         self.kademlia.set_peer_id(node_id, peer_id);
@@ -390,8 +395,9 @@ where
                 Ok(Async::NotReady) => break,
                 Ok(Async::Ready(_)) => {
                     debug!(target: "stegos_network::discovery", "Shooting at DHT to gather nodes information");
-                    let (_, random_node_id) = secure::make_random_keys();
+                    let random_node_id = secure::make_random_keys().1;
                     self.kademlia.find_node(random_node_id);
+                    self.kademlia.find_node(self.my_id.clone());
                     // Reset the `Delay` to the next random.
                     self.next_query
                         .reset(Instant::now() + self.delay_between_queries);

--- a/network/src/gatekeeper/behavior.rs
+++ b/network/src/gatekeeper/behavior.rs
@@ -38,8 +38,6 @@ use std::{
     thread,
 };
 use stegos_crypto::hashcash::{self, HashCashProof};
-use stegos_crypto::pbc::secure;
-use stegos_keychain::KeyChain;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::handler::{GatekeeperHandler, GatekeeperSendEvent};
@@ -66,8 +64,6 @@ pub struct Gatekeeper<TSubstream> {
     events: VecDeque<NetworkBehaviourAction<GatekeeperSendEvent, GatekeeperOutEvent>>,
     /// List of connected peers
     connected_peers: HashSet<PeerId>,
-    /// My PBC PublicKey
-    my_pkey: secure::PublicKey,
     /// Peers we are trying to connect to
     connecting_peers: HashSet<PeerId>,
     /// Addresses we are trying to connect to
@@ -98,7 +94,7 @@ pub struct Gatekeeper<TSubstream> {
 
 impl<TSubstream> Gatekeeper<TSubstream> {
     /// Creates a NetworkBehaviour for Gatekeeper.
-    pub fn new(config: &NetworkConfig, keychain: &KeyChain) -> Self {
+    pub fn new(config: &NetworkConfig) -> Self {
         let mut connecting_addresses: HashSet<Multiaddr> = HashSet::new();
         let mut events: VecDeque<NetworkBehaviourAction<GatekeeperSendEvent, GatekeeperOutEvent>> =
             VecDeque::new();
@@ -128,7 +124,6 @@ impl<TSubstream> Gatekeeper<TSubstream> {
         Gatekeeper {
             events,
             connected_peers: HashSet::new(),
-            my_pkey: keychain.network_pkey.clone(),
             connecting_peers: HashSet::new(),
             connecting_addresses,
             pending_out_peers: ExpiringQueue::new(HANDSHAKE_STEP_TIMEOUT),

--- a/network/src/kad/behaviour.rs
+++ b/network/src/kad/behaviour.rs
@@ -180,6 +180,12 @@ impl<TSubstream> Kademlia<TSubstream> {
         &self.my_id
     }
 
+    /// Change node's id (secure::PublicKey)
+    pub fn change_id(&mut self, new_id: secure::PublicKey) {
+        self.kbuckets = self.kbuckets.new_table(new_id.clone());
+        self.my_id = new_id;
+    }
+
     #[inline]
     pub fn find_closest(&mut self, id: &secure::PublicKey) -> VecIntoIter<secure::PublicKey> {
         self.kbuckets.find_closest(id)

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -66,6 +66,13 @@ where
 
     /// Helper for cloning boxed object
     fn box_clone(&self) -> Network;
+
+    /// Change network keys
+    fn change_network_keys(
+        &self,
+        _new_pkey: secure::PublicKey,
+        _new_skey: secure::SecretKey,
+    ) -> Result<(), Error>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/network/src/loopback.rs
+++ b/network/src/loopback.rs
@@ -89,6 +89,14 @@ impl NetworkProvider for LoopbackNetwork {
         Ok(())
     }
 
+    fn change_network_keys(
+        &self,
+        _new_pkey: secure::PublicKey,
+        _new_skey: secure::SecretKey,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     // Clone self as a box
     fn box_clone(&self) -> Network {
         Box::new((*self).clone())

--- a/network/src/ncp/behavior.rs
+++ b/network/src/ncp/behavior.rs
@@ -96,6 +96,15 @@ impl<TSubstream> Ncp<TSubstream> {
             marker: PhantomData,
         }
     }
+
+    pub fn change_network_key(&mut self, new_pkey: secure::PublicKey) {
+        self.node_id = new_pkey;
+        // Update all connected peers with our new network key
+        for p in self.connected_peers.iter() {
+            self.events
+                .push_back(NcpEvent::SendPeers { peer_id: p.clone() });
+        }
+    }
 }
 
 impl<TSubstream> NetworkBehaviour for Ncp<TSubstream>


### PR DESCRIPTION
Now `NetworkProvider` has additional function:
```
    fn change_network_keys(&self, _new_pkey: secure::PublicKey, _new_skey: secure::SecretKey) -> Result<(), Error>;
```

SecretKey is necessary, because we encrypt/decrypt Unicast messages