### PR TITLE
Clean up Snowball

### DIFF
--- a/network/src/gatekeeper/behavior.rs
+++ b/network/src/gatekeeper/behavior.rs
@@ -117,9 +117,7 @@ impl<TSubstream> Gatekeeper<TSubstream> {
                     });
                     desired_addesses.insert(maddr);
                 }
-                Err(e) => {
-                    error!(target: "stegos_network::gatekeeper", "failed to parse address: {}, error: {}", addr, e)
-                }
+                Err(e) => error!(target: "stegos_network::gatekeeper", "failed to parse address: {}, error: {}", addr, e),
             }
         }
 

--- a/network/src/libp2p_network/mod.rs
+++ b/network/src/libp2p_network/mod.rs
@@ -624,9 +624,7 @@ where
                                         })
                                 }
                             }
-                            Err(e) => {
-                                error!(target:"stegos_network::delivery", "Failure decoding unicast message: {}", e)
-                            }
+                            Err(e) => error!(target:"stegos_network::delivery", "Failure decoding unicast message: {}", e),
                         }
                         return;
                     }

--- a/wallet/protos/snowball.proto
+++ b/wallet/protos/snowball.proto
@@ -19,6 +19,7 @@ message DcMatrix {
 message SharedKeying {
     stegos.crypto.PublicKey pkey = 1;
     stegos.crypto.Pt ksig = 2;
+    stegos.crypto.SecureSignature signature = 3;
 }
 
 message Commitment {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -410,6 +410,7 @@ impl UnsealedAccountService {
         let snowball = Snowball::new(
             self.account_skey.clone(),
             self.account_pkey.clone(),
+            self.network_skey.clone(),
             self.network_pkey.clone(),
             self.network.clone(),
             self.node.clone(),

--- a/wallet/src/snowball/error.rs
+++ b/wallet/src/snowball/error.rs
@@ -32,4 +32,6 @@ pub enum SnowballError {
     NotInParticipantList,
     #[fail(display = "Not enough participants: {}", _0)]
     TooFewParticipants(usize),
+    #[fail(display = "Timeout even after we have finished")]
+    WildTimer,
 }

--- a/wallet/src/snowball/message.rs
+++ b/wallet/src/snowball/message.rs
@@ -29,6 +29,7 @@ use stegos_crypto::dicemix::ParticipantID;
 use stegos_crypto::hash::Hash;
 use stegos_crypto::hash::Hashable;
 use stegos_crypto::hash::Hasher;
+use stegos_crypto::pbc;
 use stegos_crypto::scc::Fr;
 use stegos_crypto::scc::Pt;
 use stegos_crypto::scc::PublicKey;
@@ -42,6 +43,7 @@ pub(crate) enum SnowballPayload {
     SharedKeying {
         pkey: PublicKey,
         ksig: Pt,
+        signature: pbc::Signature,
     },
     Commitment {
         cmt: Hash,
@@ -73,7 +75,11 @@ pub(crate) struct SnowballMessage {
 impl fmt::Display for SnowballPayload {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SnowballPayload::SharedKeying { pkey, ksig } => write!(
+            SnowballPayload::SharedKeying {
+                pkey,
+                ksig,
+                signature: _,
+            } => write!(
                 f,
                 "VsPayload::SharedKeying( pkey: {:?}, ksig: {:?})",
                 pkey, ksig
@@ -121,9 +127,14 @@ impl Hashable for SnowballPayload {
             });
         }
         match self {
-            SnowballPayload::SharedKeying { pkey, ksig } => {
+            SnowballPayload::SharedKeying {
+                pkey,
+                ksig,
+                signature,
+            } => {
                 pkey.hash(state);
                 ksig.hash(state);
+                signature.hash(state);
             }
             SnowballPayload::Commitment { cmt } => {
                 cmt.hash(state);

--- a/wallet/src/storage.rs
+++ b/wallet/src/storage.rs
@@ -850,5 +850,4 @@ mod test {
             assert_eq!(t, time + Duration::from_millis(id as u64));
         }
     }
-
 }


### PR DESCRIPTION
Clean up message handling and phase dispatch
use std::mem::replace() where appropriate
rename some structure slots to better indicate purpose
remove unused or redundant dictionaries

Rebase on latest dev branch, absorbing Vladimir's changes from this morning
other formatting changes, courtesy of newer Rust cargo fmt.

New event handling is single point of control state machine