### PR TITLE
Disable compaction of inputs/outputs during Macro Block creation

### DIFF
--- a/blockchain/src/block.rs
+++ b/blockchain/src/block.rs
@@ -359,10 +359,6 @@ impl MacroBlock {
         for tx in transactions {
             gamma += tx.gamma();
             for input_hash in tx.txins() {
-                // Prune output if exists.outputs.
-                if let Some(_) = outputs.remove(input_hash) {
-                    continue;
-                }
                 if !inputs.insert(input_hash.clone()) {
                     // Can happen due to double-spending in micro-blocks.
                     return Err(TransactionError::DuplicateInput(

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -107,9 +107,9 @@ pub struct NewMacroBlock {
     pub transactions: HashMap<Hash, Transaction>,
     pub statuses: HashMap<Hash, TransactionStatus>,
     #[serde(skip)]
-    pub inputs: Vec<Output>,
+    pub inputs: HashMap<Hash, Output>,
     #[serde(skip)]
-    pub outputs: Vec<Output>,
+    pub outputs: HashMap<Hash, Output>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -120,9 +120,9 @@ pub struct RollbackMicroBlock {
     pub recovered_transaction: HashMap<Hash, Transaction>,
     pub statuses: HashMap<Hash, TransactionStatus>,
     #[serde(skip)]
-    pub inputs: Vec<Output>,
+    pub inputs: HashMap<Hash, Output>,
     #[serde(skip)]
-    pub outputs: Vec<Output>,
+    pub outputs: HashMap<Hash, Output>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -133,9 +133,9 @@ pub struct NewMicroBlock {
     pub transactions: HashMap<Hash, Transaction>,
     pub statuses: HashMap<Hash, TransactionStatus>,
     #[serde(skip)]
-    pub inputs: Vec<Output>,
+    pub inputs: HashMap<Hash, Output>,
     #[serde(skip)]
-    pub outputs: Vec<Output>,
+    pub outputs: HashMap<Hash, Output>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -912,7 +912,7 @@ impl NodeService {
         let mut statuses = HashMap::new();
         let mut transactions = HashMap::new();
         // Remove conflict transactions from the mempool.
-        let tx_info = self.mempool.prune(&inputs, &outputs);
+        let tx_info = self.mempool.prune(inputs.keys(), outputs.keys());
         for (tx_hash, (tx, full)) in tx_info {
             let status = if full {
                 TransactionStatus::Committed { epoch }
@@ -1038,7 +1038,7 @@ impl NodeService {
         let mut statuses = HashMap::new();
         let mut transactions = HashMap::new();
         // Remove conflict transactions from the mempool.
-        let mut tx_info = self.mempool.prune(&inputs, &outputs);
+        let mut tx_info = self.mempool.prune(inputs.keys(), outputs.keys());
         tx_info.extend(
             block_transactions
                 .clone()
@@ -1136,11 +1136,11 @@ impl NodeService {
             validators: self.chain.validators().clone(),
             transactions: HashMap::new(),
             statuses: HashMap::new(),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
+            inputs: HashMap::new(),
+            outputs: HashMap::new(),
         };
         let msg = msg.into();
-        tx.unbounded_send(msg).ok(); // ignore error.
+        tx.unbounded_send(msg).ok(); // ignore error
         self.on_node_notification.push(tx);
         Ok(())
     }

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -315,7 +315,9 @@ mod test {
                 _ => panic!(),
             }
 
-            mempool.prune(&inputs, &outputs);
+            let input_hashes: Vec<Hash> = inputs.iter().map(Hash::digest).collect();
+            let output_hashes: Vec<Hash> = outputs.iter().map(Hash::digest).collect();
+            mempool.prune(input_hashes.iter(), output_hashes.iter());
             validate_external_transaction(&tx, &mempool, &chain, timestamp, payment_fee, stake_fee)
                 .expect("transaction is valid");
             validate_external_transaction(
@@ -477,7 +479,9 @@ mod test {
                 _ => panic!(),
             }
 
-            mempool.prune(&[], &outputs);
+            let input_hashes: Vec<Hash> = vec![];
+            let output_hashes: Vec<Hash> = outputs.iter().map(Hash::digest).collect();
+            mempool.prune(input_hashes.iter(), output_hashes.iter());
         }
     }
 }


### PR DESCRIPTION
Keep all inputs and outputs in the block even overlapping.