### PR TITLE
Refactor and tune configuration

### DIFF
--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -148,7 +148,7 @@ pub struct Blockchain {
     //
     // Configuration.
     //
-    cfg: BlockchainConfig,
+    cfg: ChainConfig,
 
     //
     // Storage.
@@ -200,7 +200,7 @@ impl Blockchain {
     //----------------------------------------------------------------------------------------------
 
     pub fn new(
-        cfg: BlockchainConfig,
+        cfg: ChainConfig,
         storage_cfg: StorageConfig,
         genesis: MacroBlock,
         timestamp: SystemTime,
@@ -210,7 +210,7 @@ impl Blockchain {
     }
 
     pub fn testing(
-        cfg: BlockchainConfig,
+        cfg: ChainConfig,
         genesis: MacroBlock,
         timestamp: SystemTime,
     ) -> Result<Blockchain, Error> {
@@ -219,7 +219,7 @@ impl Blockchain {
     }
 
     fn with_db(
-        cfg: BlockchainConfig,
+        cfg: ChainConfig,
         database: ListDb,
         genesis: MacroBlock,
         timestamp: SystemTime,
@@ -690,7 +690,7 @@ impl Blockchain {
     }
 
     /// Returns current blockchain config.
-    pub fn cfg(&self) -> &BlockchainConfig {
+    pub fn cfg(&self) -> &ChainConfig {
         &self.cfg
     }
 
@@ -1637,7 +1637,7 @@ pub mod tests {
 
         let keychains = [KeyChain::new_mem()];
         let timestamp = SystemTime::now();
-        let cfg: BlockchainConfig = Default::default();
+        let cfg: ChainConfig = Default::default();
         let block1 = genesis(
             &keychains,
             cfg.min_stake_amount,
@@ -1703,7 +1703,7 @@ pub mod tests {
 
         let keychains = [KeyChain::new_mem()];
         let mut timestamp = SystemTime::now();
-        let mut cfg: BlockchainConfig = Default::default();
+        let mut cfg: ChainConfig = Default::default();
         cfg.stake_epochs = 1;
         cfg.micro_blocks_in_epoch = 2;
         let genesis = genesis(
@@ -1816,7 +1816,7 @@ pub mod tests {
 
         let keychains = [KeyChain::new_mem()];
         let mut timestamp = SystemTime::now();
-        let cfg: BlockchainConfig = Default::default();
+        let cfg: ChainConfig = Default::default();
         let genesis = genesis(
             &keychains,
             cfg.min_stake_amount,
@@ -1940,7 +1940,7 @@ pub mod tests {
         let keychains = [KeyChain::new_mem()];
 
         let mut timestamp = SystemTime::now();
-        let mut cfg: BlockchainConfig = Default::default();
+        let mut cfg: ChainConfig = Default::default();
         cfg.micro_blocks_in_epoch = 100500;
         let stake = cfg.min_stake_amount;
         let blocks = genesis(&keychains, stake, 10 * cfg.min_stake_amount, timestamp);

--- a/blockchain/src/config.rs
+++ b/blockchain/src/config.rs
@@ -24,8 +24,9 @@
 use serde_derive::{Deserialize, Serialize};
 
 /// Blockchain configuration.
-#[derive(Debug, Clone)]
-pub struct BlockchainConfig {
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct ChainConfig {
     /// Maximal number of slots for election.
     pub max_slot_count: i64,
     /// Minimal stake amount.
@@ -42,16 +43,17 @@ pub struct BlockchainConfig {
     pub service_award_per_epoch: i64,
 }
 
-impl Default for BlockchainConfig {
+impl Default for ChainConfig {
     fn default() -> Self {
-        BlockchainConfig {
+        let micro_blocks_in_epoch: u32 = 5;
+        ChainConfig {
             max_slot_count: 1000,
             min_stake_amount: 1_000_000_000, // 1000 STG
-            micro_blocks_in_epoch: 5,
+            micro_blocks_in_epoch,
             stake_epochs: 2,
             awards_difficulty: 3,
-            block_reward: 40_000_000,                // 40 STG
-            service_award_per_epoch: 20_000_000 * 5, // 20 STG for 5 blocks
+            block_reward: 40_000_000, // 40 STG
+            service_award_per_epoch: 20_000_000i64 * (micro_blocks_in_epoch as i64 + 1), // 20 STG per block
         }
     }
 }

--- a/blockchain/src/config.rs
+++ b/blockchain/src/config.rs
@@ -45,12 +45,12 @@ pub struct ChainConfig {
 
 impl Default for ChainConfig {
     fn default() -> Self {
-        let micro_blocks_in_epoch: u32 = 5;
+        let micro_blocks_in_epoch: u32 = 60;
         ChainConfig {
             max_slot_count: 1000,
             min_stake_amount: 1_000_000_000, // 1000 STG
             micro_blocks_in_epoch,
-            stake_epochs: 2,
+            stake_epochs: 6,
             awards_difficulty: 3,
             block_reward: 40_000_000, // 40 STG
             service_award_per_epoch: 20_000_000i64 * (micro_blocks_in_epoch as i64 + 1), // 20 STG per block

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -23,22 +23,17 @@
 
 use serde_derive::{Deserialize, Serialize};
 use std::time::Duration;
-use stegos_blockchain::BlockchainConfig;
 
-/// Chain configuration.
+/// Node configuration.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct ChainConfig {
+pub struct NodeConfig {
     /// How long wait for transactions before starting to create a new block.
     pub tx_wait_timeout: Duration,
     /// How long wait for micro blocks.
     pub micro_block_timeout: Duration,
     /// How long wait for the keu blocks.
     pub macro_block_timeout: Duration,
-    /// Time to lock stakes.
-    pub stake_epochs: u64,
-    /// The number of blocks per epoch.
-    pub micro_blocks_in_epoch: u32,
     /// The maximal number of inputs + outputs in a transaction.
     pub max_utxo_in_tx: usize,
     /// The maximal number of inputs + outputs in a micro block.
@@ -46,64 +41,25 @@ pub struct ChainConfig {
     /// The maximal number of inputs + outputs in mempool.
     pub max_utxo_in_mempool: usize,
     /// Loader will send maximum N epoch at time.
-    pub chain_loader_speed_in_epoch: u64,
-    /// Fixed reward per block.
-    pub block_reward: i64,
+    pub loader_speed_in_epoch: u64,
     /// Fixed fee for payment transactions.
     pub payment_fee: i64,
     /// Fixed fee for the stake transactions.
     pub stake_fee: i64,
-    /// Maximal number of slots for election.
-    pub max_slot_count: i64,
-    /// Awards difficulty.
-    pub awards_difficulty: usize,
-    /// Minimal stake amount.
-    pub min_stake_amount: i64,
-    /// Minimal interval between loader runs.
-    pub loader_timeout: Duration,
 }
 
-impl Default for ChainConfig {
+impl Default for NodeConfig {
     fn default() -> Self {
-        let tx_wait_timeout = Duration::from_secs(10);
-        let micro_block_timeout = Duration::from_secs(30);
-        let macro_block_timeout = Duration::from_secs(30);
-
-        let blockchain_default: BlockchainConfig = Default::default();
-
-        ChainConfig {
-            tx_wait_timeout,
-            micro_block_timeout,
-            macro_block_timeout,
-            stake_epochs: blockchain_default.stake_epochs,
-            micro_blocks_in_epoch: blockchain_default.micro_blocks_in_epoch,
+        NodeConfig {
+            tx_wait_timeout: Duration::from_secs(10),
+            micro_block_timeout: Duration::from_secs(30),
+            macro_block_timeout: Duration::from_secs(30),
             max_utxo_in_tx: 10,
             max_utxo_in_block: 1000,
             max_utxo_in_mempool: 10000,
-            chain_loader_speed_in_epoch: 100,
-            block_reward: 40_000_000, // 40 STG
-            payment_fee: 1_000,       // 0.001 STG
-            stake_fee: 0,             // free
-            max_slot_count: blockchain_default.max_slot_count,
-            min_stake_amount: blockchain_default.min_stake_amount,
-            loader_timeout: Duration::from_millis(500),
-            awards_difficulty: 3,
-        }
-    }
-}
-
-impl Into<BlockchainConfig> for ChainConfig {
-    fn into(self) -> BlockchainConfig {
-        let service_award_per_epoch =
-            self.block_reward / 2 * (self.micro_blocks_in_epoch + 1) as i64;
-        BlockchainConfig {
-            awards_difficulty: self.awards_difficulty,
-            max_slot_count: self.max_slot_count,
-            min_stake_amount: self.min_stake_amount,
-            stake_epochs: self.stake_epochs,
-            micro_blocks_in_epoch: self.micro_blocks_in_epoch,
-            block_reward: self.block_reward,
-            service_award_per_epoch,
+            loader_speed_in_epoch: 100,
+            payment_fee: 1_000, // 0.001 STG
+            stake_fee: 0,       // free
         }
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -51,12 +51,12 @@ pub struct NodeConfig {
 impl Default for NodeConfig {
     fn default() -> Self {
         NodeConfig {
-            tx_wait_timeout: Duration::from_secs(10),
+            tx_wait_timeout: Duration::from_secs(5),
             micro_block_timeout: Duration::from_secs(30),
             macro_block_timeout: Duration::from_secs(30),
-            max_utxo_in_tx: 10,
-            max_utxo_in_block: 1000,
-            max_utxo_in_mempool: 10000,
+            max_utxo_in_tx: 500,
+            max_utxo_in_block: 2000,
+            max_utxo_in_mempool: 20000,
             loader_speed_in_epoch: 100,
             payment_fee: 1_000, // 0.001 STG
             stake_fee: 0,       // free

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -31,7 +31,7 @@ pub mod protos;
 #[cfg(test)]
 mod test;
 mod validation;
-pub use crate::config::ChainConfig;
+pub use crate::config::NodeConfig;
 use crate::error::*;
 use crate::loader::ChainLoaderMessage;
 use crate::mempool::Mempool;
@@ -242,7 +242,7 @@ use Validation::*;
 
 pub struct NodeService {
     /// Config.
-    cfg: ChainConfig,
+    cfg: NodeConfig,
     /// Blockchain.
     chain: Blockchain,
     /// Key Chain.
@@ -278,7 +278,7 @@ pub struct NodeService {
 impl NodeService {
     /// Constructor.
     pub fn new(
-        cfg: ChainConfig,
+        cfg: NodeConfig,
         chain: Blockchain,
         keys: KeyChain,
         network: Network,
@@ -1436,7 +1436,7 @@ impl NodeService {
             view_change,
             view_change_proof,
             self.chain.last_random(),
-            self.cfg.block_reward,
+            self.chain.cfg().block_reward,
             &self.keys,
             self.cfg.max_utxo_in_block,
         );

--- a/node/src/loader.rs
+++ b/node/src/loader.rs
@@ -140,7 +140,7 @@ impl NodeService {
         let blocks = self.chain.blocks_range(
             epoch,
             offset,
-            (self.chain.cfg().micro_blocks_in_epoch as u64) * self.cfg.chain_loader_speed_in_epoch,
+            (self.chain.cfg().micro_blocks_in_epoch as u64) * self.cfg.loader_speed_in_epoch,
         );
         info!("Feeding blocks: to={}, num_blocks={}", pkey, blocks.len());
         let msg = ChainLoaderMessage::Response(ResponseBlocks::new(blocks));

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -219,7 +219,7 @@ impl Mempool {
             let mut gamma = Fr::zero();
 
             // Create outputs for fee and rewards.
-            for (amount, comment) in vec![(block_fee, "fee"), (block_reward, "reward")] {
+            for (amount, comment) in vec![(block_reward + block_fee, "reward+fee")] {
                 if amount <= 0 {
                     continue;
                 }
@@ -424,22 +424,12 @@ mod test {
 
         assert_eq!(block.transactions.len(), 3);
         if let Transaction::CoinbaseTransaction(tx) = &block.transactions[0] {
-            // Fee.
+            // Reward + Fee.
             if let Some(Output::PaymentOutput(o)) = tx.txouts.get(0) {
                 let PaymentPayload { amount, .. } = o
                     .decrypt_payload(&keys.wallet_skey)
                     .expect("keys are valid");
-                assert_eq!(amount, 6);
-            } else {
-                unreachable!();
-            }
-
-            // Reward.
-            if let Some(Output::PaymentOutput(o)) = tx.txouts.get(1) {
-                let PaymentPayload { amount, .. } = o
-                    .decrypt_payload(&keys.wallet_skey)
-                    .expect("keys are valid");
-                assert_eq!(amount, reward);
+                assert_eq!(amount, reward + 6);
             } else {
                 unreachable!();
             }

--- a/node/src/proposal.rs
+++ b/node/src/proposal.rs
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::config::ChainConfig;
+use crate::config::NodeConfig;
 use crate::error::*;
 use failure::Error;
 use log::*;
@@ -75,7 +75,7 @@ pub fn create_macro_block_proposal(
 /// Validate proposed macro block.
 ///
 pub fn validate_proposed_macro_block(
-    cfg: &ChainConfig,
+    cfg: &NodeConfig,
     chain: &Blockchain,
     view_change: u32,
     block_hash: &Hash,
@@ -142,12 +142,12 @@ pub fn validate_proposed_macro_block(
     // Coinbase.
     if let Some(Transaction::CoinbaseTransaction(tx)) = transactions.get(0) {
         tx.validate()?;
-        if tx.block_reward != cfg.block_reward {
+        if tx.block_reward != chain.cfg().block_reward {
             return Err(BlockError::InvalidMacroBlockReward(
                 epoch,
                 block_hash.clone(),
                 tx.block_reward,
-                cfg.block_reward,
+                chain.cfg().block_reward,
             )
             .into());
         }

--- a/node/src/test/consensus.rs
+++ b/node/src/test/consensus.rs
@@ -42,7 +42,7 @@ fn smoke_test() {
     Sandbox::start(config, |mut s| {
         // Create one micro block.
         s.poll();
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.skip_micro_block();
 
         let topic = crate::CONSENSUS_TOPIC;
@@ -164,7 +164,7 @@ fn autocomit() {
     Sandbox::start(config, |mut s| {
         // Create one micro block.
         s.poll();
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.skip_micro_block();
 
         let topic = crate::CONSENSUS_TOPIC;
@@ -239,7 +239,7 @@ fn autocomit() {
         );
 
         // Wait for TX_WAIT_TIMEOUT.
-        s.wait(s.cfg().macro_block_timeout);
+        s.wait(s.config.node.macro_block_timeout);
         let last_node = s.iter_except(&skip_leader).next().unwrap();
         last_node.poll();
 
@@ -271,7 +271,7 @@ fn round() {
     Sandbox::start(config, |mut s| {
         // Create one micro block.
         s.poll();
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.skip_micro_block();
 
         let topic = crate::CONSENSUS_TOPIC;
@@ -284,7 +284,7 @@ fn round() {
 
         let epoch = s.nodes[0].node_service.chain.epoch();
         let round = s.nodes[0].node_service.chain.view_change() + 1;
-        s.wait(s.cfg().macro_block_timeout);
+        s.wait(s.config.node.macro_block_timeout);
 
         info!("====== Waiting for keyblock timeout. =====");
         s.poll();
@@ -373,7 +373,7 @@ fn multiple_rounds() {
     Sandbox::start(config, |mut s| {
         // Create one micro block.
         s.poll();
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.skip_micro_block();
 
         let topic = crate::CONSENSUS_TOPIC;
@@ -384,7 +384,7 @@ fn multiple_rounds() {
         let _proposal: ConsensusMessage = leader_node.network_service.get_broadcast(topic);
         let _prevote: ConsensusMessage = leader_node.network_service.get_broadcast(topic);
 
-        s.wait(s.cfg().macro_block_timeout - Duration::from_millis(1));
+        s.wait(s.config.node.macro_block_timeout - Duration::from_millis(1));
 
         s.poll();
         for i in 1..s.num_nodes() {
@@ -404,7 +404,7 @@ fn multiple_rounds() {
         let _proposal: ConsensusMessage = leader_node.network_service.get_broadcast(topic);
         let _prevote: ConsensusMessage = leader_node.network_service.get_broadcast(topic);
 
-        s.wait(s.cfg().macro_block_timeout * 2 - Duration::from_millis(1));
+        s.wait(s.config.node.macro_block_timeout * 2 - Duration::from_millis(1));
 
         s.poll();
         for i in 1..s.num_nodes() {
@@ -441,7 +441,7 @@ fn lock() {
     Sandbox::start(config, |mut s| {
         // Create one micro block.
         s.poll();
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.skip_micro_block();
 
         let topic = crate::CONSENSUS_TOPIC;
@@ -476,7 +476,8 @@ fn lock() {
             round += 1;
             // wait for current round end
             s.wait(
-                s.cfg().macro_block_timeout * (round - s.nodes[0].node_service.chain.view_change()),
+                s.config.node.macro_block_timeout
+                    * (round - s.nodes[0].node_service.chain.view_change()),
             );
         }
         assert!(ready);
@@ -519,7 +520,8 @@ fn lock() {
             let _precommit: ConsensusMessage = s.nodes[i].network_service.get_broadcast(topic);
         }
         s.wait(
-            s.cfg().macro_block_timeout * (round - s.nodes[0].node_service.chain.view_change() + 1),
+            s.config.node.macro_block_timeout
+                * (round - s.nodes[0].node_service.chain.view_change() + 1),
         );
 
         info!("====== Waiting for keyblock timeout. =====");

--- a/node/src/test/microblocks.rs
+++ b/node/src/test/microblocks.rs
@@ -51,10 +51,10 @@ fn dead_leader() {
 
         let leader_pk = s.nodes[0].node_service.chain.leader();
         // let leader shoot his block
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.poll();
         // emulate timeout on other nodes, and wait for request
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         info!("PARTITION BEGIN");
         s.poll();
         let mut r = s.split(&[leader_pk]);
@@ -126,7 +126,7 @@ fn silent_view_change() {
     Sandbox::start(config, |mut s| {
         s.poll();
 
-        precondition_2_different_leaderers(&mut s);
+        precondition_2_different_leaders(&mut s);
 
         let epoch = s.nodes[0].node_service.chain.epoch();
         let offset = s.nodes[0].node_service.chain.offset();
@@ -134,9 +134,9 @@ fn silent_view_change() {
         let leader_pk = s.leader();
         let new_leader = s.next_view_change_leader();
 
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.poll();
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         info!("======= PARTITION BEGIN =======");
         s.poll();
         // emulate dead leader for other nodes
@@ -228,7 +228,7 @@ fn double_view_change() {
 
         let mut blocks = 0;
 
-        for _ in 0..=s.cfg().micro_blocks_in_epoch {
+        for _ in 0..=s.config.chain.micro_blocks_in_epoch {
             let view_change = s.first_mut().node_service.chain.view_change();
             let leader1 = s.first_mut().node_service.chain.leader();
             let leader2 = s
@@ -246,18 +246,18 @@ fn double_view_change() {
                 break;
             }
 
-            s.wait(s.cfg().tx_wait_timeout);
+            s.wait(s.config.node.tx_wait_timeout);
             s.skip_micro_block();
             blocks += 1;
         }
-        assert!(blocks < s.cfg().micro_blocks_in_epoch as u32 - 2);
+        assert!(blocks < s.config.chain.micro_blocks_in_epoch as u32 - 2);
         let starting_view_changes = 0;
         let leader_pk = s.nodes[0].node_service.chain.leader();
         s.for_each(|node| assert_eq!(starting_view_changes, node.chain.view_change()));
 
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.poll();
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         info!("======= PARTITION BEGIN =======");
         s.poll();
         // emulate dead leader for other nodes
@@ -311,7 +311,7 @@ fn double_view_change() {
                 );
             }
 
-            s.wait(s.cfg().micro_block_timeout);
+            s.wait(s.config.node.micro_block_timeout);
             let mut r = s.split(&[leader_pk, new_leader]);
             r.parts.1.poll();
 
@@ -368,14 +368,14 @@ fn resolve_fork_for_view_change() {
     Sandbox::start(config, |mut s| {
         s.poll();
 
-        precondition_2_different_leaderers(&mut s);
+        precondition_2_different_leaders(&mut s);
 
         let starting_view_changes = s.nodes[0].node_service.chain.view_change();
         let starting_offset = s.nodes[0].node_service.chain.offset();
 
         let leader_pk = s.nodes[0].node_service.chain.leader();
 
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
 
         s.poll();
         s.filter_unicast(&[crate::loader::CHAIN_LOADER_TOPIC]);
@@ -386,7 +386,7 @@ fn resolve_fork_for_view_change() {
             .network_service
             .get_broadcast(crate::SEALED_BLOCK_TOPIC);
 
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         s.poll();
         // emulate dead leader for other nodes
 
@@ -478,14 +478,14 @@ fn resolve_fork_without_block() {
     Sandbox::start(config, |mut s| {
         s.poll();
 
-        precondition_2_different_leaderers(&mut s);
+        precondition_2_different_leaders(&mut s);
 
         let starting_view_changes = s.nodes[0].node_service.chain.view_change();
         let starting_offset = s.nodes[0].node_service.chain.offset();
 
         let leader_pk = s.nodes[0].node_service.chain.leader();
 
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
 
         s.poll();
         s.filter_unicast(&[crate::loader::CHAIN_LOADER_TOPIC]);
@@ -496,7 +496,7 @@ fn resolve_fork_without_block() {
             .network_service
             .get_broadcast(crate::SEALED_BLOCK_TOPIC);
 
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         s.poll();
         // emulate dead leader for other nodes
 
@@ -606,14 +606,14 @@ fn issue_896_resolve_fork() {
     Sandbox::start(config, |mut s| {
         s.poll();
 
-        precondition_2_different_leaderers(&mut s);
+        precondition_2_different_leaders(&mut s);
 
         let starting_view_changes = s.nodes[0].node_service.chain.view_change();
         let starting_offset = s.nodes[0].node_service.chain.offset();
 
         let leader_pk = s.nodes[0].node_service.chain.leader();
 
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
 
         s.poll();
         s.filter_unicast(&[crate::loader::CHAIN_LOADER_TOPIC]);
@@ -624,7 +624,7 @@ fn issue_896_resolve_fork() {
             .network_service
             .get_broadcast(crate::SEALED_BLOCK_TOPIC);
 
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         s.poll();
         // emulate dead leader for other nodes
 
@@ -678,7 +678,7 @@ fn issue_896_resolve_fork() {
             .get_unicast(crate::VIEW_CHANGE_DIRECT, &leader_pk);
 
         // wait half of view_change timer
-        r.wait(r.config.micro_block_timeout / 2);
+        r.wait(r.config.node.micro_block_timeout / 2);
 
         let first_leader = r.parts.0.first_mut();
         assert_eq!(leader_pk, first_leader.node_service.keys.network_pkey);
@@ -706,11 +706,11 @@ fn issue_896_resolve_fork() {
         assert_eq!(first_leader.node_service.chain.offset(), starting_offset);
 
         // wait for panic.
-        r.wait(r.config.micro_block_timeout - r.config.micro_block_timeout / 2);
+        r.wait(r.config.node.micro_block_timeout - r.config.node.micro_block_timeout / 2);
         r.parts.0.poll();
 
         // if panic was fixed, check for message.
-        r.wait(r.config.micro_block_timeout / 2);
+        r.wait(r.config.node.micro_block_timeout / 2);
         r.parts.0.poll();
 
         let first_leader = r.parts.0.first_mut();
@@ -740,7 +740,7 @@ fn out_of_order_keyblock_proposal() {
     Sandbox::start(config, |mut s| {
         s.poll();
 
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
 
         let epoch = s.nodes[0].node_service.chain.epoch();
         let round = s.nodes[0].node_service.chain.view_change();
@@ -887,7 +887,7 @@ fn slash_cheater() {
         s.poll();
 
         // next leader should be from different partition.
-        for _ in 0..(s.cfg().micro_blocks_in_epoch - 1) {
+        for _ in 0..(s.config.chain.micro_blocks_in_epoch - 1) {
             let first_leader_pk = s.nodes[0].node_service.chain.leader();
             let new_leader_pk = s.next_leader().unwrap();
             info!(
@@ -899,13 +899,13 @@ fn slash_cheater() {
             }
 
             info!("Skipping microlock.");
-            s.wait(s.cfg().tx_wait_timeout);
+            s.wait(s.config.node.tx_wait_timeout);
             s.skip_micro_block();
         }
         let leader_pk = s.nodes[0].node_service.chain.leader();
 
         info!("CREATE BLOCK. LEADER = {}", leader_pk);
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
 
         s.poll();
         s.filter_unicast(&[crate::loader::CHAIN_LOADER_TOPIC]);
@@ -951,7 +951,7 @@ fn slash_cheater() {
             .for_each(|node| assert_eq!(node.cheating_proofs.len(), 1));
 
         // wait for block;
-        r.wait(r.cfg().tx_wait_timeout);
+        r.wait(r.config.node.tx_wait_timeout);
         r.parts.1.skip_micro_block();
 
         // assert that nodes in partition 1 exclude node from partition 0.
@@ -968,9 +968,9 @@ fn slash_cheater() {
     });
 }
 
-fn precondition_2_different_leaderers(s: &mut Sandbox) {
+fn precondition_2_different_leaders(s: &mut Sandbox) {
     let mut ready = false;
-    for _ in 0..s.cfg().micro_blocks_in_epoch {
+    for _ in 0..s.config.chain.micro_blocks_in_epoch {
         let first_leader_pk = s.nodes[0].node_service.chain.leader();
         let new_leader_pk = s.next_view_change_leader();
         info!(
@@ -982,7 +982,7 @@ fn precondition_2_different_leaderers(s: &mut Sandbox) {
             break;
         }
         info!("Skipping microlock.");
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.skip_micro_block()
     }
     assert!(ready, "Not enought micriblocks found");

--- a/node/src/test/requests.rs
+++ b/node/src/test/requests.rs
@@ -41,10 +41,10 @@ fn request_on_timeout() {
         warn!("Leader: {}", leader_pk);
 
         // let leader shot his block
-        s.wait(s.cfg().tx_wait_timeout);
+        s.wait(s.config.node.tx_wait_timeout);
         s.poll();
         // emulate timeout on other nodes, and wait for request
-        s.wait(s.cfg().micro_block_timeout);
+        s.wait(s.config.node.micro_block_timeout);
         info!("BEFORE POLL");
         s.poll();
         s.filter_broadcast(&[crate::VIEW_CHANGE_TOPIC]); // ignore message from other modules.

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -134,7 +134,7 @@ mod test {
         let mut timestamp = SystemTime::now();
         let keychain = KeyChain::new_mem();
         let mut mempool = Mempool::new();
-        let mut cfg: BlockchainConfig = Default::default();
+        let mut cfg: ChainConfig = Default::default();
         let stake_epochs = 1;
         cfg.stake_epochs = stake_epochs;
         let stake: i64 = cfg.min_stake_amount;

--- a/src/bin/bootstrap.rs
+++ b/src/bin/bootstrap.rs
@@ -25,7 +25,7 @@ use simple_logger;
 use std::fs;
 use std::process;
 use std::time::SystemTime;
-use stegos_blockchain::{genesis, Block, BlockchainConfig};
+use stegos_blockchain::{genesis, Block, ChainConfig};
 use stegos_keychain::KeyChain;
 use stegos_keychain::KeyChainConfig;
 use stegos_serialization::traits::ProtoConvert;
@@ -33,7 +33,7 @@ use stegos_serialization::traits::ProtoConvert;
 fn main() {
     simple_logger::init_with_level(log::Level::Debug).unwrap_or_default();
 
-    let cfg: BlockchainConfig = Default::default();
+    let cfg: ChainConfig = Default::default();
     let args = App::new("Stegos Bootstrap Utility")
         .version(crate_version!())
         .author("Stegos AG <info@stegos.com>")

--- a/src/bin/stegos.rs
+++ b/src/bin/stegos.rs
@@ -204,7 +204,7 @@ fn run() -> Result<(), Error> {
 
     // Initialize node
     let (mut node_service, node) =
-        NodeService::new(cfg.chain.clone(), chain, keychain.clone(), network.clone())?;
+        NodeService::new(cfg.node.clone(), chain, keychain.clone(), network.clone())?;
 
     // Initialize TransactionPool.
     let txpool_service = TransactionPoolService::new(&keychain, network.clone(), node.clone());
@@ -214,8 +214,8 @@ fn run() -> Result<(), Error> {
         keychain.clone(),
         network.clone(),
         node.clone(),
-        cfg.chain.payment_fee,
-        cfg.chain.stake_fee,
+        cfg.node.payment_fee,
+        cfg.node.stake_fee,
         cfg.chain.stake_epochs,
         wallet_persistent_state,
     );

--- a/src/bin/transaction_generator.rs
+++ b/src/bin/transaction_generator.rs
@@ -211,7 +211,7 @@ fn run() -> Result<(), Error> {
     let genesis = initialize_genesis(&base_config)?;
     let timestamp = SystemTime::now();
     let chain = Blockchain::new(
-        base_config.chain.clone().into(),
+        base_config.chain.clone(),
         base_config.storage,
         genesis,
         timestamp,
@@ -222,7 +222,7 @@ fn run() -> Result<(), Error> {
     info!("Starting node service.");
     // Initialize node
     let (node_service, node) = NodeService::new(
-        base_config.chain.clone(),
+        base_config.node.clone(),
         chain,
         network_keychain.clone(),
         network.clone(),
@@ -239,8 +239,8 @@ fn run() -> Result<(), Error> {
             keychain.clone(),
             network.clone(),
             node.clone(),
-            cfg.chain.payment_fee,
-            cfg.chain.stake_fee,
+            cfg.node.payment_fee,
+            cfg.node.stake_fee,
             cfg.chain.stake_epochs,
             wallet_persistent_state,
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,11 +30,11 @@ use std::io::Read;
 use std::path::Path;
 use std::result::Result;
 use stegos_api::WebSocketConfig;
-use stegos_blockchain::StorageConfig;
+use stegos_blockchain::{ChainConfig, StorageConfig};
 use stegos_crypto::curve1174::PublicKey;
 use stegos_keychain::KeyChainConfig;
 use stegos_network::NetworkConfig;
-use stegos_node::ChainConfig;
+use stegos_node::NodeConfig;
 use toml;
 
 /// Configuration root
@@ -51,6 +51,8 @@ pub struct Config {
     pub general: GeneralConfig,
     /// Chain configuration.
     pub chain: ChainConfig,
+    /// Node configuration.
+    pub node: NodeConfig,
     /// Network configuration.
     pub network: NetworkConfig,
     /// Key Chain configuration.
@@ -67,6 +69,7 @@ impl Default for Config {
         Config {
             general: Default::default(),
             chain: Default::default(),
+            node: Default::default(),
             network: Default::default(),
             keychain: Default::default(),
             storage: Default::default(),


### PR DESCRIPTION
Refactor configuration
    
    - Separate BlockchainConfig from ChainConfig.
    - Rename ChainConfig to NodeConfig.
    - Rename BlockchainConfig to ChainConfig.
    
Tune blockchain constants

Closes #667