### PR TITLE
ValueShuffle enhancement

### DIFF
--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -87,12 +87,17 @@ pub struct PublicPaymentInfo {
 pub enum AccountNotification {
     BalanceChanged {
         balance: i64,
+        available_balance: i64,
     },
     SnowballStarted {
         session_id: Hash,
     },
     SnowballCreated {
         tx_hash: Hash,
+        session_id: Hash,
+    },
+    SnowballStopped {
+        tx_hash: Option<Hash>,
         session_id: Hash,
     },
     TransactionStatus {
@@ -229,6 +234,7 @@ pub enum AccountResponse {
     TransactionCreated(TransactionInfo),
     BalanceInfo {
         balance: i64,
+        available_balance: i64,
     },
     KeysInfo {
         account_address: PublicKey,

--- a/wallet/src/metrics.rs
+++ b/wallet/src/metrics.rs
@@ -29,6 +29,12 @@ lazy_static! {
         &["wallet"]
     )
     .unwrap();
+    pub static ref WALLET_AVALIABLE_BALANCES: IntGaugeVec = register_int_gauge_vec!(
+        "stegos_available_wallet_balances",
+        "Active balance per wallet public key",
+        &["wallet"]
+    )
+    .unwrap();
     pub static ref WALLET_CREATEAD_PAYMENTS: IntGaugeVec = register_int_gauge_vec!(
         "stegos_wallet_pay_count",
         "Count of payment txs created per wallet",

--- a/wallet/src/test/account_transaction.rs
+++ b/wallet/src/test/account_transaction.rs
@@ -208,7 +208,7 @@ fn full_transfer() {
         let response = get_request(rx);
         info!("{:?}", response);
         let balance = match response {
-            AccountResponse::BalanceInfo { balance } => balance,
+            AccountResponse::BalanceInfo { balance, .. } => balance,
             _ => panic!("Wrong response to payment request"),
         };
 
@@ -273,7 +273,7 @@ fn create_tx_invalid() {
         let response = get_request(rx);
         info!("{:?}", response);
         let balance = match response {
-            AccountResponse::BalanceInfo { balance } => balance,
+            AccountResponse::BalanceInfo { balance, .. } => balance,
             _ => panic!("Wrong response to payment request"),
         };
 
@@ -730,7 +730,7 @@ fn precondition_each_account_has_tokens(
         new_account.poll();
 
         match get_request(rx) {
-            AccountResponse::BalanceInfo { balance } => {
+            AccountResponse::BalanceInfo { balance, .. } => {
                 dbg!((balance, amount));
                 assert!(balance >= amount);
             }


### PR DESCRIPTION
Now VS can result in 3 ways:
* SignedTransaction(tx, leader) - the same it was before
* UnsignedTransaction(tx) - transaction formed, but not all signatures were collected
* Failure(Error) - fatal failure during protocol run

Also, added `terminate` method to VS, to reset its state and stop further participation in current session (if any)

Closes #1092