### PR TITLE
Fix crash on second re-staking

### DIFF
--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -1136,8 +1136,17 @@ impl Blockchain {
         debug!("Set difficulty to to {}", self.difficulty);
 
         info!(
-            "Registered a macro block: epoch={}, block={}",
-            epoch, block_hash
+            "Registered a macro block: epoch={}, block={}, inputs={:?}, outputs={:?}",
+            epoch,
+            block_hash,
+            inputs
+                .iter()
+                .map(|o| Hash::digest(o).to_string())
+                .collect::<Vec<String>>(),
+            outputs
+                .iter()
+                .map(|o| Hash::digest(o).to_string())
+                .collect::<Vec<String>>(),
         );
         debug!("Validators: {:?}", &self.validators());
 
@@ -1499,12 +1508,19 @@ impl Blockchain {
         metrics::EMISSION.set(self.balance().block_reward);
 
         info!(
-            "Registered a micro block: epoch={}, offset={}, block={}, inputs={}, outputs={}",
+            "Registered a micro block: epoch={}, offset={}, block={}, txs={:?}, inputs={:?}, outputs={:?}",
             epoch,
             offset,
             block_hash,
-            inputs.len(),
-            outputs.len()
+            txs.iter()
+                .map(|(h, _1tx)| h.to_string())
+                .collect::<Vec<String>>(),
+            inputs.iter()
+                .map(|o| Hash::digest(o).to_string())
+                .collect::<Vec<String>>(),
+            outputs.iter()
+                .map(|o| Hash::digest(o).to_string())
+                .collect::<Vec<String>>(),
         );
 
         Ok((inputs, outputs, txs))
@@ -1592,12 +1608,18 @@ impl Blockchain {
         metrics::EMISSION.set(self.balance().block_reward);
 
         info!(
-            "Reverted a micro block: epoch={}, offset={}, block={}, inputs={}, outputs={}",
+            "Reverted a micro block: epoch={}, offset={}, block={}, inputs={:?}, outputs={:?}",
             self.epoch,
             offset,
             &block_hash,
-            created.len(),
-            pruned.len()
+            created
+                .iter()
+                .map(|o| Hash::digest(o).to_string())
+                .collect::<Vec<String>>(),
+            pruned
+                .iter()
+                .map(|o| Hash::digest(o).to_string())
+                .collect::<Vec<String>>(),
         );
 
         Ok((pruned, created, removed))

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -63,7 +63,7 @@ impl Default for NodeConfig {
             max_inputs_in_block: 10000,
             max_outputs_in_block: 1000,
             max_inputs_in_mempool: 100000,
-            max_outputs_in_mempool: 2,
+            max_outputs_in_mempool: 10000,
             loader_speed_in_epoch: 100,
             min_payment_fee: 1_000, // 0.001 STG
             min_stake_fee: 0,       // free

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -61,6 +61,13 @@ impl Mempool {
     }
 
     ///
+    /// Get TX by `input_hash`.
+    ///
+    pub fn get_tx_by_input(&self, input_hash: &Hash) -> Option<&Hash> {
+        self.inputs.get(input_hash)
+    }
+
+    ///
     /// Checks if the mempool contains a transaction with claims `output_hash`.
     ///
     pub fn contains_output(&self, output_hash: &Hash) -> bool {


### PR DESCRIPTION
- Fix mistyped max_outputs_in_mempool limit.
- Skip stakes which are already in mempool during re-staking.
- Don't restake if not is node synchronized.
- Allow RestakeTransaction even if mempool is full.
- Add loggings of inputs/outputs to transactions and blocks.

Closes #1064