### PR TITLE
Remove ViewChangeProof from MacroBlock

### DIFF
--- a/blockchain/protos/blockchain.proto
+++ b/blockchain/protos/blockchain.proto
@@ -77,7 +77,6 @@ message MacroBlockHeader {
     int64 block_reward = 3;
     stegos.crypto.Hash inputs_range_hash = 4;
     stegos.crypto.Hash outputs_range_hash = 5;
-    ViewChangeProof proof = 6;
 }
 
 message MerkleNode {

--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -207,9 +207,6 @@ pub struct MacroBlockHeader {
 
     /// Merklish root of all range proofs for output.
     pub outputs_range_hash: Hash,
-
-    /// Proof of the happen view_change.
-    pub proof: Option<ViewChangeProof>,
 }
 
 impl Hashable for MacroBlockHeader {
@@ -220,9 +217,6 @@ impl Hashable for MacroBlockHeader {
         self.block_reward.hash(state);
         self.inputs_range_hash.hash(state);
         self.outputs_range_hash.hash(state);
-        if let Some(proof) = &self.proof {
-            proof.hash(state);
-        }
     }
 }
 
@@ -265,7 +259,7 @@ pub struct MacroBlock {
 
 impl MacroBlock {
     pub fn empty(base: BaseBlockHeader, pkey: pbc::PublicKey) -> MacroBlock {
-        Self::new(base, Fr::zero(), 0, &[], &[], None, pkey)
+        Self::new(base, Fr::zero(), 0, &[], &[], pkey)
     }
 
     pub fn new(
@@ -274,7 +268,6 @@ impl MacroBlock {
         block_reward: i64,
         inputs: &[Hash],
         outputs: &[Output],
-        proof: Option<ViewChangeProof>,
         pkey: pbc::PublicKey,
     ) -> MacroBlock {
         // Re-order all inputs to blur transaction boundaries.
@@ -314,7 +307,6 @@ impl MacroBlock {
 
         // Create header
         let header = MacroBlockHeader {
-            proof,
             base,
             gamma,
             block_reward,

--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -86,15 +86,8 @@ pub fn genesis(
         assert_eq!(coins, coins1);
 
         let gamma = -outputs_gamma;
-        let mut block = MacroBlock::new(
-            base,
-            gamma,
-            coins,
-            &[],
-            &outputs,
-            None,
-            keychains[0].network_pkey,
-        );
+        let mut block =
+            MacroBlock::new(base, gamma, coins, &[], &outputs, keychains[0].network_pkey);
 
         let block_hash = Hash::digest(&block);
         let mut signatures: BTreeMap<pbc::PublicKey, pbc::Signature> = BTreeMap::new();

--- a/blockchain/src/protos.rs
+++ b/blockchain/src/protos.rs
@@ -440,9 +440,6 @@ impl ProtoConvert for MacroBlockHeader {
         proto.set_block_reward(self.block_reward);
         proto.set_inputs_range_hash(self.inputs_range_hash.into_proto());
         proto.set_outputs_range_hash(self.outputs_range_hash.into_proto());
-        if let Some(proof) = &self.proof {
-            proto.set_proof(proof.into_proto())
-        }
         proto
     }
 
@@ -453,13 +450,7 @@ impl ProtoConvert for MacroBlockHeader {
         let inputs_range_hash = Hash::from_proto(proto.get_inputs_range_hash())?;
         let outputs_range_hash = Hash::from_proto(proto.get_outputs_range_hash())?;
 
-        let proof = if proto.has_proof() {
-            Some(ViewChangeProof::from_proto(proto.get_proof())?)
-        } else {
-            None
-        };
         Ok(MacroBlockHeader {
-            proof,
             base,
             gamma,
             block_reward,
@@ -803,7 +794,7 @@ mod tests {
         let base = BaseBlockHeader::new(version, previous, height, view_change, timestamp, random);
         roundtrip(&base);
 
-        let block = MacroBlock::new(base, gamma, 0, &inputs1, &outputs1, None, pkeypbc);
+        let block = MacroBlock::new(base, gamma, 0, &inputs1, &outputs1, pkeypbc);
         roundtrip(&block.header);
         roundtrip(&block.body);
         roundtrip(&block);

--- a/blockchain/src/validation.rs
+++ b/blockchain/src/validation.rs
@@ -1305,7 +1305,7 @@ pub mod tests {
             let (output1, gamma1) = Output::new_payment(&pkey2, amount).unwrap();
             let outputs1 = [output1];
             let gamma = gamma0 - gamma1;
-            let block = MacroBlock::new(base, gamma, 0, &inputs1, &outputs1, None, npkey);
+            let block = MacroBlock::new(base, gamma, 0, &inputs1, &outputs1, npkey);
             block.validate_balance(&[output0]).expect("block is valid");
         }
 
@@ -1320,7 +1320,7 @@ pub mod tests {
             let (output1, gamma1) = Output::new_payment(&pkey2, amount - 1).unwrap();
             let outputs1 = [output1];
             let gamma = gamma0 - gamma1;
-            let block = MacroBlock::new(base, gamma, 0, &inputs1, &outputs1, None, npkey);
+            let block = MacroBlock::new(base, gamma, 0, &inputs1, &outputs1, npkey);
             match block.validate_balance(&[output0]) {
                 Err(e) => match e.downcast::<BlockError>().unwrap() {
                     BlockError::InvalidBlockBalance(_height, _hash) => {}
@@ -1353,7 +1353,7 @@ pub mod tests {
         let (output, gamma1) = Output::new_payment(&pkey, amount).unwrap();
         let outputs = [output];
         let gamma = gamma0 - gamma1;
-        let block = MacroBlock::new(base, gamma, 0, &input_hashes, &outputs, None, npkey);
+        let block = MacroBlock::new(base, gamma, 0, &input_hashes, &outputs, npkey);
         block.validate_balance(&inputs).expect("block is valid");
 
         {
@@ -1400,8 +1400,7 @@ pub mod tests {
 
             let base =
                 BaseBlockHeader::new(version, previous, height, view_change, timestamp, random);
-            let block =
-                MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], None, npkey);
+            let block = MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], npkey);
             block.validate_balance(&inputs).expect("block is valid");
         }
 
@@ -1420,8 +1419,7 @@ pub mod tests {
 
             let base =
                 BaseBlockHeader::new(version, previous, height, view_change, timestamp, random);
-            let block =
-                MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], None, npkey);
+            let block = MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], npkey);
             block.validate_balance(&inputs).expect("block is valid");
         }
 
@@ -1442,8 +1440,7 @@ pub mod tests {
 
             let base =
                 BaseBlockHeader::new(version, previous, height, view_change, timestamp, random);
-            let block =
-                MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], None, npkey);
+            let block = MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], npkey);
             match block.validate_balance(&inputs) {
                 Err(e) => match e.downcast::<BlockError>().unwrap() {
                     BlockError::InvalidBlockBalance(_height, _hash) => {}
@@ -1471,8 +1468,7 @@ pub mod tests {
 
             let base =
                 BaseBlockHeader::new(version, previous, height, view_change, timestamp, random);
-            let block =
-                MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], None, npkey);
+            let block = MacroBlock::new(base, gamma, 0, &input_hashes[..], &outputs[..], npkey);
             match block.validate_balance(&inputs) {
                 Err(e) => match e.downcast::<OutputError>().unwrap() {
                     OutputError::InvalidStake(_output_hash) => {}
@@ -1504,15 +1500,7 @@ pub mod tests {
         let (output, output_gamma) = Output::new_payment(&pkey, output_amount).unwrap();
         let outputs = [output];
         let gamma = input_gamma - output_gamma;
-        let block = MacroBlock::new(
-            base,
-            gamma,
-            block_reward,
-            &input_hashes,
-            &outputs,
-            None,
-            npkey,
-        );
+        let block = MacroBlock::new(base, gamma, block_reward, &input_hashes, &outputs, npkey);
         block.validate_balance(&inputs).expect("block is valid");
     }
 


### PR DESCRIPTION
MacroBlock is signed by consensus. No ViewChangeProof is needed.
It wasn't used, just an artificat of MicroBlock->MacroBlock refactoring.

Needed for new MacroBlocks.