### PR TITLE
Simplified pubsub and minor updates to handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,15 +136,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,7 +311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bumpalo"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -385,8 +385,8 @@ name = "chrono"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -676,7 +676,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -988,10 +988,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1301,7 +1301,7 @@ dependencies = [
  "ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1314,9 +1314,9 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1351,12 +1351,12 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1607,10 +1607,11 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1618,13 +1619,16 @@ name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1649,7 +1653,7 @@ name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1968,7 +1972,7 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1986,7 +1990,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2047,7 +2051,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3297,65 +3301,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.44"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen-macro 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.44"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 2.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.44"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.44"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.44"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen-webidl"
-version = "0.2.44"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3364,8 +3368,8 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3376,21 +3380,21 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-webidl 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3416,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "weedle"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3554,8 +3558,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum asn1_der_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e7f92edafad155aff997fa5b727c6429b91e996b5a5d62a2b0adbae1306b5fe"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
-"checksum backtrace 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "f92d5d536fa03dc3d93711d97bac1fae2eb59aba467ca4c6600c0119da614f51"
+"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "45934a579eff9fd0ff637ac376a4bd134f47f8fc603f0b211d696b54d61e35f1"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
@@ -3573,7 +3577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-"checksum bumpalo 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "299f49401bb57849d1523425255b87e31ac78f2bbf4ac654cd681db25bc4a5d5"
+"checksum bumpalo 2.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "84dca3afd8e01b9526818b7963e5b4916063b3cdf9f10cf6b73ef0bd0ec37aa5"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
@@ -3652,7 +3656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum js-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)" = "825bc8ab4bd6a1f5c119f01400a6bcb8176e553c53f5be03ec5c5b874b8a6ca4"
+"checksum js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9987e7c13a91d9cf0efe59cca48a3a7a70e2b11695d5a4640f85ae71e28f5e73"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
@@ -3702,9 +3706,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nohash-hasher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d138afcce92d219ccb6eb53d9b1e8a96ac0d633cfd3c53cd9856d96d1741bb8"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
@@ -3865,17 +3869,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
-"checksum wasm-bindgen 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "df659e080ba2ee410d3651a84e33cc09f5bd355b0c6f014876502231f2f91659"
-"checksum wasm-bindgen-backend 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "b7adec71077d40b84d771e5155aa3ca1985e1f5bcefb36cdae4157e670509ea4"
-"checksum wasm-bindgen-futures 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)" = "9b1f125b44e5cfe2d0bdaed2c7db67c5060a0138e51f82409a750eea9c07b8e2"
-"checksum wasm-bindgen-macro 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "d2182038ee8ee22c5f5653ab081d4970c054b435b4b513d587beaa7f95c9c277"
-"checksum wasm-bindgen-macro-support 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4b5cb4ac8bf9c516016f7f12b0b8fbcaf16c6a983bf438738ba165055c2b7b"
-"checksum wasm-bindgen-shared 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "5617f78ef6ffc25f1e34130a9581cdd0d54b90000a9e8ac1e28a1cdc16ca65b3"
-"checksum wasm-bindgen-webidl 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "ce7a736ddc1fa6c7a13465797d1bf391fc38ee2d000782ca9679d2cd973aa4a7"
+"checksum wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "b7ccc7b93cfd13e26700a9e2e41e6305f1951b87e166599069f77d10358100e6"
+"checksum wasm-bindgen-backend 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "1953f91b1608eb1522513623c7739f047bb0fed4128ce51a93f08e12cc314645"
+"checksum wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "fa1af11c73eca3dc8c51c76ea475a4416e912da6402064a49fc6c0214701866d"
+"checksum wasm-bindgen-macro 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "0f69da5696545d7ca6607a2e4b1a0edf5a6b36b2c49dbb0f1df6ad1d92884047"
+"checksum wasm-bindgen-macro-support 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d4246f3bc73223bbb846f4f2430a60725826a96c9389adf715ed1d5af46dec6"
+"checksum wasm-bindgen-shared 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "c08381e07e7a79e5e229ad7c60d15833d19033542cc5dd91d085df59d235f4a6"
+"checksum wasm-bindgen-webidl 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "1f42ff7adb8102bf5ad8adbc45b1635c520c8175f9fdf6eb2c54479d485d435a"
 "checksum wasm-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad9ac33c834103916e373d648adf65f58c83fb3d8a0f3e6b9a64bca7253a4dca"
