### PR TITLE
Add Payment Certificate validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ dependencies = [
 name = "stegos_blockchain"
 version = "0.2.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvector 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -37,6 +37,7 @@ simple_logger = "1.2"
 criterion = "0.2"
 serde_derive = "1.0"
 serde_test = "1.0"
+assert_matches = "1.3"
 
 [build-dependencies]
 stegos_serialization = { version = "0.2.0", path = "../serialization" }

--- a/crypto/src/scc/mod.rs
+++ b/crypto/src/scc/mod.rs
@@ -201,6 +201,25 @@ impl fmt::Debug for Fr {
     }
 }
 
+impl Serialize for Fr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Fr {
+    fn deserialize<D>(deserializer: D) -> Result<Fr, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Fr::try_from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
 impl Hashable for Fr {
     fn hash(&self, state: &mut Hasher) {
         "Fr".hash(state);

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -47,6 +47,13 @@ pub enum NodeRequest {
     },
     #[serde(skip)]
     AddTransaction(Transaction),
+    ValidateCertificate {
+        utxo: Hash,
+        spender: scc::PublicKey,
+        recipient: scc::PublicKey,
+        amount: i64,
+        rvalue: scc::Fr,
+    },
 }
 
 ///
@@ -66,6 +73,7 @@ pub enum NodeResponse {
         hash: Hash,
         status: TransactionStatus,
     },
+    CertificateValid,
     Error {
         error: String,
     },

--- a/wallet/src/test/account_transaction.rs
+++ b/wallet/src/test/account_transaction.rs
@@ -151,14 +151,14 @@ fn create_tx_with_certificate() {
                     assert!(output
                         .decrypt_payload(&accounts[0].account_service.account_skey)
                         .is_err());
-                    let actual_amount = output
-                        .verify_proof_of_payment(
+                    output
+                        .validate_certificate(
                             &accounts[0].account_service.account_pkey,
-                            &tx.outputs[0].info.rvalue.unwrap(),
                             &recipient,
+                            10,
+                            &tx.outputs[0].info.rvalue.unwrap(),
                         )
                         .unwrap();
-                    assert_eq!(actual_amount, 10);
                 }
 
                 tx.tx_hash


### PR DESCRIPTION
- Add chain.historic_output_by_hash().
- Refactor output.validate_certificate().
- Add NodeRequest::ValidateCertificate.
- Add "validate certificate" command to CLI.

## Usage

Create a transaction using `payment` API with set  `with_certificate`:

To create certificate use `with_certificate = true" in API or /certificate in CLI:

**Console:**

```yaml
pay 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs 1 /certificate
```

**Request:**

```yaml
---
- type: payment
  recipient: 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs
  amount: 1
  payment_fee: 1000
  comment: ""
  locked_timestamp: ~
  with_certificate: true
...
```

**Response:**

```yaml
---
- account_id: "1"
  type: transaction_created
  tx_hash: 0a3e1c48c335b43b887f559f265cbc54f69a31dea646ef7f714c1bd3edcfc3f1
  fee: 2000
  outputs:
    - utxo: 5e9f51f94ad2084e75708a310a6988f3b523b3623deedfe45a69c17d489524c4
      recipient: 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs
      amount: 1
      rvalue: 0db753d6aba2c0ca26ddfe3b52cd1443e1170086dde24cc34371a651b4867dfa <!-- HERE
      comment: ""
      is_change: false
    - utxo: f2a963e60646e8f17fd24eb5996b1e87393a8e7da07480f8cbcf1e7c561ff69f
      recipient: 7eLHNiyS6qssNNLrskYrV3G7Yade1xdtNQ5HXxao4xXXA1gx5po
      amount: 7999
      comment: Change
      is_change: true
  inputs:
    - d4c7fa31b7adc7d1ad3b66ee65f112fefcebdef4e6bb8b2ffe6bba6359359425
  status: created
...
```

Similar output is returned by `history_info` API:

**Console:**

```yaml
show history 5m
```

**Request:**

```yaml
---
- type: history_info
  starting_from: "2019-07-25T14:07:48.637340886Z"
  limit: 50
...
```

**Response:**

```yaml
---
- account_id: "1"
  type: history_info
  log:
    - type: incoming
      timestamp: "2019-07-25T14:08:45.282054937Z"
      output_type: payment
      utxo: d4c7fa31b7adc7d1ad3b66ee65f112fefcebdef4e6bb8b2ffe6bba6359359425
      amount: 10000
      comment: ""
      locked_timestamp: ~
      is_change: false
    - type: outgoing
      timestamp: "2019-07-25T14:09:06.577607244Z"
      tx_hash: 0a3e1c48c335b43b887f559f265cbc54f69a31dea646ef7f714c1bd3edcfc3f1
      fee: 2000
      outputs:
        - utxo: 5e9f51f94ad2084e75708a310a6988f3b523b3623deedfe45a69c17d489524c4
          recipient: 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs
          amount: 1
          rvalue: 0db753d6aba2c0ca26ddfe3b52cd1443e1170086dde24cc34371a651b4867dfa <!-- HERE
          comment: ""
          is_change: false
        - utxo: f2a963e60646e8f17fd24eb5996b1e87393a8e7da07480f8cbcf1e7c561ff69f
          recipient: 7eLHNiyS6qssNNLrskYrV3G7Yade1xdtNQ5HXxao4xXXA1gx5po
          amount: 7999
          comment: Change
          is_change: true
      inputs:
        - d4c7fa31b7adc7d1ad3b66ee65f112fefcebdef4e6bb8b2ffe6bba6359359425
      status: committed
      epoch: 57
    - type: incoming
      timestamp: "2019-07-25T14:09:09.035047175Z"
      output_type: payment
      utxo: f2a963e60646e8f17fd24eb5996b1e87393a8e7da07480f8cbcf1e7c561ff69f
      amount: 7999
      comment: Change
      locked_timestamp: ~
      is_change: true
...
```

Validate the certificate using `validate_certificate` API.

**Console:**

```yaml
validate certificate 5e9f51f94ad2084e75708a310a6988f3b523b3623deedfe45a69c17d489524c4  7eLHNiyS6qssNNLrskYrV3G7Yade1xdtNQ5HXxao4xXXA1gx5po 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs 1 0db753d6aba2c0ca26ddfe3b52cd1443e1170086dde24cc34371a651b4867dfa
```

**Request:**

```yaml
---
- type: validate_certificate
  utxo: 5e9f51f94ad2084e75708a310a6988f3b523b3623deedfe45a69c17d489524c4
  spender: 7eLHNiyS6qssNNLrskYrV3G7Yade1xdtNQ5HXxao4xXXA1gx5po
  recipient: 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs
  amount: 1
  rvalue: 0db753d6aba2c0ca26ddfe3b52cd1443e1170086dde24cc34371a651b4867dfa
...
```

**Response:**

```yaml
---
- type: certificate_valid
...
```

As usual, "error" response is returned on error:

```yaml
---
- type: error
  error: Invalid payment certificate
...
```

Please note that `validate_certificate` is a part of Node API, not Account API. No `account_id` or active account is needed to validate the certificate. 