### PR TITLE
Refactor macro block validation

### DIFF
--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -330,7 +330,7 @@ impl Blockchain {
             }
             Block::MacroBlock(block) => {
                 if cfg!(debug_assertions) {
-                    self.validate_macro_block(&block, timestamp, false)?
+                    self.validate_macro_block(&block, timestamp)?
                 }
                 let _ = self.register_macro_block(block, timestamp);
             }
@@ -670,7 +670,7 @@ impl Blockchain {
         //
         // Validate the macro block.
         //
-        self.validate_macro_block(&block, timestamp, false)?;
+        self.validate_macro_block(&block, timestamp)?;
 
         //
         // Write the macro block to the disk.

--- a/blockchain/src/transaction.rs
+++ b/blockchain/src/transaction.rs
@@ -523,6 +523,16 @@ pub enum Transaction {
 
 impl Transaction {
     #[inline]
+    pub fn gamma(&self) -> Fr {
+        match self {
+            Transaction::CoinbaseTransaction(tx) => tx.gamma.clone(),
+            Transaction::PaymentTransaction(tx) => tx.gamma.clone(),
+            Transaction::RestakeTransaction(_tx) => Fr::zero(),
+            Transaction::SlashingTransaction(_tx) => Fr::zero(),
+        }
+    }
+
+    #[inline]
     pub fn fee(&self) -> i64 {
         match self {
             Transaction::CoinbaseTransaction(_tx) => 0,

--- a/blockchain/src/validation.rs
+++ b/blockchain/src/validation.rs
@@ -21,17 +21,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::block::{MacroBlock, MicroBlock, VERSION};
+use crate::block::{BaseBlockHeader, MacroBlock, MicroBlock, VERSION};
 use crate::blockchain::{Balance, Blockchain, ChainInfo};
 use crate::election::mix;
-use crate::error::TransactionError;
-use crate::error::{BlockError, BlockchainError};
+use crate::error::{BlockError, BlockchainError, SlashingError, TransactionError};
 use crate::multisignature::check_multi_signature;
-use crate::output::Output;
+use crate::output::{Output, PublicPaymentOutput};
+use crate::slashing::confiscate_tx;
 use crate::transaction::{
-    CoinbaseTransaction, PaymentTransaction, RestakeTransaction, Transaction,
+    CoinbaseTransaction, PaymentTransaction, RestakeTransaction, SlashingTransaction, Transaction,
 };
-use crate::{confiscate_tx, PublicPaymentOutput, SlashingError, SlashingTransaction};
 use log::*;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -492,6 +491,63 @@ impl Blockchain {
     }
 
     ///
+    /// Validate base block header.
+    ///
+    pub fn validate_base_header(
+        &self,
+        block_hash: &Hash,
+        base: &BaseBlockHeader,
+    ) -> Result<(), BlockchainError> {
+        let height = base.height;
+
+        // Check block version.
+        if base.version != VERSION {
+            return Err(BlockError::InvalidBlockVersion(
+                height,
+                *block_hash,
+                base.version,
+                VERSION,
+            )
+            .into());
+        }
+
+        // Check height.
+        if height != self.height() {
+            return Err(BlockError::OutOfOrderBlock(*block_hash, height, self.height()).into());
+        }
+
+        // Check new hash.
+        if self.contains_block(&block_hash) {
+            return Err(BlockError::BlockHashCollision(height, *block_hash).into());
+        }
+
+        // Check previous hash (skip for genesis).
+        if height > 0 {
+            let previous_hash = self.last_block_hash();
+            if previous_hash != base.previous {
+                return Err(BlockError::InvalidPreviousHash(
+                    height,
+                    *block_hash,
+                    base.previous,
+                    previous_hash,
+                )
+                .into());
+            }
+        }
+
+        // Check random (skip for genesis).
+        if height > 0 {
+            let leader = self.select_leader(base.view_change);
+            let seed = mix(self.last_random(), base.view_change);
+            if !pbc::validate_VRF_source(&base.random, &leader, &seed) {
+                return Err(BlockError::IncorrectRandom(height, *block_hash).into());
+            }
+        }
+
+        Ok(())
+    }
+
+    ///
     /// A helper for validate_micro_block().
     ///
     fn validate_micro_block_tx(
@@ -571,40 +627,8 @@ impl Blockchain {
             height, &block_hash
         );
 
-        // Check block version.
-        if block.base.version != VERSION {
-            return Err(BlockError::InvalidBlockVersion(
-                height,
-                block_hash,
-                block.base.version,
-                VERSION,
-            )
-            .into());
-        }
-
-        // Check height.
-        if height != self.height() {
-            return Err(BlockError::OutOfOrderBlock(block_hash, height, self.height()).into());
-        }
-
-        // Check previous hash.
-        if self.height() > 0 {
-            let previous_hash = self.last_block_hash();
-            if previous_hash != block.base.previous {
-                return Err(BlockError::InvalidPreviousHash(
-                    height,
-                    block_hash,
-                    block.base.previous,
-                    previous_hash,
-                )
-                .into());
-            }
-        }
-
-        // Check new hash.
-        if self.contains_block(&block_hash) {
-            return Err(BlockError::BlockHashCollision(height, block_hash).into());
-        }
+        // Validate base header.
+        self.validate_base_header(&block_hash, &block.base)?;
 
         // Check signature (exclude epoch == 0 for genesis).
         if self.epoch() > 0 {
@@ -652,11 +676,6 @@ impl Blockchain {
 
             if let Err(_e) = pbc::check_hash(&block_hash, &block.sig, &leader) {
                 return Err(BlockError::InvalidLeaderSignature(height, block_hash).into());
-            }
-
-            let seed = mix(self.last_random(), block.base.view_change);
-            if !pbc::validate_VRF_source(&block.base.random, &leader, &seed) {
-                return Err(BlockError::IncorrectRandom(height, block_hash).into());
             }
         }
 
@@ -843,7 +862,6 @@ impl Blockchain {
         &self,
         block: &MacroBlock,
         timestamp: SystemTime,
-        is_proposal: bool,
     ) -> Result<(), BlockchainError> {
         let height = block.header.base.height;
         let block_hash = Hash::digest(&block);
@@ -852,64 +870,23 @@ impl Blockchain {
             height, &block_hash
         );
 
-        // Check block version.
-        if block.header.base.version != VERSION {
-            return Err(BlockError::InvalidBlockVersion(
-                height,
-                block_hash,
-                block.header.base.version,
-                VERSION,
-            )
-            .into());
-        }
+        // Validate base header.
+        self.validate_base_header(&block_hash, &block.header.base)?;
 
-        // Check height.
-        if height != self.height() {
-            return Err(BlockError::OutOfOrderBlock(block_hash, height, self.height()).into());
-        }
-
-        // Check previous hash.
-        if self.height() > 0 {
-            let previous_hash = self.last_block_hash();
-            if previous_hash != block.header.base.previous {
-                return Err(BlockError::InvalidPreviousHash(
-                    height,
-                    block_hash,
-                    block.header.base.previous,
-                    previous_hash,
-                )
-                .into());
-            }
-        }
-
-        // Check new hash.
-        if self.contains_block(&block_hash) {
-            return Err(BlockError::BlockHashCollision(height, block_hash).into());
-        }
-
-        // skip leader selection and signature checking for genesis block.
-        if self.epoch() > 0 {
-            // Skip view change check, just check supermajority.
-            let leader = self.select_leader(block.header.base.view_change);
-
-            let seed = mix(self.last_random(), block.header.base.view_change);
-            if !pbc::validate_VRF_source(&block.header.base.random, &leader, &seed) {
-                return Err(BlockError::IncorrectRandom(height, block_hash).into());
-            }
-
+        // Validate multi-signature (skip for genesis).
+        if height > 0 {
             // Validate signature.
-            if !is_proposal {
-                check_multi_signature(
-                    &block_hash,
-                    &block.body.multisig,
-                    &block.body.multisigmap,
-                    self.validators(),
-                    self.total_slots(),
-                )
-                .map_err(|e| BlockError::InvalidBlockSignature(e, height, block_hash))?;
-            }
+            check_multi_signature(
+                &block_hash,
+                &block.body.multisig,
+                &block.body.multisigmap,
+                self.validators(),
+                self.total_slots(),
+            )
+            .map_err(|e| BlockError::InvalidBlockSignature(e, height, block_hash))?;
         }
 
+        // Validate inputs and outputs.
         self.validate_macro_block_payments(block, timestamp)?;
 
         debug!(

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -56,6 +56,11 @@ pub enum NodeBlockError {
     )]
     InvalidBlockReward(u64, Hash, i64, i64),
     #[fail(
+        display = "Unexpected block fee: height={}, block={}, got={}, expected={}",
+        _0, _1, _2, _3
+    )]
+    InvalidBlockFee(u64, Hash, i64, i64),
+    #[fail(
         display = "Invalid block proposal: height={}, expected={}, got={}",
         _0, _1, _2
     )]

--- a/node/src/proposal.rs
+++ b/node/src/proposal.rs
@@ -87,11 +87,6 @@ pub fn create_macro_block_proposal(
             .expect("Invalid block");
     let block_hash = Hash::digest(&block);
 
-    // Validate the block via chain (just double-checking here).
-    chain
-        .validate_macro_block(&block, timestamp, true)
-        .expect("proposed macro block is valid");
-
     // Create block proposal.
     let block_proposal = MacroBlockProposal {
         base: block.header.base.clone(),
@@ -158,6 +153,11 @@ pub fn validate_proposed_macro_block(
     }
 
     //
+    // Validate base header.
+    //
+    chain.validate_base_header(block_hash, &block_proposal.base)?;
+
+    //
     // Validate transactions.
     //
 
@@ -212,9 +212,6 @@ pub fn validate_proposed_macro_block(
         )
         .into());
     }
-
-    // Validate this block through blockchain.
-    chain.validate_macro_block(&block, block.header.base.timestamp, true)?;
 
     debug!("Macro block proposal is valid: block={:?}", block_hash);
     Ok(block)

--- a/node/src/test/microblocks.rs
+++ b/node/src/test/microblocks.rs
@@ -25,6 +25,7 @@ use super::*;
 use crate::*;
 use std::collections::HashSet;
 use stegos_blockchain::Block;
+use stegos_consensus::MacroBlockProposal;
 use stegos_consensus::{optimistic::SealedViewChangeProof, ConsensusMessage, ConsensusMessageBody};
 
 // CASE partition:


### PR DESCRIPTION
Remove double validation of MacroBlockProposal
    
Validators try to re-create proposed MacroBlock and check that created MacroBlock has the same hash as proposed. Don't spent time validating inputs and outputs of re-created MacroBlock on blockchains because they already have been validated before.
    
Needed for new MacroBlocks.

- Inline validate_macro_block_payments() into validate_macro_block()
