### PR TITLE
Streamline Snowball state machine

### DIFF
--- a/crypto/src/scc/mod.rs
+++ b/crypto/src/scc/mod.rs
@@ -646,6 +646,10 @@ impl PartialEq<Pt> for Pt {
 // -----------------------------------------------------------------------
 
 impl SecretKey {
+    pub fn zero() -> Self {
+        SecretKey::from(Fr::zero())
+    }
+
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
@@ -741,7 +745,7 @@ impl fmt::Debug for PublicKey {
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = self.to_hex();
-        write!(f, "PublicKey({}...{})", &s[0..7], &s[57..64])
+        write!(f, "{}", &s[0..7])
     }
 }
 

--- a/wallet/src/snowball/error.rs
+++ b/wallet/src/snowball/error.rs
@@ -28,10 +28,6 @@ use failure::Fail;
 
 #[derive(Debug, Fail)]
 pub enum SnowballError {
-    #[fail(display = "We aren't a participant")]
-    NotInParticipantList,
     #[fail(display = "Not enough participants: {}", _0)]
     TooFewParticipants(usize),
-    #[fail(display = "Timeout even after we have finished")]
-    WildTimer,
 }


### PR DESCRIPTION
- Merge PoolState and MessageState into one enum.
- Remove timer_context.
- Remove future_facilitator.
- Use timer for PoolWait.
- Improve logging.