### PR TITLE
fix ValueShuffle 

### DIFF
--- a/crypto/src/scc/mod.rs
+++ b/crypto/src/scc/mod.rs
@@ -1248,4 +1248,44 @@ pub mod tests {
         let timing = start.elapsed().unwrap();
         println!("Const Time (1111...) = {:?}", timing / niter);
     }
+
+    #[test]
+    fn check_hex_conversions() {
+        let str = "1000000000000000000000000000000000000000000000000000000000000000";
+        let x = Fr::try_from_hex(str).expect("ok");
+        let rep = x.to_bytes();
+        println!("x = {:?}", x);
+        println!("rep = {:?}", rep);
+        assert!(
+            rep == [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 16
+            ]
+        );
+
+        let str = "1000000000000000000000000000000014DEF9DEA2F79CD65812631A5CF5D3ED";
+        let _x = Fr::try_from_hex(str).expect_err("ok");
+
+        let str = "0000000000000000000000000000000000000000000000000000000000000001";
+        let x = Fr::try_from_hex(str).expect("ok");
+        let rep = x.to_bytes();
+        println!("x = {:?}", x);
+        assert!(
+            rep == [
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        );
+
+        let str = "1";
+        let x = Fr::try_from_hex(str).expect("ok");
+        let rep = x.to_bytes();
+        println!("x = {:?}", x);
+        assert!(
+            rep == [
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        );
+    }
 }

--- a/wallet/protos/valueshuffle.proto
+++ b/wallet/protos/valueshuffle.proto
@@ -30,7 +30,7 @@ message CloakedVals {
     DcMatrix matrix = 1;
     stegos.crypto.Fr gamma_sum = 2;
     stegos.crypto.Fr fee_sum = 3;
-    repeated stegos.crypto.DiceMixParticipantID parts = 4;
+    repeated stegos.crypto.DiceMixParticipantID drops = 4;
     repeated stegos.crypto.Hash cloaks = 5;
 }
 

--- a/wallet/src/valueshuffle/protos.rs
+++ b/wallet/src/valueshuffle/protos.rs
@@ -74,10 +74,10 @@ impl ProtoConvert for VsPayload {
                 body.set_matrix(dcsheets);
                 body.set_gamma_sum(gamma_sum.into_proto());
                 body.set_fee_sum(fee_sum.into_proto());
-                for (p, h) in cloaks {
-                    body.parts.push(p.into_proto());
+                cloaks.iter().for_each(|(p, h)| {
+                    body.drops.push(p.into_proto());
                     body.cloaks.push(h.into_proto());
-                }
+                });
                 msg.set_cloakedvals(body);
             }
             VsPayload::Signature { sig } => {
@@ -120,14 +120,14 @@ impl ProtoConvert for VsPayload {
                     }
                     matrix.push(rows);
                 }
+                let gamma_sum = Fr::from_proto(msg.get_gamma_sum())?;
+                let fee_sum = Fr::from_proto(msg.get_fee_sum())?;
                 let mut cloaks: HashMap<ParticipantID, Hash> = HashMap::new();
-                for (part, hash) in msg.parts.iter().zip(msg.cloaks.iter()) {
-                    let p = ParticipantID::from_proto(part)?;
+                for (drop, hash) in msg.drops.iter().zip(msg.cloaks.iter()) {
+                    let p = ParticipantID::from_proto(drop)?;
                     let h = Hash::from_proto(hash)?;
                     cloaks.insert(p, h);
                 }
-                let gamma_sum = Fr::from_proto(msg.get_gamma_sum())?;
-                let fee_sum = Fr::from_proto(msg.get_fee_sum())?;
                 VsPayload::CloakedVals {
                     matrix,
                     gamma_sum,


### PR DESCRIPTION
- should not enter dc_decode when number of participants falls below expected number from earlier matrix construction

It is apparent that checking self.pending_participants is not sufficient to ensure that original number of participants remain. So we were calling DiceMix::dc_decode() with inconsistent numbers of matrices when there had been drop out participants. Not all dropouts were tallied by self.pending_participants. 

(Perhaps participants who supplied invalid messages were also removed from pending_participants?) 

This patch to ValueShuffle should prevent a large number of panics that have been experienced recently. No material change to DiceMix (just some test code at the bottom, and removed yesterday's patch to count MIA's). This time if DiceMix panics then something is seriously wrong.