### PR TITLE
Allow to override configuration options via command-line

### DIFF
--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -399,7 +399,7 @@ impl WebSocketServer {
         let node2 = node.clone();
         let version2 = version.clone();
         let addr: SocketAddr = endpoint.parse()?;
-        info!("Starting WebSocket API on {}", &addr);
+        info!("Starting API Server on {}", &addr);
         let server = TcpListener::bind(&addr)?
             .incoming()
             .map_err(|e| {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1268,7 +1268,7 @@ impl NodeService {
             let solver = self.chain.vdf_solver();
             let solver = move || {
                 let solution = solver();
-                tx.send(solution).expect("node is alive");
+                tx.send(solution).ok(); // ignore errors.
             };
             // Spawn a background thread to solve VDF puzzle.
             thread::spawn(solver);

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ pub struct GeneralConfig {
     /// Force strict checking (BP + BLS + VRF) of blockchain on the disk.
     pub force_check: bool,
     /// Log4RS configuration file
-    pub log4rs_config: String,
+    pub log_config: PathBuf,
     /// Prometheus exporter endpoint
     pub prometheus_endpoint: String,
     /// WebSocket API endpoint,
@@ -94,7 +94,7 @@ impl Default for GeneralConfig {
             chain: "testnet".to_string(),
             data_dir,
             force_check: cfg!(debug_assertions),
-            log4rs_config: "stegos-log4rs.toml".to_string(),
+            log_config: PathBuf::new(),
             prometheus_endpoint: "".to_string(),
             api_endpoint: "0.0.0.0:3145".to_string(),
         }

--- a/testing/node01/stegos.toml
+++ b/testing/node01/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9891"
 api_endpoint = "127.0.0.1:3145"
 data_dir = "testing/node01"

--- a/testing/node02/stegos.toml
+++ b/testing/node02/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9892"
 api_endpoint = "127.0.0.1:3146"
 data_dir = "testing/node02"

--- a/testing/node03/stegos.toml
+++ b/testing/node03/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9893"
 api_endpoint = "127.0.0.1:3147"
 data_dir = "testing/node03"

--- a/testing/node04/stegos.toml
+++ b/testing/node04/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9894"
 api_endpoint = "127.0.0.1:3148"
 data_dir = "testing/node04"

--- a/testing/node05/stegos.toml
+++ b/testing/node05/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9895"
 api_endpoint = "127.0.0.1:3149"
 data_dir = "testing/node05"

--- a/testing/node06/stegos.toml
+++ b/testing/node06/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9896"
 api_endpoint = "127.0.0.1:3150"
 data_dir = "testing/node06"

--- a/testing/node07/stegos.toml
+++ b/testing/node07/stegos.toml
@@ -1,6 +1,6 @@
 [general]
 chain = "dev"
-log4rs_config = "stegos-log4rs.toml"
+log_config = "stegos-log4rs.toml"
 prometheus_endpoint = "127.0.0.1:9897"
 api_endpoint = "127.0.0.1:3151"
 data_dir = "testing/node07"


### PR DESCRIPTION
stegosd:

- Add `--data-dir`, `--api-endpoint`, `--prometheus-endpoint`,
  `--log-config`, `--verbose`, '--force-check'.
- Allow to override the default log level via '-v', '-vv', '-vvv'.
- Don't read `stegos-log4s.toml` from the current directory by default.
- Rename `general.log4rs_config` to `general.log_config`.

stegos:

- Remove `ws://` prefix from --api-endpoint in Stegos CLI.
- Allow to override default log level via '-v', '-vv', '-vvv'.
- Don't print node notifications unless Debug level is enabled.

Needed for Stegos Wallet UI.