-"checksum web-sys 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)" = "9d149c7b5c5fc579dbb5ad5f4db6c68fab3fb2414d75cff8393e26509639ad92"
+"checksum web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "540b8259eb242ff3a566fa0140bda03a4ece4e5c226e1284b5c95dddcd4341f6"
 "checksum websocket 0.22.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0adcd2a64c5746c9702b354a1b992802b0c363df1dfa324a74cb7aebe10e0cbf"
-"checksum weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26a4c67f132386d965390b8a734d5d10adbcd30eb5cc74bd9229af8b83f10044"
+"checksum weedle 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc44aa200daee8b1f3a004beaf16554369746f1b4486f0cf93b0caf8a3c2d1e"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/network/src/delivery/behavior.rs
+++ b/network/src/delivery/behavior.rs
@@ -78,7 +78,7 @@ impl<TSubstream> Delivery<TSubstream> {
 impl<TSubstream> Delivery<TSubstream> {
     pub fn deliver_unicast(&mut self, next_hop: &PeerId, message: Unicast) {
         if self.connected_peers.contains(next_hop) {
-            debug!(target: "stegos_network::delivery", "delivering message to connected peer: peer_id={}, seq_no={}", next_hop.to_base58(), u8v_to_hexstr(&message.seq_no));
+            debug!(target: "stegos_network::delivery", "delivering message to connected peer: peer_id={}, seq_no={}", next_hop, u8v_to_hexstr(&message.seq_no));
             self.events.push_back(NetworkBehaviourAction::SendEvent {
                 peer_id: next_hop.clone(),
                 event: DeliverySendEvent::Deliver(DeliveryMessage::UnicastMessage(message)),
@@ -86,7 +86,7 @@ impl<TSubstream> Delivery<TSubstream> {
             return;
         }
 
-        debug!(target: "stegos_network::delivery", "dialing peer for message delivery: peer_id={}, seq_no={}", next_hop.to_base58(), u8v_to_hexstr(&message.seq_no));
+        debug!(target: "stegos_network::delivery", "dialing peer for message delivery: peer_id={}, seq_no={}", next_hop, u8v_to_hexstr(&message.seq_no));
         if !self.dial_queue.contains_key(next_hop) {
             self.dial_queue.insert(next_hop.clone(), ());
             self.events.push_back(NetworkBehaviourAction::DialPeer {
@@ -116,12 +116,12 @@ where
     }
 
     fn inject_connected(&mut self, id: PeerId, _: ConnectedPoint) {
-        debug!(target: "stegos_network::delivery", "peer connected: peer_id={}", id.to_base58());
+        debug!(target: "stegos_network::delivery", "peer connected: peer_id={}", id);
         self.connected_peers.insert(id.clone());
         if self.dial_queue.contains_key(&id) {
             self.dial_queue.remove(&id);
             if let Some(queue) = self.send_queue.get_mut(&id) {
-                debug!(target: "stegos_network::delivery", "delivering queued messages: peer_id={}, queue_len={}", id.to_base58(), queue.len());
+                debug!(target: "stegos_network::delivery", "delivering queued messages: peer_id={}, queue_len={}", id, queue.len());
                 for m in queue.drain() {
                     self.events.push_back(NetworkBehaviourAction::SendEvent {
                         peer_id: id.clone(),
@@ -142,7 +142,7 @@ where
         match event {
             DeliveryRecvEvent::Message(msg) => match msg {
                 DeliveryMessage::UnicastMessage(unicast) => {
-                    debug!(target: "stegos_network::delivery", "received unicast message from peer: peer_id={}, seq_no={}", propagation_source.to_base58(), u8v_to_hexstr(&unicast.seq_no));
+                    debug!(target: "stegos_network::delivery", "received unicast message from peer: peer_id={}, seq_no={}", propagation_source, u8v_to_hexstr(&unicast.seq_no));
                     self.events.push_back(NetworkBehaviourAction::GenerateEvent(
                         DeliveryEvent::Message(DeliveryMessage::UnicastMessage(unicast)),
                     ))
@@ -169,7 +169,7 @@ where
         loop {
             match self.dial_queue.poll() {
                 Ok(Async::Ready(ref entry)) => {
-                    debug!(target: "stegos_network::delivery", "dialout timeout: peer_id={}", entry.0.clone().to_base58());
+                    debug!(target: "stegos_network::delivery", "dialout timeout: peer_id={}", entry.0.clone());
                     // Drop sending queue for the peer
                     self.send_queue.remove(&entry.0);
                 }

--- a/network/src/delivery/handler.rs
+++ b/network/src/delivery/handler.rs
@@ -32,12 +32,11 @@ use libp2p::core::{
 use log::{debug, trace};
 use smallvec::SmallVec;
 use std::collections::VecDeque;
-use std::{
-    fmt, io,
-    time::{Duration, Instant},
-};
+use std::{fmt, io, time::Instant};
 use tokio::codec::Framed;
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::NETWORK_IDLE_TIMEOUT;
 
 /// Protocol handler that handles communication with the remote for the Delivery protocol.
 ///
@@ -262,7 +261,7 @@ where
         }
 
         if self.substreams.is_empty() {
-            self.keep_alive = KeepAlive::Until(Instant::now() + Duration::from_secs(10));
+            self.keep_alive = KeepAlive::Until(Instant::now() + NETWORK_IDLE_TIMEOUT);
         } else {
             self.keep_alive = KeepAlive::Yes;
         }

--- a/network/src/discovery/behavior.rs
+++ b/network/src/discovery/behavior.rs
@@ -152,7 +152,7 @@ where
     pub fn route(&mut self, to: &pbc::PublicKey, message: Unicast) {
         // Check if we already know node's peer_id
         if let Some(peer_id) = self.known_nodes.get_by_key(to) {
-            debug!(target: "stegos_network::delivery", "found node's peer_id: node_id={}, peer_id={}, seq_no={}", to, peer_id.to_base58(), u8v_to_hexstr(&message.seq_no));
+            debug!(target: "stegos_network::delivery", "found node's peer_id: node_id={}, peer_id={}, seq_no={}", to, peer_id, u8v_to_hexstr(&message.seq_no));
             self.out_events.push_back(DiscoveryOutEvent::Route {
                 next_hop: peer_id.clone(),
                 message,
@@ -164,7 +164,7 @@ where
         if let Some(node_info) = self.kademlia.get_node(to) {
             if let Some(peer_id) = node_info.peer_id() {
                 if self.connected_peers.contains(&peer_id) || node_info.has_addresses() {
-                    debug!(target: "stegos_network::delivery", "node is connected, delivering: node_id={}, peer_id={}, seq_no={}", to, peer_id.to_base58(), u8v_to_hexstr(&message.seq_no));
+                    debug!(target: "stegos_network::delivery", "node is connected, delivering: node_id={}, peer_id={}, seq_no={}", to, peer_id, u8v_to_hexstr(&message.seq_no));
                     self.out_events.push_back(DiscoveryOutEvent::Route {
                         next_hop: peer_id,
                         message,
@@ -243,13 +243,13 @@ where
     }
 
     fn inject_connected(&mut self, peer_id: PeerId, endpoint: ConnectedPoint) {
-        debug!(target: "stegos_network::discovery", "new peer connected: peer_id={}", peer_id.to_base58());
+        debug!(target: "stegos_network::discovery", "new peer connected: peer_id={}", peer_id);
         self.connected_peers.insert(peer_id.clone());
         NetworkBehaviour::inject_connected(&mut self.kademlia, peer_id, endpoint)
     }
 
     fn inject_disconnected(&mut self, peer_id: &PeerId, endpoint: ConnectedPoint) {
-        debug!(target: "stegos_network::discovery", "peer disconnected: peer_id={}", peer_id.to_base58());
+        debug!(target: "stegos_network::discovery", "peer disconnected: peer_id={}", peer_id);
         self.connected_peers.remove(peer_id);
         NetworkBehaviour::inject_disconnected(&mut self.kademlia, peer_id, endpoint)
     }
@@ -310,7 +310,7 @@ where
                             self.known_nodes.insert(node_id.clone(), peer_id.clone());
                             debug!(target: "stegos_network::discovery",
                                 "Discovered peer: node_id={}, peer_id={}, addresses={:?}, connected={:?}",
-                                node_id, peer_id.to_base58(), addresses, ty
+                                node_id, peer_id, addresses, ty
                             );
                             if addresses.len() > 0 {
                                 self.kademlia.set_peer_id(node_id, peer_id.clone());
@@ -370,12 +370,12 @@ where
                             match node_info.peer_id() {
                                 Some(p) => {
                                     if !self.connected_peers.contains(&p) {
-                                        debug!(target: "stegos_network::discovery", "connecting to known closest peer: {}, distance: {}", p.to_base58(), &my_id.distance_with(node));
+                                        debug!(target: "stegos_network::discovery", "connecting to known closest peer: {}, distance: {}", p, &my_id.distance_with(node));
                                         self.out_events.push_back(DiscoveryOutEvent::DialPeer {
                                             peer_id: p.clone(),
                                         });
                                     } else {
-                                        debug!(target: "stegos_network::discovery", "already connected to closest peer: {}, distance: {}", p.to_base58(), &my_id.distance_with(node));
+                                        debug!(target: "stegos_network::discovery", "already connected to closest peer: {}, distance: {}", p, &my_id.distance_with(node));
                                     }
                                 }
                                 None => (),

--- a/network/src/kad/behaviour.rs
+++ b/network/src/kad/behaviour.rs
@@ -780,13 +780,13 @@ where
                             };
                             if let Some(peer_id) = target_peer {
                                 if self.connected_peers.contains(&peer_id) {
-                                    debug!(target: "stegos_network::kad", "sending event to node: node_id={}, peer_id={}", node_id, peer_id.to_base58());
+                                    debug!(target: "stegos_network::kad", "sending event to node: node_id={}, peer_id={}", node_id, peer_id);
                                     return Async::Ready(NetworkBehaviourAction::SendEvent {
                                         peer_id: peer_id.clone(),
                                         event: rpc,
                                     });
                                 } else {
-                                    debug!(target: "stegos_network::kad", "dialing node: node_id={}, peer_id={}", node_id, peer_id.to_base58());
+                                    debug!(target: "stegos_network::kad", "dialing node: node_id={}, peer_id={}", node_id, peer_id);
                                     self.pending_rpcs.push((node_id.clone(), rpc));
                                     return Async::Ready(NetworkBehaviourAction::DialPeer {
                                         peer_id: peer_id.clone(),

--- a/network/src/kad/handler.rs
+++ b/network/src/kad/handler.rs
@@ -31,8 +31,10 @@ use libp2p::core::{
     either::EitherOutput, upgrade, upgrade::Negotiated, InboundUpgrade, OutboundUpgrade,
 };
 use libp2p::multihash::Multihash;
-use std::{error, fmt, io, time::Duration, time::Instant};
+use std::{error, fmt, io, time::Instant};
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::NETWORK_IDLE_TIMEOUT;
 
 /// Protocol handler that handles Kademlia communications with the remote.
 ///
@@ -527,7 +529,7 @@ where
         }
 
         if self.substreams.is_empty() {
-            self.keep_alive = KeepAlive::Until(Instant::now() + Duration::from_secs(10));
+            self.keep_alive = KeepAlive::Until(Instant::now() + NETWORK_IDLE_TIMEOUT);
         } else {
             self.keep_alive = KeepAlive::Yes;
         }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -41,6 +41,7 @@ use stegos_crypto::pbc;
 pub use self::config::*;
 pub use self::kad::KBucketsPeerId;
 pub use self::libp2p_network::Libp2pNetwork;
+pub use self::libp2p_network::NETWORK_IDLE_TIMEOUT;
 pub use self::libp2p_network::NETWORK_READY_TOKEN;
 pub use self::libp2p_network::NETWORK_STATUS_TOPIC;
 pub use self::utils::IntoMultihash;

--- a/network/src/ncp/behavior.rs
+++ b/network/src/ncp/behavior.rs
@@ -120,6 +120,12 @@ impl<TSubstream> Ncp<TSubstream> {
                 .push_back(NcpEvent::SendPeers { peer_id: p.clone() });
         }
     }
+
+    // Terminate connection to peer
+    pub fn terminate(&mut self, peer_id: PeerId) {
+        debug!(target: "stegos_network::ncp", "terminating connection with peer: peer_id={}", peer_id);
+        self.events.push_back(NcpEvent::Terminate { peer_id });
+    }
 }
 
 impl<TSubstream> NetworkBehaviour for Ncp<TSubstream>

--- a/network/src/ncp/handler.rs
+++ b/network/src/ncp/handler.rs
@@ -33,10 +33,12 @@ use libp2p::core::{
 use log::{debug, trace, warn};
 use smallvec::SmallVec;
 use std::collections::VecDeque;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use std::{fmt, io};
 use tokio::codec::Framed;
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::NETWORK_IDLE_TIMEOUT;
 
 /// Protocol handler that handles communication with the remote for the NCP protocol.
 ///
@@ -263,7 +265,7 @@ where
         }
 
         if self.substreams.is_empty() {
-            self.keep_alive = KeepAlive::Until(Instant::now() + Duration::from_secs(10));
+            self.keep_alive = KeepAlive::Until(Instant::now() + NETWORK_IDLE_TIMEOUT);
         } else {
             self.keep_alive = KeepAlive::Yes;
         }


### PR DESCRIPTION
* now filter incoming/outgoing events on `NetworkBehaviour` levels for PubSub
* removed `shutdown` logic from protocols (we can use Terminate NCP method to drop connections
* (refactoring) `PeerId` implements `Display` trait, so no need for explicit `.to_base58()` call