### PR TITLE
Support JSON formatting in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "rustyline 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stegos_api 0.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ tempdir = "0.3"
 rpassword = "4.0"
 libc = "0.2"
 atty = "0.2"
+serde_json = "1.0"
 
 [build-dependencies]
 failure = "0.1"

--- a/src/bin/stegos/main.rs
+++ b/src/bin/stegos/main.rs
@@ -21,6 +21,7 @@
 
 mod console;
 
+use crate::console::Formatter;
 use clap;
 use clap::{App, Arg};
 use console::ConsoleService;
@@ -88,6 +89,17 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("formatter")
+                .short("f")
+                .long("formatter")
+                .env("FORMATTER")
+                .value_name("FORMATTER")
+                .help("Formatter to use: yaml or json")
+                .default_value("yaml")
+                .possible_values(&["json", "yaml"])
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("verbose")
                 .help("Change verbosity level")
                 .short("v")
@@ -128,9 +140,11 @@ fn main() {
             std::process::exit(1);
         }
     };
+    let formatter = Formatter::from_str(args.value_of("formatter").unwrap()).unwrap();
 
     let mut rt = Runtime::new().expect("Failed to initialize tokio");
-    let console_service = ConsoleService::new(name, version, uri, api_token, history_file);
+    let console_service =
+        ConsoleService::new(name, version, uri, api_token, history_file, formatter);
     rt.block_on(console_service)
         .expect("errors are handled earlier");
 }


### PR DESCRIPTION
Add -f/--formatter option to CLI to choose between `yaml` and `json`
formatters.