### PR TITLE
Add clear_wau() to support SchnorrSig

### DIFF
--- a/crypto/src/curve1174/cpt.rs
+++ b/crypto/src/curve1174/cpt.rs
@@ -484,7 +484,8 @@ pub fn sign_hash(hmsg: &Hash, skey: &SecretKey) -> SchnorrSig {
     let K = &k * *G;
     let pkey = PublicKey::from(skey);
     let h = Hash::digest_chain(&[&K, &pkey, hmsg]);
-    let u = k + Fr::from(h) * Fr::from(skey);
+    let mut u = k + Fr::from(h) * Fr::from(skey);
+    u.clear_wau();
     SchnorrSig {
         u: u.unscaled(),
         K: Pt::from(K),
@@ -525,7 +526,8 @@ pub fn sign_hash_with_kval(
     let my_K = k_val * *G;
     let pkey = PublicKey::from(Pt::from(*sumPKey));
     let h = Hash::digest_chain(&[sumK, &pkey, hmsg]);
-    let u = k_val + Fr::from(h) * Fr::from(skey);
+    let mut u = k_val + Fr::from(h) * Fr::from(skey);
+    u.clear_wau();
     SchnorrSig {
         u: u.unscaled(),
         K: Pt::from(my_K),

--- a/crypto/src/curve1174/fields.rs
+++ b/crypto/src/curve1174/fields.rs
@@ -111,6 +111,13 @@ macro_rules! field_impl {
                 }
             }
 
+            pub fn clear_wau(&mut self) {
+                match self {
+                    $name::Scaled(v) => v.clear_wau(),
+                    $name::Unscaled(v) => v.clear_wau(),
+                }
+            }
+
             pub fn maybe_zap(&mut self) {
                 match self {
                     $name::Scaled(v) => v.maybe_zap(),

--- a/crypto/src/curve1174/u256.rs
+++ b/crypto/src/curve1174/u256.rs
@@ -62,6 +62,10 @@ impl U256 {
         self.1 = true;
     }
 
+    pub fn clear_wau(&mut self) {
+        self.1 = false;
+    }
+
     pub fn maybe_zap(&mut self) {
         if Self::has_wau(self) {
             Self::zap(self);


### PR DESCRIPTION
WAU is contagious in the result when any operand in a field arithmetic expression has WAU. Hence the u-value of the signature would be serialized using AONT encryption. 

This is not necessary in the u-value of a SchnorrSig, since by addition of two secret values from the field, the sum effectively cloaks each other's secrecy contribution. There is no need to cloak any secrecy in the u-value.

Implement a clear_wau() primitive in the field and its underlying U256 representation, to signal that serialization can proceed without AONT encryption, and add explicit clear_wau() after constructing the signature u-value.