### PR TITLE
Fix bug in API that return incorrect error for "cloak" command.

### DIFF
--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -26,6 +26,8 @@ use failure::Fail;
 pub enum WalletError {
     #[fail(display = "Not enough money.")]
     NotEnoughMoney,
+    #[fail(display = "No unspent public outputs was found.")]
+    NoPublicOutputs,
     #[fail(display = "Negative amount: amount={}", _0)]
     NegativeAmount(i64),
     #[fail(display = "Insufficient stake: min={}, got={}.", _0, _1)]

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -455,7 +455,7 @@ impl UnsealedAccountService {
     /// Cloak all available public outputs.
     fn cloak_all(&mut self, payment_fee: i64) -> Result<PaymentTransactionValue, Error> {
         if self.public_payments.is_empty() {
-            return Err(WalletError::NotEnoughMoney.into());
+            return Err(WalletError::NoPublicOutputs.into());
         }
 
         let public_utxos = self.public_payments.values();


### PR DESCRIPTION
Closes: #985

current output:
```
---
- type: cloak_all
  payment_fee: 1000
...

---
- type: error
  error: No unspent public outputs was found.
```