### PR TITLE
Limit number of input UTXOs in composed transactions

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -40,6 +40,7 @@ pub use crate::config::NodeConfig;
 use crate::error::*;
 use crate::loader::ChainLoaderMessage;
 use crate::mempool::Mempool;
+pub use crate::txpool::MAX_PARTICIPANTS;
 use crate::validation::*;
 use failure::Error;
 use futures::sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};

--- a/node/src/txpool/mod.rs
+++ b/node/src/txpool/mod.rs
@@ -23,7 +23,7 @@ use tokio_timer::Interval;
 
 pub const MESSAGE_TIMEOUT: Duration = Duration::from_secs(30);
 const MIN_PARTICIPANTS: usize = 3;
-const MAX_PARTICIPANTS: usize = 20;
+pub const MAX_PARTICIPANTS: usize = 20;
 
 type TXIN = Hash;
 type UTXO = PaymentOutput;

--- a/src/bin/stegosd.rs
+++ b/src/bin/stegosd.rs
@@ -254,6 +254,7 @@ fn run() -> Result<(), Error> {
         node.clone(),
         rt.executor(),
         cfg.chain.stake_epochs,
+        cfg.node.max_inputs_in_tx,
     )?;
     rt.spawn(wallet_service);
 

--- a/wallet/src/test/mod.rs
+++ b/wallet/src/test/mod.rs
@@ -60,6 +60,7 @@ struct AccountSandbox {
 impl AccountSandbox {
     pub fn new(
         stake_epochs: u64,
+        max_inputs_in_tx: usize,
         keys: KeyChain,
         node: Node,
         chain: &Blockchain,
@@ -99,6 +100,7 @@ impl AccountSandbox {
             network,
             node,
             stake_epochs,
+            max_inputs_in_tx,
             subscribers,
             events,
         );
@@ -114,12 +116,14 @@ impl AccountSandbox {
 
     pub fn new_genesis(s: &mut Sandbox, node_id: usize) -> AccountSandbox {
         let stake_epochs = s.config.chain.stake_epochs;
+        let max_inputs_in_tx = s.config.node.max_inputs_in_tx;
         let node = s.nodes[node_id].node.clone();
         let keys = s.keychains[node_id].clone();
         // genesis accounts should reuse the same network.
         let (network_service, network) = s.nodes[node_id].clone_network();
         Self::new(
             stake_epochs,
+            max_inputs_in_tx,
             keys,
             node,
             &s.nodes[node_id].chain(),
@@ -131,6 +135,7 @@ impl AccountSandbox {
     #[allow(dead_code)]
     pub fn new_custom(s: &mut Sandbox, node_id: usize) -> AccountSandbox {
         let stake_epochs = s.config.chain.stake_epochs;
+        let max_inputs_in_tx = s.config.node.max_inputs_in_tx;
         let node = s.nodes[node_id].node.clone();
         let mut keys = s.keychains[node_id].clone();
         // change account keys to custom
@@ -141,6 +146,7 @@ impl AccountSandbox {
         let (network_service, network) = Loopback::new();
         Self::new(
             stake_epochs,
+            max_inputs_in_tx,
             keys,
             node,
             &s.nodes[node_id].chain(),


### PR DESCRIPTION
Also, tries to fill up inputs with smallest UTXOs to burn 'em.

Closes #1113