### PR TITLE
Fix ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY --from=source --chown=1111:1111 /node /node
 USER 1111:1111
 WORKDIR /node
 
-ENTRYPOINT [ "/usr/local/bin/stegos" ]
+ENTRYPOINT [ "/usr/local/bin/stegosd" ]


### PR DESCRIPTION
Use `/usr/local/bin/stegosd` as ENTRYPOINT (was `/usr/local/bin/stegos` which is now binary for CLI)

Closes #1010 