### PR TITLE
Add support for variable tx fees

### DIFF
--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -42,10 +42,10 @@ pub struct NodeConfig {
     pub max_utxo_in_mempool: usize,
     /// Loader will send maximum N epoch at time.
     pub loader_speed_in_epoch: u64,
-    /// Fixed fee for payment transactions.
-    pub payment_fee: i64,
-    /// Fixed fee for the stake transactions.
-    pub stake_fee: i64,
+    /// Minimal fee for payment transactions.
+    pub min_payment_fee: i64,
+    /// Minimal fee for the stake transactions.
+    pub min_stake_fee: i64,
 }
 
 impl Default for NodeConfig {
@@ -58,8 +58,8 @@ impl Default for NodeConfig {
             max_utxo_in_block: 2000,
             max_utxo_in_mempool: 20000,
             loader_speed_in_epoch: 100,
-            payment_fee: 1_000, // 0.001 STG
-            stake_fee: 0,       // free
+            min_payment_fee: 1_000, // 0.001 STG
+            min_stake_fee: 0,       // free
         }
     }
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -416,8 +416,8 @@ impl NodeService {
             &self.mempool,
             &self.chain,
             timestamp,
-            self.cfg.payment_fee,
-            self.cfg.stake_fee,
+            self.cfg.min_payment_fee,
+            self.cfg.min_stake_fee,
         )?;
 
         // Queue to mempool.

--- a/src/bin/stegosd.rs
+++ b/src/bin/stegosd.rs
@@ -331,8 +331,6 @@ fn run() -> Result<(), Error> {
         network_pkey,
         network.clone(),
         node.clone(),
-        cfg.node.payment_fee,
-        cfg.node.stake_fee,
         cfg.chain.stake_epochs,
         wallet_persistent_state,
     );

--- a/src/bin/transaction_generator.rs
+++ b/src/bin/transaction_generator.rs
@@ -266,8 +266,6 @@ fn run() -> Result<(), Error> {
             instance.network_pkey,
             network.clone(),
             node.clone(),
-            cfg.node.payment_fee,
-            cfg.node.stake_fee,
             cfg.chain.stake_epochs,
             wallet_persistent_state,
         );

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -32,6 +32,7 @@ use tokio_timer::Delay;
 
 static WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 const MIN_BALANCE: i64 = 10_000; // just some small number
+const PAYMENT_FEE: i64 = 1_000; // 0.001 STG
 
 pub struct Generator {
     // start generator with specific delay, because our network could be not ready.
@@ -188,6 +189,7 @@ impl Generator {
                 password,
                 comment: "generator".into(),
                 amount: 1,
+                payment_fee: PAYMENT_FEE,
                 recipient,
                 locked_timestamp: None,
             },
@@ -195,6 +197,7 @@ impl Generator {
                 password,
                 comment: "generator".into(),
                 amount: 1,
+                payment_fee: PAYMENT_FEE,
                 recipient,
                 locked_timestamp: None,
             },

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -97,6 +97,7 @@ pub enum WalletRequest {
         password: String,
         recipient: PublicKey,
         amount: i64,
+        payment_fee: i64,
         comment: String,
         locked_timestamp: Option<SystemTime>,
     },
@@ -104,12 +105,14 @@ pub enum WalletRequest {
         password: String,
         recipient: PublicKey,
         amount: i64,
+        payment_fee: i64,
         locked_timestamp: Option<SystemTime>,
     },
     SecurePayment {
         password: String,
         recipient: PublicKey,
         amount: i64,
+        payment_fee: i64,
         comment: String,
         locked_timestamp: Option<SystemTime>,
     },
@@ -119,19 +122,23 @@ pub enum WalletRequest {
     Stake {
         password: String,
         amount: i64,
+        payment_fee: i64,
     },
     Unstake {
         password: String,
         amount: i64,
+        payment_fee: i64,
     },
     UnstakeAll {
         password: String,
+        payment_fee: i64,
     },
     RestakeAll {
         password: String,
     },
     CloakAll {
         password: String,
+        payment_fee: i64,
     },
     KeysInfo {},
     BalanceInfo {},


### PR DESCRIPTION
- Add support for `payment_fee` in API.
- Allow user to specify fee in Console.
- Sort mempool transactions by fee.