### PR TITLE
Fr from Hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2405,15 +2405,15 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_api 0.2.0",
- "stegos_blockchain 0.2.0",
- "stegos_consensus 0.2.0",
- "stegos_crypto 0.2.0",
- "stegos_keychain 0.2.0",
- "stegos_network 0.4.0",
- "stegos_node 0.2.0",
- "stegos_serialization 0.2.0",
- "stegos_wallet 0.2.0",
+ "stegos_api 1.0.0",
+ "stegos_blockchain 1.0.0",
+ "stegos_consensus 1.0.0",
+ "stegos_crypto 1.0.0",
+ "stegos_keychain 1.0.0",
+ "stegos_network 1.0.0",
+ "stegos_node 1.0.0",
+ "stegos_serialization 1.0.0",
+ "stegos_wallet 1.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "stegos_api"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2434,10 +2434,10 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_crypto 0.2.0",
- "stegos_network 0.4.0",
- "stegos_node 0.2.0",
- "stegos_wallet 0.2.0",
+ "stegos_crypto 1.0.0",
+ "stegos_network 1.0.0",
+ "stegos_node 1.0.0",
+ "stegos_wallet 1.0.0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.22.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "stegos_blockchain"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2467,14 +2467,14 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_crypto 0.2.0",
- "stegos_serialization 0.2.0",
+ "stegos_crypto 1.0.0",
+ "stegos_serialization 1.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stegos_consensus"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2484,15 +2484,15 @@ dependencies = [
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_blockchain 0.2.0",
- "stegos_crypto 0.2.0",
- "stegos_keychain 0.2.0",
- "stegos_serialization 0.2.0",
+ "stegos_blockchain 1.0.0",
+ "stegos_crypto 1.0.0",
+ "stegos_keychain 1.0.0",
+ "stegos_serialization 1.0.0",
 ]
 
 [[package]]
 name = "stegos_crypto"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base58check 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2523,13 +2523,13 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_serialization 0.2.0",
- "vdf_field 0.1.0",
+ "stegos_serialization 1.0.0",
+ "vdf_field 1.0.0",
 ]
 
 [[package]]
 name = "stegos_keychain"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2538,14 +2538,14 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_crypto 0.2.0",
- "stegos_serialization 0.2.0",
+ "stegos_crypto 1.0.0",
+ "stegos_serialization 1.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stegos_network"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2558,7 +2558,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0",
+ "libp2p 1.0.0",
  "libp2p-core 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core-derive 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-dns 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2576,8 +2576,8 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_crypto 0.2.0",
- "stegos_serialization 0.2.0",
+ "stegos_crypto 1.0.0",
+ "stegos_serialization 1.0.0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "stegos_node"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2612,11 +2612,11 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_blockchain 0.2.0",
- "stegos_consensus 0.2.0",
- "stegos_crypto 0.2.0",
- "stegos_network 0.4.0",
- "stegos_serialization 0.2.0",
+ "stegos_blockchain 1.0.0",
+ "stegos_consensus 1.0.0",
+ "stegos_crypto 1.0.0",
+ "stegos_network 1.0.0",
+ "stegos_serialization 1.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "stegos_serialization"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "stegos_wallet"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2653,12 +2653,12 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stegos_blockchain 0.2.0",
- "stegos_crypto 0.2.0",
- "stegos_keychain 0.2.0",
- "stegos_network 0.4.0",
- "stegos_node 0.2.0",
- "stegos_serialization 0.2.0",
+ "stegos_blockchain 1.0.0",
+ "stegos_crypto 1.0.0",
+ "stegos_keychain 1.0.0",
+ "stegos_network 1.0.0",
+ "stegos_node 1.0.0",
+ "stegos_serialization 1.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vdf_field"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "blake2b_simd 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
change hash to Fr to utilize right shifing of hash value to range (2^251, 2^252)

        // With this change, 97% of all hashes will
        // produce an Fr value in the range (2^251, 2^252). 
        // Whereas, before, a modular wrapping would keep only
        // about 50% of all hashes in that range.
        //
        // Hence we significantly increase the probability of
        // having many mixing bits in Fr multiplications.
