### PR TITLE
Check locked_timestamp() in validate_macro_block()

### DIFF
--- a/blockchain/src/validation.rs
+++ b/blockchain/src/validation.rs
@@ -628,6 +628,18 @@ impl Blockchain {
             )
             .into());
         }
+        for (input_hash, input) in block.inputs.iter().zip(inputs) {
+            if let Some(timestamp) = input.locked_timestamp() {
+                if timestamp >= self.last_macro_block_timestamp() {
+                    return Err(OutputError::UtxoLocked(
+                        *input_hash,
+                        timestamp,
+                        self.last_macro_block_timestamp(),
+                    )
+                    .into());
+                }
+            }
+        }
 
         //
         // Validate outputs.


### PR DESCRIPTION
The locked timestamp is already validated in micro blocks.
Add this extra check just for sure.

Closes #1006

I will test all corner cases as part of #394 