### PR TITLE
Don't send dummy NewMacroBlock notification on the start

### DIFF
--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -66,7 +66,12 @@ pub enum NodeResponse {
     EscrowInfo(EscrowInfo),
     BlockPopped,
     #[serde(skip)]
-    AccountRecovered(AccountRecoveryState),
+    AccountRecovered {
+        recovery_state: AccountRecoveryState,
+        epoch: u64,
+        facilitator_pkey: pbc::PublicKey,
+        last_macro_block_timestamp: Timestamp,
+    },
     #[serde(skip)]
     AddTransaction {
         hash: Hash,


### PR DESCRIPTION
This hack was needed to notify AccountService and TransactionPoolService
about current facilitator on the start. Patch NodeService to call TxPool
directly on init(). Patch NodeService to include information about
facilitator to AccountRecovered message for AccountService.