### PR TITLE
Fix Snowball to avoid DiceMix panics

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -108,6 +108,15 @@ pub enum CryptoError {
     NetworkPrefixAlreadySet(&'static str),
     #[fail(display = "Failed to set network prefix from two threads.")]
     NetworkPrefixSetFailed,
+
+    #[fail(display = "No solution in DiceMix")]
+    DiceMixNoSolution,
+    #[fail(display = "Non-monic root in DiceMix")]
+    DiceMixNonMonicRoot,
+    #[fail(display = "Not enough roots in DiceMix")]
+    DiceMixNotEnoughRoots,
+    #[fail(display = "Internal error in flint solver, return value = {}", _0)]
+    DiceMixInternalError(i32),
 }
 
 impl From<hex::FromHexError> for CryptoError {

--- a/wallet/src/snowball/mod.rs
+++ b/wallet/src/snowball/mod.rs
@@ -1490,7 +1490,7 @@ impl Snowball {
         sdebug!(self, "txins hash: {}", state.result());
 
         // get the cloaks we put there for all missing participants
-        let msgs = dc_decode(
+        let msgs = match dc_decode(
             &self.participants,
             &self.matrices,
             &self.my_participant_id,
@@ -1498,7 +1498,13 @@ impl Snowball {
             ROWS_FIXED_SIZE,
             &self.excl_participants, // the excluded participants
             &self.all_excl_cloaks,
-        );
+        ) {
+            Err(_) => {
+                swarn!(self, "DiceMix Error");
+                return self.start();
+            }
+            Ok(ms) => ms,
+        };
         sdebug!(self, "nbr msgs = {}", msgs.len());
 
         let mut all_utxos = Vec::<UTXO>::new();


### PR DESCRIPTION
This patch provides error handling from DiceMix errors, instead of panicking. It doesn't solve the reason for why the errors are happening. But if an error arises in DiceMix, the attempt at forming a provisional super-transaction is halted, a log message is printed, and the session is restarted for that node.

In all likelihood this will eventually lead to the node becoming orphaned from the group, and he will fail this Snowball attempt. He will then have to renegotiate between wallet and facilitator to try again in another Snowball session.

I can only guess that the reason for the DiceMix errors are that the node failed to see some participants and now receives cloaked data from others, which includes cloaking for the nodes he doesn't know about. And since their cloaking includes the participants not known to the node, he can't successfully uncloak the data. He then has no choice but to give up and try again for another session where he can hear all the participants.