### PR TITLE
Refactor ValueShuffle

### DIFF
--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -38,4 +38,6 @@ pub enum WalletError {
     InvalidUTXOData,
     #[fail(display = "Nothing to re-stake")]
     NothingToRestake,
+    #[fail(display = "Snownall already started")]
+    SnowballBusy,
 }

--- a/wallet/src/test/account_transaction.rs
+++ b/wallet/src/test/account_transaction.rs
@@ -820,6 +820,7 @@ fn create_vs_tx() {
         s.filter_broadcast(&[stegos_node::VIEW_CHANGE_TOPIC]);
         s.filter_unicast(&[stegos_node::CHAIN_LOADER_TOPIC]);
         debug!("===== ANONCING TXPOOL =====");
+        accounts.iter_mut().for_each(AccountSandbox::poll);
         s.deliver_unicast(stegos_node::txpool::POOL_ANNOUNCE_TOPIC);
 
         debug!("===== VS STARTED NEW POOL: Send::SharedKeying =====");

--- a/wallet/src/valueshuffle/error.rs
+++ b/wallet/src/valueshuffle/error.rs
@@ -28,24 +28,8 @@ use failure::Fail;
 
 #[derive(Debug, Fail)]
 pub enum VsError {
-    #[fail(display = "Can't form SuperTransaction")]
-    VsFail, // if can't achieve any result in ValueShuffle session
-    #[fail(display = "Too many UTXOs proposed")]
-    VsTooManyUTXO,
-    #[fail(display = "Bad UTXO Encrypted Payload Keying")]
-    VsBadUTXO, // UTXO has bad encryption keying on payload
-    #[fail(display = "Bad TXIN Reference")]
-    VsBadTXIN, // TXIN not accessible with provided ownership sig
-    #[fail(display = "Bad Transaction Attempted")]
-    VsBadTransaction, // user output plus fee not equal TXIN input
     #[fail(display = "We aren't a participant")]
     VsNotInParticipantList,
-    #[fail(display = "ValueShuffle already started")]
-    VsBusy,
-    #[fail(display = "ValueShuffle not in session")]
-    VsNotInSession,
-    #[fail(display = "Invalid message")]
-    VsInvalidMessage,
     #[fail(display = "Not enough participants: {}", _0)]
     VsTooFewParticipants(usize),
 }


### PR DESCRIPTION
- Convert ValueShufle to oneshot Future.
- Remove wallet_tx_info and queue_transaction();
- Fix handling of non-fatal errors.
- Remove try_xxx() wrappers.
- Move FacilitatorChanged handling to AccountService.