### PR TITLE
Snowball Instrumentation

### DIFF
--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -37,7 +37,7 @@ mod transaction;
 
 use self::error::WalletError;
 use self::recovery::recovery_to_account_skey;
-use self::snowball::{Snowball, SnowballOutput, State as SnowballState};
+use self::snowball::{Snowball, SnowballOutput, SnowballTestPlan, State as SnowballState};
 use self::storage::*;
 use self::transaction::*;
 use api::*;
@@ -418,7 +418,7 @@ impl UnsealedAccountService {
                 .is_none());
         }
 
-        let snowball = Snowball::new(
+        let mut snowball = Snowball::new(
             self.account_skey.clone(),
             self.account_pkey.clone(),
             self.network_pkey.clone(),
@@ -429,6 +429,11 @@ impl UnsealedAccountService {
             outputs,
             fee,
         );
+        // force innocuous use of the set_test_plan function to satisfy Rust...
+        snowball.set_test_plan(SnowballTestPlan::StopCommunication(
+            snowball::State::Started,
+            None,
+        ));
 
         metrics::WALLET_CREATEAD_SECURE_PAYMENTS
             .with_label_values(&[&String::from(&self.account_pkey)])

--- a/wallet/src/snowball/message.rs
+++ b/wallet/src/snowball/message.rs
@@ -97,18 +97,18 @@ impl fmt::Debug for SnowballPayload {
         match self {
             SnowballPayload::SharedKeying { pkey, ksig } => write!(
                 f,
-                "VsPayload::SharedKeying( pkey: {:?}, ksig: {:?})",
+                "SnowballPayload::SharedKeying( pkey: {:?}, ksig: {:?})",
                 pkey, ksig
             ),
             SnowballPayload::Commitment { cmt } => {
-                write!(f, "VsPayload::Commitment( cmt: {})", cmt)
+                write!(f, "SnowballPayload::Commitment( cmt: {})", cmt)
             }
-            SnowballPayload::CloakedVals { .. } => write!(f, "VsPayload::CloakedVals(...)"),
+            SnowballPayload::CloakedVals { .. } => write!(f, "SnowballPayload::CloakedVals(...)"),
             SnowballPayload::Signature { sig } => {
-                write!(f, "VsPayload::Signature( sig: {:?})", sig)
+                write!(f, "SnowballPayload::Signature( sig: {:?})", sig)
             }
             SnowballPayload::SecretKeying { skey, .. } => {
-                write!(f, "VsPayload::SecretKeying( skey: {:?})", skey)
+                write!(f, "SnowballPayload::SecretKeying( skey: {:?})", skey)
             }
         }
     }


### PR DESCRIPTION
initial commit - won't yet compile, but based of latest dev 08/13/19

Add a test instrument that permits freshly constructed Snowball instances to be told to fail in communicating with other or all participants after some state has completed work.
