### PR TITLE
Update ValidateCertificate API

### DIFF
--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -51,7 +51,6 @@ pub enum NodeRequest {
         utxo: Hash,
         spender: scc::PublicKey,
         recipient: scc::PublicKey,
-        amount: i64,
         rvalue: scc::Fr,
     },
 }
@@ -73,7 +72,13 @@ pub enum NodeResponse {
         hash: Hash,
         status: TransactionStatus,
     },
-    CertificateValid,
+    CertificateValid {
+        epoch: u64,
+        block_hash: Hash,
+        is_final: bool,
+        timestamp: Timestamp,
+        amount: i64,
+    },
     Error {
         error: String,
     },

--- a/src/console.rs
+++ b/src/console.rs
@@ -67,7 +67,7 @@ lazy_static! {
     /// Regex to parse "send" command.
     static ref SEND_COMMAND_RE: Regex = Regex::new(r"\s*(?P<recipient>[0-9a-f]+)\s+(?P<topic>[0-9A-Za-z]+)\s+(?P<msg>.+)$").unwrap();
     /// Regex to parse "validate certificate" command.
-    static ref VALIDATE_CERTIFICATE_COMMAND_RE: Regex = Regex::new(r"\s*(?P<utxo>[0-9a-f]+)\s+(?P<spender>[0-9A-Za-z]+)\s+(?P<recipient>[0-9A-Za-z]+)\s+(?P<amount>[0-9\.]{1,19})\s+(?P<rvalue>[0-9a-f]+)\s*$").unwrap();
+    static ref VALIDATE_CERTIFICATE_COMMAND_RE: Regex = Regex::new(r"\s*(?P<utxo>[0-9a-f]+)\s+(?P<spender>[0-9A-Za-z]+)\s+(?P<recipient>[0-9A-Za-z]+)\s+(?P<rvalue>[0-9a-f]+)\s*$").unwrap();
     /// Regex to parse "use" command.
     static ref USE_COMMAND_RE: Regex = Regex::new(r"\s*(?P<account_id>[0-9A-Za-z]+)\s*$").unwrap();
 }
@@ -209,7 +209,7 @@ impl ConsoleService {
         eprintln!(
             "pay ADDRESS AMOUNT [COMMENT] [/snowball] [/public] [/lock DATETIME] [/fee FEE] [/certificate] - send money"
         );
-        eprintln!("validate certificate UTXO SENDER_ADDRESS RECIPIENT_ADDRESS AMOUNT RVALUE - check that payment certificate is valid");
+        eprintln!("validate certificate UTXO SENDER_ADDRESS RECIPIENT_ADDRESS RVALUE - check that payment certificate is valid");
         eprintln!("msg ADDRESS MESSAGE - send a message via blockchain");
         eprintln!("stake AMOUNT - stake money");
         eprintln!("unstake [AMOUNT] - unstake money");
@@ -267,13 +267,10 @@ impl ConsoleService {
     }
 
     fn help_validate_certificate() {
-        eprintln!(
-            "Usage: validate certificate UTXO SENDER_ADDRESS RECIPIENT_ADDRESS AMOUNT RVALUE"
-        );
+        eprintln!("Usage: validate certificate UTXO SENDER_ADDRESS RECIPIENT_ADDRESS RVALUE");
         eprintln!(" - UTXO - UTXO ID");
         eprintln!(" - SENDER_ADDRESS - senders's address");
         eprintln!(" - RECIPIENT_ADDRESS - recipient's address");
-        eprintln!(" - AMOUNT - amount in μSTG");
         eprintln!(" - RVALUE - decryption key");
         eprintln!();
     }
@@ -565,15 +562,6 @@ impl ConsoleService {
                     return Ok(true);
                 }
             };
-            let amount = caps.name("amount").unwrap().as_str();
-            let amount = match parse_money(amount) {
-                Ok(amount) => amount,
-                Err(e) => {
-                    eprintln!("{}", e);
-                    Self::help_validate_certificate();
-                    return Ok(true);
-                }
-            };
             let rvalue = caps.name("rvalue").unwrap().as_str();
             let rvalue = match scc::Fr::try_from_hex(rvalue) {
                 Ok(r) => r,
@@ -588,7 +576,6 @@ impl ConsoleService {
                 utxo,
                 spender,
                 recipient,
-                amount,
                 rvalue,
             };
             self.send_node_request(request)?

--- a/wallet/src/test/account_transaction.rs
+++ b/wallet/src/test/account_transaction.rs
@@ -151,14 +151,14 @@ fn create_tx_with_certificate() {
                     assert!(output
                         .decrypt_payload(&accounts[0].account_service.account_skey)
                         .is_err());
-                    output
+                    let amount = output
                         .validate_certificate(
                             &accounts[0].account_service.account_pkey,
                             &recipient,
-                            10,
                             &tx.outputs[0].info.rvalue.unwrap(),
                         )
                         .unwrap();
+                    assert_eq!(amount, 10);
                 }
 
                 tx.tx_hash


### PR DESCRIPTION
- Remove `amount from ValidateCertificate request.
- Add `amount`, `epoch`, `block_hash`, `timestamp`, `is_final` to
  CertofocateValid response.

Request:

```yaml
---
- type: validate_certificate
  utxo: 5e9f51f94ad2084e75708a310a6988f3b523b3623deedfe45a69c17d489524c4
  spender: 7eLHNiyS6qssNNLrskYrV3G7Yade1xdtNQ5HXxao4xXXA1gx5po
  recipient: 7fVEggZSzjHtZ6aV7EDExuvJHZJ8Q3rrSivPmdJVFaNVt1CRsEs
  rvalue: 0db753d6aba2c0ca26ddfe3b52cd1443e1170086dde24cc34371a651b4867dfa
...
```

Response:

```yaml
---
- type: certificate_valid
  epoch: 57
  block_hash: d8c0646f76c854601078b1bfaeb6fa69d9cc93d92ae4e425a86abefc1c320438
  is_final: true
  timestamp: "2019-07-25T14:09:18.519078288Z"
  amount: 1
...
```