### PR TITLE
Replaced hex encodings for Wallet PKey with Base58Check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "base58check"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2589,7 @@ dependencies = [
 name = "stegos_crypto"
 version = "0.2.0"
 dependencies = [
+ "base58check 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvector 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2590,6 +2605,7 @@ dependencies = [
  "rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-libpbc 0.1.0 (git+https://github.com/stegos/rust-pbcintf.git)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_serialization 0.2.0",
 ]
@@ -3562,6 +3578,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)" = "1a13fc43f04daf08ab4f71e3d27e1fc27fc437d3e95ac0063a796d92fb40f39b"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+"checksum base58check 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "821c80f71fdcd7e7a24fa9d16c8b23a9c8236ab4a0b03f67618fc3c76431998b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bigint 4.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebecac13b3c745150d7b6c3ea7572d372f09d627c2077e893bf26c5c7f70d282"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -14,6 +14,7 @@ description = "Stegos - Crypto Library"
 
 [dependencies]
 stegos_serialization = { version = "0.2.0", path = "../serialization" }
+base58check = "0.0.1"
 bitvector = "0.1"
 failure = "0.1"
 hex = "0.3"
@@ -29,6 +30,9 @@ rust-libpbc = { version = "0.1.0", git = "https://github.com/stegos/rust-pbcintf
 sha3 = "0.8"
 clear_on_drop = "0.2"
 serde = "1.0"
+
+[dev-dependencies]
+serde_json = "1.0"
 
 [build-dependencies]
 stegos_serialization = { version = "0.2.0", path = "../serialization" }

--- a/src/bin/stegos.rs
+++ b/src/bin/stegos.rs
@@ -146,14 +146,17 @@ fn load_keys(
             info!("Recovering keys...");
             let wallet_skey = keychain::input::read_recovery(&cfg.recovery_file)?;
             let wallet_pkey: curve1174::PublicKey = wallet_skey.clone().into();
-            info!("Recovered a wallet key: pkey={}", wallet_pkey.to_hex());
+            info!(
+                "Recovered a wallet key: pkey={}",
+                String::from(&wallet_pkey)
+            );
             (wallet_skey, wallet_pkey)
         } else {
             debug!("Generating a new wallet key pair...");
             let (wallet_skey, wallet_pkey) = curve1174::make_random_keys();
             info!(
                 "Generated a new wallet key pair: pkey={}",
-                wallet_pkey.to_hex()
+                String::from(&wallet_pkey)
             );
             (wallet_skey, wallet_pkey)
         };

--- a/src/console.rs
+++ b/src/console.rs
@@ -33,6 +33,7 @@ use regex::Regex;
 use rustyline as rl;
 use std::fmt;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::thread;
 use std::time::{Duration, SystemTime};
 use stegos_crypto::curve1174::PublicKey;
@@ -57,7 +58,7 @@ use stegos_wallet::{
 
 lazy_static! {
     /// Regex to parse "pay" command.
-    static ref PAY_COMMAND_RE: Regex = Regex::new(r"\s*(?P<recipient>[0-9a-f]+)\s+(?P<amount>[0-9\.]{1,19})(?P<arguments>.+)?\s*$").unwrap();
+    static ref PAY_COMMAND_RE: Regex = Regex::new(r"\s*(?P<recipient>[0-9A-Za-z]+)\s+(?P<amount>[0-9\.]{1,19})(?P<arguments>.+)?\s*$").unwrap();
     /// Regex to parse argument of "pay" command.
     static ref PAY_ARGUMENTS_RE: Regex = Regex::new(r"^(\s+(?P<public>(/public)))?(\s+(?P<comment>[^/]+?))?(\s+(?P<lock>(/lock\s*.*)))?\s*$").unwrap();
     /// Regex to parse argument of "pay" command.
@@ -293,7 +294,7 @@ impl ConsoleService {
             };
 
             let recipient = caps.name("recipient").unwrap().as_str();
-            let recipient = match PublicKey::try_from_hex(recipient) {
+            let recipient = match PublicKey::from_str(recipient) {
                 Ok(r) => r,
                 Err(e) => {
                     println!("Invalid wallet public key '{}': {}", recipient, e);
@@ -351,7 +352,7 @@ impl ConsoleService {
                 info!(
                     "Sending {} STG to {}, with uncloaked recipient and amount.",
                     format_money(amount),
-                    recipient.to_hex()
+                    String::from(&recipient)
                 );
                 let password = input::read_password_from_stdin(false)?;
                 WalletRequest::PublicPayment {
@@ -364,7 +365,7 @@ impl ConsoleService {
                 info!(
                     "Sending {} STG to {}",
                     format_money(amount),
-                    recipient.to_hex()
+                    String::from(&recipient)
                 );
                 let password = input::read_password_from_stdin(false)?;
                 WalletRequest::Payment {
@@ -386,7 +387,7 @@ impl ConsoleService {
             };
 
             let recipient = caps.name("recipient").unwrap().as_str();
-            let recipient = match PublicKey::try_from_hex(recipient) {
+            let recipient = match PublicKey::from_str(recipient) {
                 Ok(r) => r,
                 Err(e) => {
                     println!("Invalid wallet public key '{}': {}", recipient, e);
@@ -435,7 +436,7 @@ impl ConsoleService {
             info!(
                 "Sending {} to {} via ValueShuffle",
                 format_money(amount),
-                recipient.to_hex()
+                String::from(&recipient)
             );
             let password = input::read_password_from_stdin(false)?;
             let request = WalletRequest::SecurePayment {
@@ -456,7 +457,7 @@ impl ConsoleService {
             };
 
             let recipient = caps.name("recipient").unwrap().as_str();
-            let recipient = match PublicKey::try_from_hex(recipient) {
+            let recipient = match PublicKey::from_str(recipient) {
                 Ok(r) => r,
                 Err(e) => {
                     println!("Invalid wallet public key '{}': {}", recipient, e);
@@ -468,7 +469,7 @@ impl ConsoleService {
             let comment = caps.name("msg").unwrap().as_str().to_string();
             assert!(comment.len() > 0);
 
-            info!("Sending message to {}", recipient.to_hex());
+            info!("Sending message to {}", String::from(&recipient));
             let password = input::read_password_from_stdin(false)?;
             let request = WalletRequest::Payment {
                 password,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -236,7 +236,7 @@ impl WalletService {
         stake_epochs: u64,
         persistent_state: Vec<(Output, u64)>,
     ) -> (Self, Wallet) {
-        info!("My wallet key: {}", wallet_pkey.to_hex());
+        info!("My wallet key: {}", String::from(&wallet_pkey));
         debug!("My network key: {}", network_pkey.to_hex());
         //
         // State.
@@ -315,7 +315,7 @@ impl WalletService {
         }
 
         metrics::WALLET_BALANCES
-            .with_label_values(&[&service.wallet_pkey.to_hex()])
+            .with_label_values(&[&String::from(&service.wallet_pkey)])
             .set(service.balance());
 
         let api = Wallet { outbox };
@@ -363,7 +363,7 @@ impl WalletService {
         let tx: Transaction = tx.into();
         self.node.send_transaction(tx.clone())?;
         metrics::WALLET_CREATEAD_PAYMENTS
-            .with_label_values(&[&self.wallet_pkey.to_hex()])
+            .with_label_values(&[&String::from(&self.wallet_pkey)])
             .inc();
         //firstly check that no conflict input was found;
         self.add_transaction_interest(tx.into());
@@ -402,7 +402,7 @@ impl WalletService {
         let tx: Transaction = tx.into();
         self.node.send_transaction(tx.clone())?;
         metrics::WALLET_CREATEAD_PAYMENTS
-            .with_label_values(&[&self.wallet_pkey.to_hex()])
+            .with_label_values(&[&String::from(&self.wallet_pkey)])
             .inc();
         //firstly check that no conflict input was found;
         self.add_transaction_interest(tx.into());
@@ -462,7 +462,7 @@ impl WalletService {
         let saved_tx = SavedTransaction::ValueShuffle(inputs.iter().map(|(h, _)| *h).collect());
         let hash = Hash::digest(&saved_tx);
         metrics::WALLET_CREATEAD_SECURE_PAYMENTS
-            .with_label_values(&[&self.wallet_pkey.to_hex()])
+            .with_label_values(&[&String::from(&self.wallet_pkey)])
             .inc();
         self.add_transaction_interest(saved_tx);
         Ok(hash)
@@ -637,7 +637,7 @@ impl WalletService {
         if saved_balance != balance {
             debug!("Balance changed");
             metrics::WALLET_BALANCES
-                .with_label_values(&[&self.wallet_pkey.to_hex()])
+                .with_label_values(&[&String::from(&self.wallet_pkey)])
                 .set(balance);
             self.notify(WalletNotification::BalanceChanged { balance });
         }
@@ -743,12 +743,12 @@ impl WalletService {
                 match tx {
                     SavedTransaction::Regular(_) => {
                         metrics::WALLET_COMMITTED_PAYMENTS
-                            .with_label_values(&[&self.wallet_pkey.to_hex()])
+                            .with_label_values(&[&String::from(&self.wallet_pkey)])
                             .inc();
                     }
                     SavedTransaction::ValueShuffle(_) => {
                         metrics::WALLET_COMMITTED_SECURE_PAYMENTS
-                            .with_label_values(&[&self.wallet_pkey.to_hex()])
+                            .with_label_values(&[&String::from(&self.wallet_pkey)])
                             .inc();
                     }
                 };


### PR DESCRIPTION
Closes #785 

* removed `to_hex/from_hex` from `curve1174::cpt::PublicKey`
* implemented trait FromStr for `curve1174::cpt::PublicKey`
* implemented trait `From<&curve1174::cpt::PublicKey> for String
