### PR TITLE
Don't send network messages until network is ready

### DIFF
--- a/network/src/gatekeeper/behavior.rs
+++ b/network/src/gatekeeper/behavior.rs
@@ -408,7 +408,9 @@ where
                     self.solvers.insert(peer_id.clone());
                     thread::spawn(move || {
                         let start = SystemTime::now();
+                        info!("Solving a hashcash puzzle: peer_id={:?}", peer_id);
                         let proof = hashcash::delay(p.nbits, &p.seed);
+                        info!("Solved a hashcash puzzle: peer_id={:?}", peer_id);
                         if let Err(e) = tx.unbounded_send((
                             peer_id,
                             proof,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -41,6 +41,8 @@ use stegos_crypto::pbc::secure;
 pub use self::config::*;
 pub use self::kad::KBucketsPeerId;
 pub use self::libp2p_network::Libp2pNetwork;
+pub use self::libp2p_network::NETWORK_READY_TOKEN;
+pub use self::libp2p_network::NETWORK_STATUS_TOPIC;
 pub use self::utils::IntoMultihash;
 
 pub type Network = Box<dyn NetworkProvider + Send>;

--- a/node/src/test/mod.rs
+++ b/node/src/test/mod.rs
@@ -203,7 +203,10 @@ impl NodeSandbox {
         let timestamp = SystemTime::now();
         let chain = Blockchain::testing(cfg.clone().into(), genesis, timestamp)
             .expect("Failed to create blockchain");
-        let (node_service, node) = NodeService::new(cfg, chain, keychain, network).unwrap();
+        let (mut node_service, node) = NodeService::new(cfg, chain, keychain, network).unwrap();
+        node_service
+            .handle_network_status(NETWORK_READY_TOKEN[..].to_vec())
+            .unwrap();
         Self {
             network_service,
             node,


### PR DESCRIPTION
Fix a race on start - don't send the key && micro blocks and
the view changes until network is ready.

Closes #759