### PR TITLE
Refactor serialization representation of PaymentTransactionValue and OutputValue.

### DIFF
--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -191,6 +191,7 @@ fn cloak_key(recipient_pkey: &PublicKey, gamma: &Fr) -> Result<(PublicKey, Fr), 
 
 /// Unpacked data field of PaymentPayload.
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum PaymentPayloadData {
     /// A string up to PAYLOAD_DATA_LEN - 2 bytes inclusive.
     Comment(String),

--- a/wallet/protos/account_log.proto
+++ b/wallet/protos/account_log.proto
@@ -42,6 +42,7 @@ message PaymentTransactionValue {
     stegos.blockchain.PaymentTransaction tx = 1;
     TransactionStatus status = 2;
     repeated PaymentCertificate certificates = 3;
+    int64 amount = 4;
 }
 
 // Incoming event

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -34,6 +34,8 @@ use stegos_node::TransactionStatus;
 pub type AccountId = String;
 
 #[derive(Eq, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
 pub enum LogEntryInfo {
     Incoming {
         timestamp: Timestamp,
@@ -46,6 +48,8 @@ pub enum LogEntryInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "output_type")]
 pub enum OutputInfo {
     Payment(PaymentInfo),
     PublicPayment(PublicPaymentInfo),
@@ -56,6 +60,7 @@ pub enum OutputInfo {
 pub struct PaymentInfo {
     pub utxo: Hash,
     pub amount: i64,
+    #[serde(flatten)]
     pub data: PaymentPayloadData,
     pub locked_timestamp: Option<Timestamp>,
 }
@@ -190,6 +195,7 @@ pub enum WalletRequest {
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentTransactionInfo {
     pub tx_hash: Hash,
+    pub amount: i64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub certificates: Vec<PaymentCertificate>,
     #[serde(flatten)]

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -138,7 +138,7 @@ struct UnsealedAccountService {
     vs: ValueShuffle,
     //TODO: Temporary hack to receive newly created transaction from valueshuffle.
     wallet_tx_info_receiver: mpsc::UnboundedReceiver<(PaymentTransaction, bool)>,
-    vs_session: Option<(Hash, oneshot::Sender<AccountResponse>)>,
+    vs_session: Option<(Hash, oneshot::Sender<AccountResponse>, i64)>,
     transaction_response: Option<oneshot::Receiver<NodeResponse>>,
 
     //
@@ -401,7 +401,7 @@ impl UnsealedAccountService {
             self.last_macro_block_timestamp,
             self.max_inputs_in_tx,
         )?;
-        let payment_info = PaymentTransactionValue::new_stake(tx.clone());
+        let payment_info = PaymentTransactionValue::new_stake(tx.clone(), amount);
 
         self.account_log
             .push_outgoing(Timestamp::now(), payment_info.clone())?;
@@ -426,7 +426,7 @@ impl UnsealedAccountService {
             self.last_macro_block_timestamp,
             self.max_inputs_in_tx,
         )?;
-        let payment_info = PaymentTransactionValue::new_stake(tx.clone());
+        let payment_info = PaymentTransactionValue::new_stake(tx.clone(), amount);
         self.send_transaction(tx.into())?;
         Ok(payment_info)
     }
@@ -447,6 +447,11 @@ impl UnsealedAccountService {
             return Err(WalletError::NothingToRestake.into());
         }
 
+        let mut amount = 0;
+        for output in self.stakes.values().map(|val| &val.output) {
+            amount += output.amount;
+        }
+
         let stakes = self.stakes.values().map(|val| &val.output);
         let tx = create_restaking_transaction(
             &self.account_skey,
@@ -457,13 +462,18 @@ impl UnsealedAccountService {
         )?;
         let tx_hash = Hash::digest(&tx);
         self.send_transaction(tx.into())?;
-        Ok((tx_hash, 0))
+        Ok((tx_hash, amount))
     }
 
     /// Cloak all available public outputs.
     fn cloak_all(&mut self, payment_fee: i64) -> Result<PaymentTransactionValue, Error> {
         if self.public_payments.is_empty() {
             return Err(WalletError::NoPublicOutputs.into());
+        }
+
+        let mut amount = 0;
+        for output in self.public_payments.values() {
+            amount += output.amount
         }
 
         let public_utxos = self.public_payments.values();
@@ -475,7 +485,7 @@ impl UnsealedAccountService {
             self.last_macro_block_timestamp,
         )?;
 
-        let info = PaymentTransactionValue::new_cloak(tx.clone());
+        let info = PaymentTransactionValue::new_cloak(tx.clone(), amount);
         self.send_transaction(tx.into())?;
         Ok(info)
     }
@@ -679,6 +689,7 @@ impl UnsealedAccountService {
         tx: PaymentTransaction,
         leader: bool,
         session_id: Hash,
+        amount: i64,
     ) -> Result<PaymentTransactionInfo, Error> {
         let tx_hash = Hash::digest(&tx);
         metrics::WALLET_PUBLISHED_PAYMENTS
@@ -690,7 +701,7 @@ impl UnsealedAccountService {
         };
         self.notify(notify);
 
-        let payment_info = PaymentTransactionValue::new_vs(tx.clone());
+        let payment_info = PaymentTransactionValue::new_vs(tx.clone(), amount);
 
         self.account_log
             .push_outgoing(Timestamp::now(), payment_info.clone())?;
@@ -779,9 +790,10 @@ impl From<Result<PaymentTransactionValue, Error>> for AccountResponse {
 impl From<Result<(Hash, i64), Error>> for AccountResponse {
     fn from(r: Result<(Hash, i64), Error>) -> Self {
         match r {
-            Ok((hash, _fee)) => {
+            Ok((hash, amount)) => {
                 let info = PaymentTransactionInfo {
                     tx_hash: hash,
+                    amount,
                     certificates: vec![],
                     status: TransactionStatus::Created {},
                 };
@@ -870,9 +882,9 @@ impl Future for UnsealedAccountService {
                 Async::Ready(msg) => {
                     let (tx, leader) = msg.expect("channel not ended.");
 
-                    let (session_id, response_sender) =
+                    let (session_id, response_sender, amount) =
                         self.vs_session.take().expect("active snowball session");
-                    match self.handle_snowball_transaction(tx, leader, session_id) {
+                    match self.handle_snowball_transaction(tx, leader, session_id, amount) {
                         Ok(tx) => {
                             let _ = response_sender.send(AccountResponse::TransactionCreated(tx));
                         }
@@ -1002,7 +1014,7 @@ impl Future for UnsealedAccountService {
                                     self.notify(AccountNotification::SnowballStarted {
                                         session_id,
                                     });
-                                    self.vs_session = (session_id, tx).into();
+                                    self.vs_session = (session_id, tx, amount).into();
                                     continue;
                                 }
                                 Err(e) => AccountResponse::Error {

--- a/wallet/src/protos.rs
+++ b/wallet/src/protos.rs
@@ -234,6 +234,7 @@ impl ProtoConvert for PaymentTransactionValue {
             }
         }
         msg.set_status(status);
+        msg.set_amount(self.amount);
         msg
     }
 
@@ -285,9 +286,11 @@ impl ProtoConvert for PaymentTransactionValue {
                 .into());
             }
         };
+        let amount = proto.get_amount();
         let payload = PaymentTransactionValue {
             tx,
             status,
+            amount,
             certificates,
         };
         Ok(payload)

--- a/wallet/src/storage.rs
+++ b/wallet/src/storage.rs
@@ -411,6 +411,7 @@ pub struct PaymentTransactionValue {
     #[serde(skip_serializing)]
     pub tx: PaymentTransaction,
     pub status: TransactionStatus,
+    pub amount: i64,
     pub certificates: Vec<PaymentCertificate>,
 }
 
@@ -582,33 +583,37 @@ impl PaymentTransactionValue {
         PaymentTransactionValue {
             certificates,
             tx,
+            amount,
             status: TransactionStatus::Created {},
         }
     }
 
-    pub fn new_vs(tx: PaymentTransaction) -> PaymentTransactionValue {
+    pub fn new_vs(tx: PaymentTransaction, amount: i64) -> PaymentTransactionValue {
         assert!(tx.txouts.len() >= 2);
         PaymentTransactionValue {
             certificates: Vec::new(),
             tx,
+            amount,
             status: TransactionStatus::Created {},
         }
     }
 
-    pub fn new_cloak(tx: PaymentTransaction) -> PaymentTransactionValue {
+    pub fn new_cloak(tx: PaymentTransaction, amount: i64) -> PaymentTransactionValue {
         assert_eq!(tx.txouts.len(), 1);
 
         PaymentTransactionValue {
             certificates: Vec::new(),
             tx,
+            amount,
             status: TransactionStatus::Created {},
         }
     }
 
-    pub fn new_stake(tx: PaymentTransaction) -> PaymentTransactionValue {
+    pub fn new_stake(tx: PaymentTransaction, amount: i64) -> PaymentTransactionValue {
         PaymentTransactionValue {
             certificates: Vec::new(),
             tx,
+            amount,
             status: TransactionStatus::Created {},
         }
     }
@@ -617,6 +622,7 @@ impl PaymentTransactionValue {
         let tx_hash = Hash::digest(&self.tx);
         PaymentTransactionInfo {
             tx_hash,
+            amount: self.amount,
             certificates: self.certificates.clone(),
             status: self.status.clone(),
         }


### PR DESCRIPTION
Closes: https://github.com/stegos/stegos/issues/1154

1) PaymentTransactionValue now contain amount, of token that was sent.
2) LogEntry::Incoming and LogEntry::Outgoing now has tag as saperate field and has lowercase.
3) comment in OutputValue now serialized as field name, and in lowercase (data field was removed).
4) OutputValue tag now serialized as value of field `output_type`.


Example of current representation:

```
    - type: outgoing
      timestamp: "2019-07-24T14:04:49.598637648Z"
      tx:
        tx_hash: 4f5c615218eba250dc28d042d83c1804061f2c432172bfd1f78da8e33aaa3a54
        amount: 4
        status: committed
        epoch: 1
    - type: incoming
      timestamp: "2019-07-24T14:08:29.452600221Z"
      output:
        output_type: payment
        utxo: 03bf9dd22b26c8131fbf4491be776617196e4ade86b9461d8bae980bac5587dc
        amount: 24000000
        comment: Block reward+fee
        locked_timestamp: ~
```