### PR TITLE
Add more tests for wallet

### DIFF
--- a/wallet/src/storage.rs
+++ b/wallet/src/storage.rs
@@ -576,7 +576,7 @@ impl PaymentTransactionValue {
             })
             .collect();
 
-        assert_eq!(tx.txouts.len(), 2);
+        assert!(tx.txouts.len() <= 2);
         assert!(certificates.len() <= 1);
 
         PaymentTransactionValue {


### PR DESCRIPTION
1. Get recovery key using api.
2. Recover from disk should save transactions.
3. Transaction should has status `Committed` on epoch change.
4. Check possibility of creating certificates, and using them to access encrypted payload.
5. Check that public payments work, and we can see amount.
6. Create transaction with invalid request produce errors: negative amount, amount more than balance, invalid comment length.


Also fix a bug in wallet, that disallow creating payment transaction with only one output.