### PR TITLE
Add tests for service award.

### DIFF
--- a/blockchain/src/awards.rs
+++ b/blockchain/src/awards.rs
@@ -54,6 +54,14 @@ impl Awards {
         }
     }
 
+    pub fn validators_activivty(&self) -> &BTreeMap<PublicKey, ValidatorAwardState> {
+        &self.validators_activity
+    }
+
+    pub fn budget(&self) -> i64 {
+        self.budget
+    }
+
     fn add_reward(&mut self, piece: i64) {
         assert!(piece > 0);
         self.budget += piece;

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -43,6 +43,7 @@ mod transaction;
 mod validation;
 pub mod view_changes;
 
+pub use crate::awards::ValidatorAwardState;
 pub use crate::block::*;
 pub use crate::blockchain::*;
 pub use crate::config::*;

--- a/blockchain/src/validation.rs
+++ b/blockchain/src/validation.rs
@@ -589,7 +589,13 @@ impl Blockchain {
         // Validate Awards.
         //
         if epoch > 0 {
-            let (_activity_map, winner) = self.awards_from_active_epoch(&block.header.random);
+            let validators_activity = self
+                .epoch_activity_from_macro_block(&block.header.activity_map)
+                .unwrap();
+            let mut service_awards = self.service_awards().clone();
+            service_awards.finalize_epoch(self.cfg().service_award_per_epoch, validators_activity);
+            let winner = service_awards.check_winners(block.header.random.rand);
+
             // calculate block reward + service award.
             let full_reward = self.cfg().block_reward
                 * (self.cfg().micro_blocks_in_epoch as i64 + 1i64)

--- a/node/src/test/mod.rs
+++ b/node/src/test/mod.rs
@@ -418,6 +418,7 @@ pub trait Api<'p> {
         let offset = self.first().node_service.chain.offset();
         let last_block = self.first().node_service.chain.last_block_hash();
         for node in self.iter() {
+            trace!("Checking node = {:?}", node.validator_id());
             assert_eq!(node.node_service.chain.epoch(), epoch);
             assert_eq!(node.node_service.chain.offset(), offset);
             assert_eq!(node.node_service.chain.last_block_hash(), last_block);


### PR DESCRIPTION
Closes: https://github.com/stegos/stegos/issues/944

Assert that service awards preserve epoch statuses.

Also fix bug in macro_block validation. Which checks state according to current epoch stat, rather then according to block information.