### PR TITLE
Streamline curve1174 and pbc imports

### DIFF
--- a/blockchain/benches/election.rs
+++ b/blockchain/benches/election.rs
@@ -24,7 +24,7 @@ use rand::{Rng, SeedableRng};
 use rand_isaac::IsaacRng;
 use stegos_blockchain::election;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 extern crate test;
 use test::Bencher;
 
@@ -61,13 +61,13 @@ fn select_1000_slots_out_of_16(b: &mut Bencher) {
     const STAKE: i64 = 100_000;
 
     let random = Hash::digest("bla");
-    let (skey, _pkey) = secure::make_random_keys();
+    let (skey, _pkey) = pbc::make_random_keys();
 
-    let random = secure::make_VRF(&skey, &random);
+    let random = pbc::make_VRF(&skey, &random);
 
     let mut stakers = Vec::new();
     for _ in 0..GROUP_SIZE {
-        let (_, pkey) = secure::make_random_keys();
+        let (_, pkey) = pbc::make_random_keys();
         stakers.push((pkey, STAKE));
     }
 
@@ -83,21 +83,21 @@ fn select_1000_slots_out_of_16(b: &mut Bencher) {
 #[bench]
 fn create_vrf(b: &mut Bencher) {
     let random = Hash::digest("bla");
-    let (skey, _pkey) = secure::make_random_keys();
+    let (skey, _pkey) = pbc::make_random_keys();
 
     b.iter(|| {
-        test::black_box(secure::make_VRF(&skey, &random));
+        test::black_box(pbc::make_VRF(&skey, &random));
     });
 }
 
 #[bench]
 fn verify_vrf(b: &mut Bencher) {
     let random = Hash::digest("bla");
-    let (skey, pkey) = secure::make_random_keys();
-    let vrf = secure::make_VRF(&skey, &random);
+    let (skey, pkey) = pbc::make_random_keys();
+    let vrf = pbc::make_VRF(&skey, &random);
 
     b.iter(|| {
-        assert!(test::black_box(secure::validate_VRF_source(
+        assert!(test::black_box(pbc::validate_VRF_source(
             &vrf, &pkey, &random
         )));
     });

--- a/blockchain/src/error.rs
+++ b/blockchain/src/error.rs
@@ -25,7 +25,7 @@ use crate::view_changes::ViewChangeProof;
 use crate::OutputError;
 use failure::Fail;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use stegos_crypto::CryptoError;
 
 #[derive(Debug, Fail)]
@@ -40,7 +40,7 @@ pub enum BlockchainError {
         display = "Stake is locked: validator={}, expected_balance={}, minimum_balance={}",
         _0, _1, _2
     )]
-    StakeIsLocked(secure::PublicKey, i64, i64),
+    StakeIsLocked(pbc::PublicKey, i64, i64),
     #[fail(display = "Internal storage error={}", _0)]
     StorageError(failure::Error),
     #[fail(display = "Transaction error={}", _0)]
@@ -167,7 +167,7 @@ pub enum BlockError {
         display = "Different leader found in received block: elected={}, sender={}",
         _0, _1
     )]
-    DifferentPublicKey(secure::PublicKey, secure::PublicKey),
+    DifferentPublicKey(pbc::PublicKey, pbc::PublicKey),
     #[fail(
         display = "Invalid leader signature found: height={}, block={}",
         _0, _1

--- a/blockchain/src/escrow.rs
+++ b/blockchain/src/escrow.rs
@@ -29,11 +29,11 @@ use serde_derive::Serialize;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 struct EscrowKey {
-    validator_pkey: secure::PublicKey,
+    validator_pkey: pbc::PublicKey,
     output_hash: Hash,
 }
 
@@ -58,7 +58,7 @@ pub struct EscrowInfo {
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ValidatorInfo {
-    pub network_pkey: secure::PublicKey,
+    pub network_pkey: pbc::PublicKey,
     pub active_stake: i64,
     pub expired_stake: i64,
     pub stakes: Vec<StakeInfo>,
@@ -86,7 +86,7 @@ impl Escrow {
     pub fn stake(
         &mut self,
         version: u64,
-        validator_pkey: secure::PublicKey,
+        validator_pkey: pbc::PublicKey,
         output_hash: Hash,
         epoch: u64,
         stakes_epoch: u64,
@@ -122,7 +122,7 @@ impl Escrow {
     pub fn unstake(
         &mut self,
         version: u64,
-        validator_pkey: secure::PublicKey,
+        validator_pkey: pbc::PublicKey,
         output_hash: Hash,
         epoch: u64,
     ) {
@@ -144,7 +144,7 @@ impl Escrow {
     ///
     /// Returns (active_balance, expired_balance) stake.
     ///
-    pub fn get(&self, validator_pkey: &secure::PublicKey, epoch: u64) -> (i64, i64) {
+    pub fn get(&self, validator_pkey: &pbc::PublicKey, epoch: u64) -> (i64, i64) {
         let (hash_min, hash_max) = Hash::bounds();
         let key_min = EscrowKey {
             validator_pkey: validator_pkey.clone(),
@@ -177,8 +177,8 @@ impl Escrow {
         &self,
         epoch: u64,
         min_stake_amount: i64,
-    ) -> Vec<(secure::PublicKey, i64)> {
-        let mut stakes: BTreeMap<secure::PublicKey, i64> = BTreeMap::new();
+    ) -> Vec<(pbc::PublicKey, i64)> {
+        let mut stakes: BTreeMap<pbc::PublicKey, i64> = BTreeMap::new();
         for (k, v) in self.escrow.iter() {
             if v.active_until_epoch < epoch {
                 // Skip expired stakes.
@@ -197,7 +197,7 @@ impl Escrow {
 
     /// Returns an object that represent printable part of the state.
     pub fn info(&self, epoch: u64) -> EscrowInfo {
-        let mut validators: HashMap<secure::PublicKey, ValidatorInfo> = HashMap::new();
+        let mut validators: HashMap<pbc::PublicKey, ValidatorInfo> = HashMap::new();
         for (k, v) in self.escrow.iter() {
             let entry = validators
                 .entry(k.validator_pkey.clone())

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -28,7 +28,7 @@ use crate::output::*;
 use std::collections::BTreeMap;
 use std::time::SystemTime;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use stegos_keychain::KeyChain;
 
 /// Genesis blocks.
@@ -53,7 +53,7 @@ pub fn genesis(
     let block1 = {
         let previous = Hash::digest(&"genesis".to_string());
         let seed = mix(init_random, view_change);
-        let random = secure::make_VRF(&keychains[0].network_skey, &seed);
+        let random = pbc::make_VRF(&keychains[0].network_skey, &seed);
         let base = BaseBlockHeader::new(version, previous, height, view_change, timestamp, random);
         //
         // Genesis has one PaymentOutput + N * StakeOutput, where N is the number of validators.
@@ -97,10 +97,10 @@ pub fn genesis(
         );
 
         let block_hash = Hash::digest(&block);
-        let mut signatures: BTreeMap<secure::PublicKey, secure::Signature> = BTreeMap::new();
-        let mut validators: BTreeMap<secure::PublicKey, i64> = BTreeMap::new();
+        let mut signatures: BTreeMap<pbc::PublicKey, pbc::Signature> = BTreeMap::new();
+        let mut validators: BTreeMap<pbc::PublicKey, i64> = BTreeMap::new();
         for keychain in keychains.iter() {
-            let sig = secure::sign_hash(&block_hash, &keychain.network_skey);
+            let sig = pbc::sign_hash(&block_hash, &keychain.network_skey);
             signatures.insert(keychain.network_pkey.clone(), sig);
             validators.insert(keychain.network_pkey.clone(), stake);
         }

--- a/blockchain/src/storage.rs
+++ b/blockchain/src/storage.rs
@@ -121,15 +121,15 @@ mod test {
     use crate::block::{BaseBlockHeader, MacroBlock};
     use std::time::SystemTime;
     use stegos_crypto::hash::Hash;
-    use stegos_crypto::pbc::secure;
+    use stegos_crypto::pbc;
 
     fn create_block(previous: Hash) -> Block {
-        let (skey0, pkey0) = secure::make_random_keys();
+        let (skey0, pkey0) = pbc::make_random_keys();
         let version: u64 = 1;
         let epoch: u64 = 1;
         let timestamp = SystemTime::now();
 
-        let random = secure::make_VRF(&skey0, &Hash::digest("random"));
+        let random = pbc::make_VRF(&skey0, &Hash::digest("random"));
         let base = BaseBlockHeader::new(version, previous, epoch, 0, timestamp, random);
 
         let block = MacroBlock::empty(base, pkey0);

--- a/blockchain/src/transaction.rs
+++ b/blockchain/src/transaction.rs
@@ -23,11 +23,9 @@
 
 use crate::output::*;
 use failure::Error;
-use stegos_crypto::curve1174::cpt::{
-    sign_hash, sign_hash_with_kval, PublicKey, SchnorrSig, SecretKey,
+use stegos_crypto::curve1174::{
+    sign_hash, sign_hash_with_kval, ECp, Fr, PublicKey, SchnorrSig, SecretKey,
 };
-use stegos_crypto::curve1174::ecpt::ECp;
-use stegos_crypto::curve1174::fields::Fr;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
 
 //--------------------------------------------------------------------------------------------------

--- a/blockchain/src/view_changes.rs
+++ b/blockchain/src/view_changes.rs
@@ -24,18 +24,18 @@ use crate::error::MultisignatureError;
 use crate::multisignature::{check_multi_signature, create_multi_signature_index};
 use bitvector::BitVector;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ViewChangeProof {
     pub multimap: BitVector,
-    pub multisig: secure::Signature,
+    pub multisig: pbc::Signature,
 }
 
 impl ViewChangeProof {
     pub fn new<'a, I>(signatures: I) -> Self
     where
-        I: Iterator<Item = (u32, &'a secure::Signature)>,
+        I: Iterator<Item = (u32, &'a pbc::Signature)>,
     {
         let (multisig, multimap) = create_multi_signature_index(signatures);
         ViewChangeProof { multisig, multimap }

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -23,26 +23,26 @@
 
 use failure::Fail;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 #[derive(Debug, Fail)]
 pub enum ConsensusError {
     #[fail(display = "Unknown peer: pkey={}", _0)]
-    UnknownMessagePeer(secure::PublicKey),
+    UnknownMessagePeer(pbc::PublicKey),
     #[fail(display = "Invalid message signature.")]
     InvalidMessageSignature,
     #[fail(
         display = "Invalid request hash: expected={}, got={}, pkey={}.",
         _0, _1, _2
     )]
-    InvalidRequestHash(Hash, Hash, secure::PublicKey),
+    InvalidRequestHash(Hash, Hash, pbc::PublicKey),
     #[fail(display = "Invalid message: state={} msg={}.", _0, _1)]
     InvalidMessage(&'static str, &'static str),
     #[fail(
         display = "Proposal from non-leader: request_hash={}, expected={}, got={}",
         _0, _1, _2
     )]
-    ProposalFromNonLeader(Hash, secure::PublicKey, secure::PublicKey),
+    ProposalFromNonLeader(Hash, pbc::PublicKey, pbc::PublicKey),
     #[fail(display = "Received invalid propose={}", _0)]
     InvalidPropose(failure::Error),
 

--- a/consensus/src/optimistic.rs
+++ b/consensus/src/optimistic.rs
@@ -30,13 +30,13 @@ use std::collections::HashMap;
 use stegos_blockchain::view_changes::*;
 use stegos_blockchain::{check_supermajority, Blockchain, ChainInfo, ValidatorId};
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ViewChangeMessage {
     pub chain: ChainInfo,
     pub validator_id: ValidatorId,
-    pub signature: secure::Signature,
+    pub signature: pbc::Signature,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -54,9 +54,9 @@ impl Hashable for ViewChangeMessage {
 }
 
 impl ViewChangeMessage {
-    pub fn new(chain: ChainInfo, validator_id: ValidatorId, skey: &secure::SecretKey) -> Self {
+    pub fn new(chain: ChainInfo, validator_id: ValidatorId, skey: &pbc::SecretKey) -> Self {
         let hash = Hash::digest(&chain);
-        let signature = secure::sign_hash(&hash, skey);
+        let signature = pbc::sign_hash(&hash, skey);
         ViewChangeMessage {
             chain,
             validator_id,
@@ -72,7 +72,7 @@ impl ViewChangeMessage {
         }
         let hash = Hash::digest(&self.chain);
         let author = blockchain.validators()[validator_id as usize].0;
-        if let Err(_e) = secure::check_hash(&hash, &self.signature, &author) {
+        if let Err(_e) = pbc::check_hash(&hash, &self.signature, &author) {
             return Err(ConsensusError::InvalidViewChangeSignature);
         }
         Ok(())
@@ -89,15 +89,15 @@ pub struct ViewChangeCollector {
     /// validator_id of current node.
     /// If None, ignore events for current epoch.
     validator_id: Option<ValidatorId>,
-    pkey: secure::PublicKey,
-    skey: secure::SecretKey,
+    pkey: pbc::PublicKey,
+    skey: pbc::SecretKey,
 }
 
 impl ViewChangeCollector {
     pub fn new(
         blockchain: &Blockchain,
-        pkey: secure::PublicKey,
-        skey: secure::SecretKey,
+        pkey: pbc::PublicKey,
+        skey: pbc::SecretKey,
     ) -> ViewChangeCollector {
         let mut collector = ViewChangeCollector {
             pkey,

--- a/crypto/examples/bruteforce.rs
+++ b/crypto/examples/bruteforce.rs
@@ -34,7 +34,6 @@ use rand::thread_rng;
 use rand::Rng;
 use std::time::{Duration, SystemTime};
 use stegos_crypto::bulletproofs::*;
-use stegos_crypto::curve1174::fields::*;
 use stegos_crypto::curve1174::*;
 use stegos_crypto::hash::*;
 use stegos_crypto::keying::*;

--- a/crypto/src/bulletproofs/mod.rs
+++ b/crypto/src/bulletproofs/mod.rs
@@ -25,9 +25,6 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 
-use crate::curve1174::cpt::*;
-use crate::curve1174::ecpt::*;
-use crate::curve1174::fields::*;
 use crate::curve1174::*;
 use crate::hash::*;
 use crate::utils::*;

--- a/crypto/src/curve1174/mod.rs
+++ b/crypto/src/curve1174/mod.rs
@@ -44,17 +44,17 @@ use self::lev32::*;
 mod u256; // internal represntation of field elements
 use self::u256::*;
 
-pub mod fields;
-use self::fields::*;
+mod fields;
+pub use self::fields::*;
 
 mod fq51; // coord representation for Elliptic curve points
 use self::fq51::*;
 
-pub mod ecpt; // uncompressed points, affine & projective coords
-use self::ecpt::*;
+mod ecpt; // uncompressed points, affine & projective coords
+pub use self::ecpt::*;
 
-pub mod cpt; // compressed point representation
-use self::cpt::*;
+mod cpt; // compressed point representation
+pub use self::cpt::*;
 
 // -------------------------------------------------------------------
 // Signature Public Key - for checking curve constants validity

--- a/crypto/src/dicemix/mod.rs
+++ b/crypto/src/dicemix/mod.rs
@@ -86,14 +86,14 @@ participants engage.
 
 // -------------------------------------------------
 
-type Fr = curve1174::fields::Fr;
-type Pt = curve1174::cpt::Pt;
-type ECp = curve1174::ecpt::ECp;
+use curve1174::ECp;
+use curve1174::Fr;
+use curve1174::Pt;
 
 pub type ParticipantID = pbc::secure::PublicKey;
-type PublicKey = curve1174::cpt::PublicKey;
-type SecretKey = curve1174::cpt::SecretKey;
-type SchnorrSig = curve1174::cpt::SchnorrSig;
+use curve1174::PublicKey;
+use curve1174::SchnorrSig;
+use curve1174::SecretKey;
 
 pub type DcRow = Vec<Fr>; // one cell per chunk
 pub type DcSheet = Vec<DcRow>;
@@ -800,9 +800,9 @@ mod tests {
         let participants_3 = vec![pk1, pk2];
 
         let sess = Hash::from_str("session1");
-        let (sess_sk1, sess_pk1) = curve1174::cpt::make_deterministic_keys(b"User1-session1");
-        let (sess_sk2, sess_pk2) = curve1174::cpt::make_deterministic_keys(b"User2-session1");
-        let (sess_sk3, sess_pk3) = curve1174::cpt::make_deterministic_keys(b"User3-session1");
+        let (sess_sk1, sess_pk1) = curve1174::make_deterministic_keys(b"User1-session1");
+        let (sess_sk2, sess_pk2) = curve1174::make_deterministic_keys(b"User2-session1");
+        let (sess_sk3, sess_pk3) = curve1174::make_deterministic_keys(b"User3-session1");
 
         let mut npk1 = HashMap::new();
         npk1.insert(pk2, sess_pk2);
@@ -1062,7 +1062,7 @@ mod tests {
         let mut sess_skeys = HashMap::new();
         for ix in 0..nparts {
             let seed = format!("User_{}_Session_Key", ix).into_bytes();
-            let (sk, pk) = curve1174::cpt::make_deterministic_keys(&seed);
+            let (sk, pk) = curve1174::make_deterministic_keys(&seed);
             let p = participants[ix];
             sess_pkeys.insert(p, pk);
             sess_skeys.insert(p, sk);

--- a/crypto/src/pbc/mod.rs
+++ b/crypto/src/pbc/mod.rs
@@ -28,6 +28,7 @@ pub mod fast;
 pub mod secure;
 use crate::hash::*;
 use crate::utils::*;
+pub use secure::*;
 
 use lazy_static::lazy_static;
 use rust_libpbc;

--- a/crypto/src/protos.rs
+++ b/crypto/src/protos.rs
@@ -23,9 +23,7 @@ use failure::Error;
 use stegos_serialization::traits::*;
 
 use crate::bulletproofs::{BulletProof, DotProof, L2_NBASIS, LR};
-use crate::curve1174::cpt::Pt;
-use crate::curve1174::cpt::{EncryptedKey, EncryptedPayload, PublicKey, SchnorrSig, SecretKey};
-use crate::curve1174::fields::Fr;
+use crate::curve1174::{EncryptedKey, EncryptedPayload, Fr, Pt, PublicKey, SchnorrSig, SecretKey};
 use crate::hash::Hash;
 use crate::hashcash::HashCashProof;
 use crate::pbc::secure;
@@ -326,10 +324,9 @@ impl ProtoConvert for VRF {
 mod tests {
     use super::*;
     use crate::bulletproofs::make_range_proof;
-    use crate::curve1174::cpt::{decrypt_key, encrypt_key, make_random_keys};
-    use crate::curve1174::ecpt::ECp;
+    use crate::curve1174::{decrypt_key, encrypt_key, make_random_keys, ECp};
     use crate::hash::Hashable;
-    use crate::pbc::secure::make_random_keys as make_secure_random_keys;
+    use crate::pbc;
     use rand::rngs::ThreadRng;
     use rand::thread_rng;
     use rand::Rng;
@@ -366,7 +363,7 @@ mod tests {
 
     #[test]
     fn secure_keys() {
-        let (_skey, pkey) = make_secure_random_keys();
+        let (_skey, pkey) = pbc::make_random_keys();
         roundtrip(&pkey);
     }
 

--- a/keychain/src/input.rs
+++ b/keychain/src/input.rs
@@ -25,7 +25,7 @@ use log::*;
 use rpassword::prompt_password_stdout;
 use std::fs;
 use std::path::Path;
-use stegos_crypto::curve1174::cpt;
+use stegos_crypto::curve1174;
 
 /// PEM tag for encrypted wallet secret key.
 const RECOVERY_PROMPT: &'static str = "Enter 24-word recovery phrase: ";
@@ -41,7 +41,7 @@ fn fix_newline(password: &mut String) {
     }
 }
 
-fn read_recovery_from_stdin() -> Result<cpt::SecretKey, KeyError> {
+fn read_recovery_from_stdin() -> Result<curve1174::SecretKey, KeyError> {
     loop {
         let recovery = prompt_password_stdout(RECOVERY_PROMPT)
             .map_err(|e| KeyError::InputOutputError("stdin".to_string(), e))?;
@@ -55,7 +55,7 @@ fn read_recovery_from_stdin() -> Result<cpt::SecretKey, KeyError> {
     }
 }
 
-fn read_recovery_from_file(recovery_file: &str) -> Result<cpt::SecretKey, KeyError> {
+fn read_recovery_from_file(recovery_file: &str) -> Result<curve1174::SecretKey, KeyError> {
     info!("Reading recovery phrase from file {}...", recovery_file);
     let recovery_file_path = Path::new(recovery_file);
     let mut recovery = fs::read_to_string(recovery_file_path)
@@ -64,7 +64,7 @@ fn read_recovery_from_file(recovery_file: &str) -> Result<cpt::SecretKey, KeyErr
     Ok(recovery_to_wallet_skey(&recovery)?)
 }
 
-pub(crate) fn read_recovery(recovery_file: &str) -> Result<cpt::SecretKey, KeyError> {
+pub(crate) fn read_recovery(recovery_file: &str) -> Result<curve1174::SecretKey, KeyError> {
     if recovery_file == "-" && atty::is(atty::Stream::Stdin) {
         read_recovery_from_stdin()
     } else {

--- a/keychain/src/recovery.rs
+++ b/keychain/src/recovery.rs
@@ -20,7 +20,7 @@
 // SOFTWARE.
 
 use crate::error::KeyError;
-use stegos_crypto::curve1174::cpt;
+use stegos_crypto::curve1174;
 use stegos_crypto::keying::{convert_int_to_wordlist, convert_wordlist_to_int};
 
 fn checksum(bytes: &[u8]) -> u8 {
@@ -31,7 +31,7 @@ fn checksum(bytes: &[u8]) -> u8 {
     chk
 }
 
-pub fn wallet_skey_to_recovery(skey: &cpt::SecretKey) -> String {
+pub fn wallet_skey_to_recovery(skey: &curve1174::SecretKey) -> String {
     let skey = skey.to_bytes();
     let mut bytes = [08; 33];
     bytes[0..32].copy_from_slice(&skey[..]);
@@ -40,13 +40,13 @@ pub fn wallet_skey_to_recovery(skey: &cpt::SecretKey) -> String {
     words[..].join(" ")
 }
 
-pub fn recovery_to_wallet_skey(recovery: &str) -> Result<cpt::SecretKey, KeyError> {
+pub fn recovery_to_wallet_skey(recovery: &str) -> Result<curve1174::SecretKey, KeyError> {
     let words: Vec<&str> = recovery.split(' ').collect();
     let bytes = convert_wordlist_to_int(&words).map_err(|_| KeyError::InvalidRecoveryPhrase)?;
     if checksum(&bytes[0..32]) != bytes[32] {
         return Err(KeyError::InvalidRecoveryPhrase);
     }
-    cpt::SecretKey::try_from_bytes(&bytes[0..32]).map_err(|e| KeyError::InvalidRecoveryKey(e))
+    curve1174::SecretKey::try_from_bytes(&bytes[0..32]).map_err(|e| KeyError::InvalidRecoveryKey(e))
 }
 
 #[cfg(test)]
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     fn encode_decode() {
-        let (skey, _pkey) = cpt::make_random_keys();
+        let (skey, _pkey) = curve1174::make_random_keys();
         let words = wallet_skey_to_recovery(&skey);
         let skey2 = recovery_to_wallet_skey(&words).expect("invalid");
         assert_eq!(skey, skey2);

--- a/network/src/kad/kbucket.rs
+++ b/network/src/kad/kbucket.rs
@@ -36,7 +36,7 @@ use libp2p::multihash::Multihash;
 use std::slice::IterMut as SliceIterMut;
 use std::time::{Duration, Instant};
 use std::vec::IntoIter as VecIntoIter;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 /// Maximum number of nodes in a bucket.
 pub const MAX_NODES_PER_BUCKET: usize = 20;
@@ -134,7 +134,7 @@ impl KBucketsPeerId<Multihash> for PeerId {
     }
 }
 
-impl KBucketsPeerId for secure::PublicKey {
+impl KBucketsPeerId for pbc::PublicKey {
     #[inline]
     fn distance_with(&self, other: &Self) -> u32 {
         Multihash::distance_with(
@@ -149,7 +149,7 @@ impl KBucketsPeerId for secure::PublicKey {
     }
 }
 
-impl KBucketsPeerId<Multihash> for secure::PublicKey {
+impl KBucketsPeerId<Multihash> for pbc::PublicKey {
     #[inline]
     fn distance_with(&self, other: &Multihash) -> u32 {
         Multihash::distance_with(&self.clone().into_multihash(), other)
@@ -539,7 +539,7 @@ mod tests {
     use rand::random;
     use std::thread;
     use std::time::Duration;
-    use stegos_crypto::pbc::secure;
+    use stegos_crypto::pbc;
 
     #[test]
     fn basic_closest() {
@@ -681,8 +681,8 @@ mod tests {
 
     #[test]
     fn pbc_distance_between_keys() {
-        let (_, a) = secure::make_random_keys();
-        let (_, b) = secure::make_random_keys();
+        let (_, a) = pbc::make_random_keys();
+        let (_, b) = pbc::make_random_keys();
         assert_eq!(a.distance_with(&a), 0);
         assert!(a.distance_with(&a) < b.distance_with(&a));
         assert!(a.distance_with(&b) > b.distance_with(&b));
@@ -690,8 +690,8 @@ mod tests {
 
     #[test]
     fn pbc_basic_closest() {
-        let (_, my_id) = secure::make_random_keys();
-        let (_, other_id) = secure::make_random_keys();
+        let (_, my_id) = pbc::make_random_keys();
+        let (_, other_id) = pbc::make_random_keys();
 
         let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
         table.entry_mut(&other_id);
@@ -703,7 +703,7 @@ mod tests {
 
     #[test]
     fn pbc_update_local_id_fails() {
-        let (_, my_id) = secure::make_random_keys();
+        let (_, my_id) = pbc::make_random_keys();
 
         let mut table = KBucketsTable::<_, ()>::new(my_id.clone(), Duration::from_secs(5));
         assert!(table.entry_mut(&my_id).is_none());
@@ -715,13 +715,13 @@ mod tests {
 
     #[test]
     fn pbc_update_time_last_refresh() {
-        let (_, my_id) = secure::make_random_keys();
+        let (_, my_id) = pbc::make_random_keys();
         let mut table = KBucketsTable::<_, ()>::new(my_id, Duration::from_secs(5));
 
         // Generate some other IDs varying by just one bit.
         let other_ids = (0..random::<usize>() % 128)
             .map(|_| {
-                let (_, id) = secure::make_random_keys();
+                let (_, id) = pbc::make_random_keys();
                 (id, table.bucket_num(&id).unwrap())
             })
             .collect::<Vec<_>>();

--- a/network/src/kad/protocol.rs
+++ b/network/src/kad/protocol.rs
@@ -35,7 +35,7 @@ use libp2p::multihash::Multihash;
 use protobuf::{self, Message};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use tokio::codec::Framed;
 use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec;
@@ -87,7 +87,7 @@ impl Into<dht_proto::dht::Message_ConnectionType> for KadConnectionType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KadPeer {
     /// Identifier of the peer.
-    pub node_id: secure::PublicKey,
+    pub node_id: pbc::PublicKey,
     /// Network PeerId
     pub peer_id: Option<PeerId>,
     /// The multiaddresses that the sender think can be used in order to reach the peer.
@@ -98,7 +98,7 @@ pub struct KadPeer {
 
 impl KadPeer {
     fn from_peer(peer: &mut dht_proto::dht::Message_Peer) -> Result<KadPeer, IoError> {
-        let node_id = secure::PublicKey::try_from_bytes(peer.get_id()).map_err(|_| {
+        let node_id = pbc::PublicKey::try_from_bytes(peer.get_id()).map_err(|_| {
             IoError::new(
                 IoErrorKind::InvalidData,
                 "bad protobuf encoding, failed to decode node_id",
@@ -485,7 +485,7 @@ mod tests {
         PeerId,
     };
     use libp2p::multihash::{encode, Hash, Multihash};
-    use stegos_crypto::pbc::secure;
+    use stegos_crypto::pbc;
     use tokio::net::{TcpListener, TcpStream};
 
     #[test]
@@ -504,7 +504,7 @@ mod tests {
         test_one_req(KadRequestMsg::AddProvider {
             key: encode(Hash::SHA3512, &[9, 12, 0, 245, 245, 201, 28, 95]).unwrap(),
             provider_peer: KadPeer {
-                node_id: secure::PublicKey::from(secure::G2::generator()),
+                node_id: pbc::PublicKey::from(pbc::G2::generator()),
                 peer_id: Some(PeerId::random()),
                 multiaddrs: vec!["/ip4/9.1.2.3/udp/23".parse().unwrap()],
                 connection_ty: KadConnectionType::Connected,
@@ -515,7 +515,7 @@ mod tests {
         test_one_res(KadResponseMsg::Pong);
         test_one_res(KadResponseMsg::FindNode {
             closer_peers: vec![KadPeer {
-                node_id: secure::PublicKey::from(secure::G2::generator()),
+                node_id: pbc::PublicKey::from(pbc::G2::generator()),
                 peer_id: Some(PeerId::random()),
                 multiaddrs: vec!["/ip4/100.101.102.103/tcp/20105".parse().unwrap()],
                 connection_ty: KadConnectionType::Connected,
@@ -523,13 +523,13 @@ mod tests {
         });
         test_one_res(KadResponseMsg::GetProviders {
             closer_peers: vec![KadPeer {
-                node_id: secure::PublicKey::from(secure::G2::generator()),
+                node_id: pbc::PublicKey::from(pbc::G2::generator()),
                 peer_id: Some(PeerId::random()),
                 multiaddrs: vec!["/ip4/100.101.102.103/tcp/20105".parse().unwrap()],
                 connection_ty: KadConnectionType::Connected,
             }],
             provider_peers: vec![KadPeer {
-                node_id: secure::PublicKey::from(secure::G2::generator()),
+                node_id: pbc::PublicKey::from(pbc::G2::generator()),
                 peer_id: Some(PeerId::random()),
                 multiaddrs: vec!["/ip4/200.201.202.203/tcp/1999".parse().unwrap()],
                 connection_ty: KadConnectionType::NotConnected,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -36,7 +36,7 @@ mod utils;
 use failure::{Error, Fail};
 use futures::sync::mpsc;
 use std::fmt;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 pub use self::config::*;
 pub use self::kad::KBucketsPeerId;
@@ -64,7 +64,7 @@ where
     ) -> Result<mpsc::UnboundedReceiver<UnicastMessage>, Error>;
 
     /// Send unicast message to peer identified by network public key
-    fn send(&self, dest: secure::PublicKey, protocol_id: &str, data: Vec<u8>) -> Result<(), Error>;
+    fn send(&self, dest: pbc::PublicKey, protocol_id: &str, data: Vec<u8>) -> Result<(), Error>;
 
     /// Helper for cloning boxed object
     fn box_clone(&self) -> Network;
@@ -72,14 +72,14 @@ where
     /// Change network keys
     fn change_network_keys(
         &self,
-        _new_pkey: secure::PublicKey,
-        _new_skey: secure::SecretKey,
+        _new_pkey: pbc::PublicKey,
+        _new_skey: pbc::SecretKey,
     ) -> Result<(), Error>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnicastMessage {
-    pub from: secure::PublicKey,
+    pub from: pbc::PublicKey,
     pub data: Vec<u8>,
 }
 
@@ -94,5 +94,5 @@ impl Clone for Network {
 #[derive(Clone, Debug, Fail, PartialEq, Eq)]
 pub enum NetworkError {
     #[fail(display = "Generic network error talking to node: {:#?}", _0)]
-    GenericError(secure::PublicKey),
+    GenericError(pbc::PublicKey),
 }

--- a/network/src/ncp/behavior.rs
+++ b/network/src/ncp/behavior.rs
@@ -36,7 +36,7 @@ use std::{
     marker::PhantomData,
     time::{Duration, Instant},
 };
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use stegos_keychain::KeyChain;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::timer::Delay;
@@ -51,7 +51,7 @@ const KNOWN_PEERS_TABLE_SIZE: usize = 1024;
 /// about them.
 pub struct Ncp<TSubstream> {
     /// Out network key
-    node_id: secure::PublicKey,
+    node_id: pbc::PublicKey,
     /// Queue of internal events
     events: VecDeque<NcpEvent>,
     /// Events that need to be yielded to the outside when polling.
@@ -59,7 +59,7 @@ pub struct Ncp<TSubstream> {
     /// List of connected peers (including disabled)
     connected_peers: HashSet<PeerId>,
     /// Known peers
-    known_peers: LruCache<Vec<u8>, (secure::PublicKey, SmallVec<[Multiaddr; 16]>)>,
+    known_peers: LruCache<Vec<u8>, (pbc::PublicKey, SmallVec<[Multiaddr; 16]>)>,
     /// Maximum connections allowd
     max_connections: usize,
     /// Minimum connections to keep
@@ -82,7 +82,7 @@ impl<TSubstream> Ncp<TSubstream> {
             out_events: VecDeque::new(),
             connected_peers: HashSet::new(),
             known_peers:
-                LruCache::<Vec<u8>, (secure::PublicKey, SmallVec<[Multiaddr; 16]>)>::with_capacity(
+                LruCache::<Vec<u8>, (pbc::PublicKey, SmallVec<[Multiaddr; 16]>)>::with_capacity(
                     KNOWN_PEERS_TABLE_SIZE,
                 ),
             max_connections: config.max_connections,
@@ -97,7 +97,7 @@ impl<TSubstream> Ncp<TSubstream> {
         }
     }
 
-    pub fn change_network_key(&mut self, new_pkey: secure::PublicKey) {
+    pub fn change_network_key(&mut self, new_pkey: pbc::PublicKey) {
         self.node_id = new_pkey;
         // Update all connected peers with our new network key
         for p in self.connected_peers.iter() {
@@ -365,7 +365,7 @@ pub enum NcpOutEvent {
         peer_id: PeerId,
     },
     DiscoveredPeer {
-        node_id: secure::PublicKey,
+        node_id: pbc::PublicKey,
         peer_id: PeerId,
         addresses: Vec<Multiaddr>,
     },

--- a/network/src/ncp/protocol.rs
+++ b/network/src/ncp/protocol.rs
@@ -27,7 +27,7 @@ use libp2p::core::{InboundUpgrade, OutboundUpgrade, PeerId, UpgradeInfo};
 use libp2p::Multiaddr;
 use protobuf::Message;
 use std::{io, iter};
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use tokio::codec::{Decoder, Encoder, Framed};
 use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec;
@@ -169,7 +169,7 @@ impl Decoder for NcpCodec {
                             )
                         })?;
                     let node_id =
-                        secure::PublicKey::try_from_bytes(peer.get_node_id()).map_err(|_| {
+                        pbc::PublicKey::try_from_bytes(peer.get_node_id()).map_err(|_| {
                             io::Error::new(
                                 io::ErrorKind::InvalidData,
                                 "bad protobuf encoding, failed to decode node_id",
@@ -204,7 +204,7 @@ pub enum NcpMessage {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PeerInfo {
     pub peer_id: PeerId,
-    pub node_id: secure::PublicKey,
+    pub node_id: pbc::PublicKey,
     pub addresses: Vec<Multiaddr>,
 }
 
@@ -214,7 +214,7 @@ pub struct GetPeersResponse {
 }
 
 impl PeerInfo {
-    pub fn new(peer_id: &PeerId, node_id: &secure::PublicKey) -> Self {
+    pub fn new(peer_id: &PeerId, node_id: &pbc::PublicKey) -> Self {
         Self {
             peer_id: peer_id.clone(),
             node_id: node_id.clone(),
@@ -229,14 +229,14 @@ mod tests {
     use futures::{Future, Sink, Stream};
     use libp2p::core::upgrade::{InboundUpgrade, OutboundUpgrade};
     use libp2p::core::PeerId;
-    use stegos_crypto::pbc::secure;
+    use stegos_crypto::pbc;
     use tokio::net::{TcpListener, TcpStream};
 
     #[test]
     fn correct_transfer() {
         test_one(NcpMessage::GetPeersRequest);
 
-        let (_, node_id) = secure::make_random_keys();
+        let (_, node_id) = pbc::make_random_keys();
 
         let msg = NcpMessage::GetPeersResponse {
             response: GetPeersResponse {

--- a/network/src/utils/multihash.rs
+++ b/network/src/utils/multihash.rs
@@ -23,13 +23,13 @@
 
 use libp2p::core::PeerId;
 use libp2p::multihash::{encode, Hash::SHA3512, Multihash};
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 pub trait IntoMultihash {
     fn into_multihash(self) -> Multihash;
 }
 
-impl IntoMultihash for secure::PublicKey {
+impl IntoMultihash for pbc::PublicKey {
     fn into_multihash(self) -> Multihash {
         encode(SHA3512, &self.to_bytes()).expect("should never fail")
     }

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -29,7 +29,7 @@ use std::time::SystemTime;
 use stegos_blockchain::view_changes::ViewChangeProof;
 use stegos_blockchain::*;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use stegos_keychain::KeyChain;
 
 /// Memory Pool of Transactions.
@@ -167,7 +167,7 @@ impl Mempool {
     ) -> MicroBlock {
         let timestamp = SystemTime::now();
         let seed = mix(last_random, view_change);
-        let random = secure::make_VRF(&keychain.network_skey, &seed);
+        let random = pbc::make_VRF(&keychain.network_skey, &seed);
 
         //
         // Transactions.
@@ -212,7 +212,7 @@ impl Mempool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use stegos_crypto::curve1174::cpt::make_random_keys;
+    use stegos_crypto::curve1174::make_random_keys;
 
     #[test]
     fn basic() {

--- a/node/src/test/consensus.rs
+++ b/node/src/test/consensus.rs
@@ -25,7 +25,7 @@ use super::*;
 use crate::*;
 use stegos_blockchain::Block;
 use stegos_consensus::ConsensusMessageBody;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 #[test]
 fn smoke_test() {
@@ -97,7 +97,7 @@ fn smoke_test() {
                 request_hash_sig, ..
             } = precommit.body
             {
-                secure::check_hash(
+                pbc::check_hash(
                     &proposal.request_hash,
                     &request_hash_sig,
                     &node.node_service.keys.network_pkey,
@@ -559,7 +559,7 @@ fn out_of_order_micro_block() {
             leader.node_service.chain.last_random(),
             leader.node_service.chain.view_change(),
         );
-        let random = secure::make_VRF(&leader.node_service.keys.network_skey, &seed);
+        let random = pbc::make_VRF(&leader.node_service.keys.network_skey, &seed);
 
         let base = BaseBlockHeader::new(
             version,
@@ -573,7 +573,7 @@ fn out_of_order_micro_block() {
 
         let block_hash = Hash::digest(&block);
         let leader_node = s.node(&leader_pk).unwrap();
-        block.sig = secure::sign_hash(&block_hash, &leader_node.node_service.keys.network_skey);
+        block.sig = pbc::sign_hash(&block_hash, &leader_node.node_service.keys.network_skey);
         let block: Block = Block::MicroBlock(block);
 
         // Discard proposal from leader for a proposal from the leader.

--- a/node/src/test/microblocks.rs
+++ b/node/src/test/microblocks.rs
@@ -597,7 +597,7 @@ fn out_of_order_keyblock_proposal() {
             let version = 1;
             let timestamp = SystemTime::now();
             let seed = mix(last_random, round);
-            let random = secure::make_VRF(&leader_node.node_service.keys.network_skey, &seed);
+            let random = pbc::make_VRF(&leader_node.node_service.keys.network_skey, &seed);
             let base = BaseBlockHeader::new(version, previous, height, round, timestamp, random);
             let leader = leader_node.node_service.keys.network_pkey;
             let request = MacroBlock::empty(base, leader);
@@ -666,7 +666,7 @@ fn micro_block_without_signature() {
             leader.node_service.chain.last_random(),
             leader.node_service.chain.view_change(),
         );
-        let random = secure::make_VRF(&leader.node_service.keys.network_skey, &seed);
+        let random = pbc::make_VRF(&leader.node_service.keys.network_skey, &seed);
         let base = BaseBlockHeader::new(
             version,
             last_block_hash,

--- a/node/src/test/mod.rs
+++ b/node/src/test/mod.rs
@@ -31,8 +31,8 @@ mod requests;
 use crate::*;
 use assert_matches::assert_matches;
 use log::Level;
-use stegos_crypto::pbc::secure;
-use stegos_crypto::pbc::secure::VRF;
+use stegos_crypto::pbc;
+use stegos_crypto::pbc::VRF;
 use stegos_keychain::KeyChain;
 use tokio_timer::Timer;
 
@@ -102,7 +102,7 @@ impl<'timer> Sandbox<'timer> {
         &self.config
     }
 
-    fn split<'a>(&'a mut self, first_partitions_nodes: &[secure::PublicKey]) -> PartitionGuard<'a> {
+    fn split<'a>(&'a mut self, first_partitions_nodes: &[pbc::PublicKey]) -> PartitionGuard<'a> {
         let divider = |key| {
             first_partitions_nodes
                 .iter()
@@ -225,7 +225,7 @@ impl NodeSandbox {
     #[allow(dead_code)]
     fn create_vrf_from_seed(&self, random: Hash, view_change: u32) -> VRF {
         let seed = mix(random, view_change);
-        secure::make_VRF(&self.node_service.keys.network_skey, &seed)
+        pbc::make_VRF(&self.node_service.keys.network_skey, &seed)
     }
 
     fn validator_id(&self) -> Option<usize> {
@@ -273,7 +273,7 @@ trait Api<'p> {
     /// Iterator among all nodes, except one of
     fn iter_except<'a>(
         &'a mut self,
-        validators: &'a [secure::PublicKey],
+        validators: &'a [pbc::PublicKey],
     ) -> Box<dyn Iterator<Item = &'a mut NodeSandbox> + 'a>
     where
         'p: 'a,
@@ -347,13 +347,13 @@ trait Api<'p> {
         self.poll();
     }
 
-    fn leader(&mut self) -> secure::PublicKey {
+    fn leader(&mut self) -> pbc::PublicKey {
         self.first_mut().node_service.chain.leader()
     }
 
     /// Returns next leader publicKey.
     /// Returns None if current leader was not found in current partition.
-    fn next_leader(&mut self) -> Option<secure::PublicKey> {
+    fn next_leader(&mut self) -> Option<pbc::PublicKey> {
         let first_leader_pk = self.first_mut().node_service.chain.leader();
         let view_change = self.first_mut().node_service.chain.view_change();
 
@@ -363,7 +363,7 @@ trait Api<'p> {
         Some(election.select_leader(view_change + 1))
     }
 
-    fn next_view_change_leader(&mut self) -> secure::PublicKey {
+    fn next_view_change_leader(&mut self) -> pbc::PublicKey {
         let view_change = self.first_mut().node_service.chain.view_change();
         self.first_mut()
             .node_service
@@ -382,7 +382,7 @@ trait Api<'p> {
     }
 
     /// Return node for publickey.
-    fn node<'a>(&'a mut self, pk: &secure::PublicKey) -> Option<&'a mut NodeSandbox>
+    fn node<'a>(&'a mut self, pk: &pbc::PublicKey) -> Option<&'a mut NodeSandbox>
     where
         'p: 'a,
     {
@@ -391,7 +391,7 @@ trait Api<'p> {
     }
 
     /// Return node for publickey.
-    fn node_ref<'a>(&'a mut self, pk: &secure::PublicKey) -> Option<&'a NodeSandbox>
+    fn node_ref<'a>(&'a mut self, pk: &pbc::PublicKey) -> Option<&'a NodeSandbox>
     where
         'p: 'a,
     {

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -171,7 +171,7 @@ mod test {
     use super::*;
     use std::time::{Duration, SystemTime};
     use stegos_blockchain::*;
-    use stegos_crypto::curve1174::fields::Fr;
+    use stegos_crypto::curve1174::Fr;
     use stegos_keychain::KeyChain;
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 use std::result::Result;
 use stegos_api::WebSocketConfig;
 use stegos_blockchain::StorageConfig;
-use stegos_crypto::curve1174::cpt::PublicKey;
+use stegos_crypto::curve1174::PublicKey;
 use stegos_keychain::KeyChainConfig;
 use stegos_network::NetworkConfig;
 use stegos_node::ChainConfig;

--- a/src/console.rs
+++ b/src/console.rs
@@ -36,8 +36,8 @@ use rustyline as rl;
 use std::fmt;
 use std::path::PathBuf;
 use std::thread;
-use stegos_crypto::curve1174::cpt::PublicKey;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::curve1174::PublicKey;
+use stegos_crypto::pbc;
 use stegos_network::Network;
 use stegos_network::UnicastMessage;
 use stegos_node::{Node, NodeRequest, NodeResponse};
@@ -292,7 +292,7 @@ impl ConsoleService {
             };
 
             let recipient = caps.name("recipient").unwrap().as_str();
-            let recipient = match secure::PublicKey::try_from_hex(recipient) {
+            let recipient = match pbc::PublicKey::try_from_hex(recipient) {
                 Ok(r) => r,
                 Err(e) => {
                     println!("Invalid network public key '{}': {}", recipient, e);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -25,7 +25,7 @@ use futures::{Async, Future, Poll, Stream};
 use log::*;
 use rand::seq::SliceRandom;
 use std::time::Duration;
-use stegos_crypto::curve1174::cpt::PublicKey;
+use stegos_crypto::curve1174::PublicKey;
 use stegos_wallet::{Wallet, WalletNotification, WalletRequest, WalletResponse};
 use tokio_timer::Delay;
 

--- a/txpool/src/lib.rs
+++ b/txpool/src/lib.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use stegos_blockchain::PaymentOutput;
 use stegos_crypto::curve1174;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use stegos_keychain::KeyChain;
 use stegos_network::Network;
 use stegos_node::EpochChanged;
@@ -24,8 +24,8 @@ const MESSAGE_TIMEOUT: Duration = Duration::from_secs(30);
 
 type TXIN = Hash;
 type UTXO = PaymentOutput;
-type SchnorrSig = curve1174::cpt::SchnorrSig;
-type ParticipantID = secure::PublicKey;
+type SchnorrSig = curve1174::SchnorrSig;
+type ParticipantID = pbc::PublicKey;
 
 struct FacilitatorState {
     participants: HashMap<ParticipantID, (Vec<TXIN>, Vec<UTXO>, SchnorrSig)>,

--- a/txpool/src/messages.rs
+++ b/txpool/src/messages.rs
@@ -22,7 +22,7 @@
 use stegos_blockchain::PaymentOutput;
 use stegos_crypto::curve1174;
 use stegos_crypto::hash::{Hash, Hashable, Hasher};
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 /// A topic used for Join requests.
 pub const POOL_JOIN_TOPIC: &'static str = "txpool_join";
@@ -31,8 +31,8 @@ pub const POOL_ANNOUNCE_TOPIC: &'static str = "txpool_announce";
 
 type TXIN = Hash;
 type UTXO = PaymentOutput;
-type SchnorrSig = curve1174::cpt::SchnorrSig;
-type ParticipantID = secure::PublicKey;
+type SchnorrSig = curve1174::SchnorrSig;
+type ParticipantID = pbc::PublicKey;
 
 // --------------------------------------------------
 

--- a/txpool/src/protos.rs
+++ b/txpool/src/protos.rs
@@ -21,9 +21,9 @@
 
 use failure::Error;
 use stegos_blockchain::PaymentOutput;
-use stegos_crypto::curve1174::cpt::SchnorrSig;
+use stegos_crypto::curve1174::SchnorrSig;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure::PublicKey;
+use stegos_crypto::pbc::PublicKey;
 use stegos_serialization::traits::*;
 
 use crate::messages::{ParticipantTXINMap, PoolInfo, PoolJoin};
@@ -149,12 +149,12 @@ mod tests {
 
     #[test]
     fn pool_info() {
-        let (_, pkey) = secure::make_random_keys();
-        let (_, pkey1) = secure::make_random_keys();
+        let (_, pkey) = pbc::make_random_keys();
+        let (_, pkey1) = pbc::make_random_keys();
 
         let session_id = Hash::digest(&1u64);
-        let mut participants: Vec<secure::PublicKey> = Vec::new();
-        participants.push((pkey.clone(), Vec::new(), cpt::SchnorrSig::new()));
+        let mut participants: Vec<pbc::PublicKey> = Vec::new();
+        participants.push((pkey.clone(), Vec::new(), curve1174::SchnorrSig::new()));
         participants.push(pkey1);
         let pool = PoolInfo {
             participants,

--- a/wallet/examples/show_utxo_chunks.rs
+++ b/wallet/examples/show_utxo_chunks.rs
@@ -29,23 +29,23 @@ use std::time::SystemTime;
 use stegos_blockchain::Output;
 use stegos_blockchain::PaymentTransaction;
 use stegos_blockchain::{PaymentOutput, PaymentPayloadData};
-use stegos_crypto::curve1174::cpt::make_random_keys;
-use stegos_crypto::curve1174::cpt::Pt;
-use stegos_crypto::curve1174::cpt::PublicKey;
-use stegos_crypto::curve1174::cpt::SchnorrSig;
-use stegos_crypto::curve1174::cpt::SecretKey;
-use stegos_crypto::curve1174::ecpt::ECp;
-use stegos_crypto::curve1174::fields::Fr;
+use stegos_crypto::curve1174::make_random_keys;
+use stegos_crypto::curve1174::ECp;
+use stegos_crypto::curve1174::Fr;
+use stegos_crypto::curve1174::Pt;
+use stegos_crypto::curve1174::PublicKey;
+use stegos_crypto::curve1174::SchnorrSig;
+use stegos_crypto::curve1174::SecretKey;
 use stegos_crypto::dicemix::*;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::hash::{Hashable, Hasher, HASH_SIZE};
-use stegos_crypto::pbc::secure::make_random_keys as make_secure_random_keys;
+use stegos_crypto::pbc;
 use stegos_serialization::traits::ProtoConvert;
 
 fn main() {
     // Determine number of DiceMix chunks needed to support our UTXO's
     let (_skey, pkey) = make_random_keys();
-    let (sskey, spkey) = make_secure_random_keys();
+    let (sskey, spkey) = pbc::make_random_keys();
     let tstamp = SystemTime::now();
     let data = PaymentPayloadData::Comment("Testing".to_string());
     let (out, gamma) =

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -29,9 +29,9 @@ use serde_derive::Deserialize;
 use serde_derive::Serialize;
 pub use stegos_blockchain::PaymentPayloadData;
 pub use stegos_blockchain::StakeInfo;
-use stegos_crypto::curve1174::cpt::PublicKey;
+use stegos_crypto::curve1174::PublicKey;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 use stegos_node::EpochChanged;
 use stegos_node::OutputsChanged;
 
@@ -105,7 +105,7 @@ pub enum WalletResponse {
     },
     KeysInfo {
         wallet_pkey: PublicKey,
-        network_pkey: secure::PublicKey,
+        network_pkey: pbc::PublicKey,
     },
     UnspentInfo {
         payments: Vec<PaymentInfo>,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -44,7 +44,7 @@ use futures_stream_select_all_send::select_all;
 use log::*;
 use std::collections::HashMap;
 use stegos_blockchain::*;
-use stegos_crypto::curve1174::cpt::PublicKey;
+use stegos_crypto::curve1174::PublicKey;
 use stegos_crypto::hash::Hash;
 use stegos_keychain::KeyChain;
 use stegos_network::Network;

--- a/wallet/src/transaction.rs
+++ b/wallet/src/transaction.rs
@@ -27,11 +27,11 @@ use crate::valueshuffle::ProposedUTXO;
 use failure::Error;
 use log::*;
 use stegos_blockchain::*;
-use stegos_crypto::curve1174::cpt::PublicKey;
-use stegos_crypto::curve1174::cpt::SecretKey;
-use stegos_crypto::curve1174::fields::Fr;
+use stegos_crypto::curve1174::Fr;
+use stegos_crypto::curve1174::PublicKey;
+use stegos_crypto::curve1174::SecretKey;
 use stegos_crypto::hash::Hash;
-use stegos_crypto::pbc::secure;
+use stegos_crypto::pbc;
 
 /// Create a new ValueShuffle payment transaction. (no data)
 pub(crate) fn create_vs_payment_transaction<'a, UnspentIter>(
@@ -240,8 +240,8 @@ where
 pub(crate) fn create_staking_transaction<'a, UnspentIter>(
     sender_skey: &SecretKey,
     sender_pkey: &PublicKey,
-    validator_pkey: &secure::PublicKey,
-    validator_skey: &secure::SecretKey,
+    validator_pkey: &pbc::PublicKey,
+    validator_skey: &pbc::SecretKey,
     unspent_iter: UnspentIter,
     amount: i64,
     payment_fee: i64,
@@ -343,8 +343,8 @@ where
 pub(crate) fn create_unstaking_transaction<'a, UnspentIter>(
     sender_skey: &SecretKey,
     sender_pkey: &PublicKey,
-    validator_pkey: &secure::PublicKey,
-    validator_skey: &secure::SecretKey,
+    validator_pkey: &pbc::PublicKey,
+    validator_skey: &pbc::SecretKey,
     unspent_iter: UnspentIter,
     amount: i64,
     payment_fee: i64,
@@ -435,8 +435,8 @@ where
 pub(crate) fn create_restaking_transaction<'a, UnspentIter>(
     sender_skey: &SecretKey,
     sender_pkey: &PublicKey,
-    validator_pkey: &secure::PublicKey,
-    validator_skey: &secure::SecretKey,
+    validator_pkey: &pbc::PublicKey,
+    validator_skey: &pbc::SecretKey,
     stakes_iter: UnspentIter,
 ) -> Result<PaymentTransaction, Error>
 where
@@ -486,8 +486,8 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use stegos_crypto::curve1174::cpt::make_random_keys;
-    use stegos_crypto::pbc::secure;
+    use stegos_crypto::curve1174::make_random_keys;
+    use stegos_crypto::pbc;
 
     /// Check transaction signing and validation.
     #[test]
@@ -498,7 +498,7 @@ pub mod tests {
         simple_logger::init_with_level(log::Level::Debug).unwrap_or_default();
 
         let (skey, pkey) = make_random_keys();
-        let (validator_skey, validator_pkey) = secure::make_random_keys();
+        let (validator_skey, validator_pkey) = pbc::make_random_keys();
 
         let stake: i64 = 100;
 

--- a/wallet/src/valueshuffle/message.rs
+++ b/wallet/src/valueshuffle/message.rs
@@ -24,11 +24,11 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use stegos_crypto::curve1174::cpt::Pt;
-use stegos_crypto::curve1174::cpt::PublicKey;
-use stegos_crypto::curve1174::cpt::SchnorrSig;
-use stegos_crypto::curve1174::cpt::SecretKey;
-use stegos_crypto::curve1174::fields::Fr;
+use stegos_crypto::curve1174::Fr;
+use stegos_crypto::curve1174::Pt;
+use stegos_crypto::curve1174::PublicKey;
+use stegos_crypto::curve1174::SchnorrSig;
+use stegos_crypto::curve1174::SecretKey;
 use stegos_crypto::dicemix::DcMatrix;
 use stegos_crypto::dicemix::ParticipantID;
 use stegos_crypto::hash::Hash;

--- a/wallet/src/valueshuffle/mod.rs
+++ b/wallet/src/valueshuffle/mod.rs
@@ -25,7 +25,7 @@
 // ========================================================================
 // When a wallet wants to participate in a ValueShuffle session,
 // it should advertise its desire by sending a message to the Facilitator
-// node, along with its network ID (currently a pbc::secure::PublicKey).
+// node, along with its network ID (currently a pbc::pbc::PublicKey).
 //
 // When the Facilitator has accumulated a sufficient number of requestor
 // nodes, it collects those ID's and sends a message to each of them, to
@@ -100,16 +100,11 @@ use stegos_blockchain::Output;
 use stegos_blockchain::PaymentTransaction;
 use stegos_blockchain::{PaymentOutput, PaymentPayloadData};
 use stegos_crypto::bulletproofs::{simple_commit, validate_range_proof};
-use stegos_crypto::curve1174::cpt::Pt;
-use stegos_crypto::curve1174::cpt::PublicKey;
-use stegos_crypto::curve1174::cpt::SchnorrSig;
-use stegos_crypto::curve1174::cpt::SecretKey;
-use stegos_crypto::curve1174::cpt::{make_deterministic_keys, sign_hash, validate_sig};
-use stegos_crypto::curve1174::ecpt::ECp;
-use stegos_crypto::curve1174::fields::Fr;
+use stegos_crypto::curve1174::{
+    make_deterministic_keys, sign_hash, validate_sig, ECp, Fr, Pt, PublicKey, SchnorrSig, SecretKey,
+};
 use stegos_crypto::dicemix::*;
-use stegos_crypto::hash::Hash;
-use stegos_crypto::hash::{Hashable, Hasher, HASH_SIZE};
+use stegos_crypto::hash::{Hash, Hashable, Hasher, HASH_SIZE};
 use stegos_network::Network;
 use stegos_node::Node;
 use stegos_serialization::traits::ProtoConvert;
@@ -129,7 +124,7 @@ pub const MAX_UTXOS: usize = 5; // max nbr of txout UTXO permitted
 
 // ==============================================================
 
-type ParticipantID = stegos_crypto::pbc::secure::PublicKey;
+type ParticipantID = stegos_crypto::pbc::PublicKey;
 
 type TXIN = Hash;
 type UTXO = PaymentOutput;
@@ -459,7 +454,7 @@ impl ValueShuffle {
 
     // When a wallet wants to participate in a ValueShuffle session,
     // it should advertise its desire by sending a message to the Facilitator
-    // node, along with its network ID (currently a pbc::secure::PublicKey).
+    // node, along with its network ID (currently a pbc::pbc::PublicKey).
     //
     // When the Facilitator has accumulated a sufficient number of requestor
     // nodes, it collects those ID's and sends a message to each of them, to

--- a/wallet/src/valueshuffle/protos.rs
+++ b/wallet/src/valueshuffle/protos.rs
@@ -31,13 +31,12 @@ use stegos_crypto::protos::*;
 include!(concat!(env!("OUT_DIR"), "/valueshuffle/mod.rs"));
 
 use std::collections::HashMap;
-use stegos_crypto::curve1174::cpt::{Pt, PublicKey, SchnorrSig, SecretKey};
-use stegos_crypto::curve1174::fields::Fr;
+use stegos_crypto::curve1174::{Fr, Pt, PublicKey, SchnorrSig, SecretKey};
 use stegos_crypto::hash::Hash;
 
 type DcRow = Vec<Fr>;
 type DcSheet = Vec<DcRow>;
-type ParticipantID = stegos_crypto::pbc::secure::PublicKey;
+type ParticipantID = stegos_crypto::pbc::PublicKey;
 
 impl ProtoConvert for VsPayload {
     type Proto = valueshuffle::VsPayload;
@@ -207,7 +206,7 @@ pub mod tests {
     use super::*;
     use std::dbg;
     use stegos_crypto::bulletproofs::simple_commit;
-    use stegos_crypto::curve1174::cpt::make_random_keys;
+    use stegos_crypto::curve1174::make_random_keys;
 
     #[test]
     fn vs_serialization() {


### PR DESCRIPTION
- Import `cpt::*`, `ecpt::*`, `fields::*` into `stegos_crypto::curve1177`.
- Import `secure::*` into `stegos_crypto::pbc`.
- Use `pbc::` prefix instead of `secure::`.
- Use `curve1174::` prefis instead of `cpt::`.