### PR TITLE
Add `accounts_info` as an alias for `list_accounts`

### DIFF
--- a/src/bin/stegos/console.rs
+++ b/src/bin/stegos/console.rs
@@ -439,6 +439,18 @@ impl ConsoleService {
     }
 
     fn send_wallet_control_request(&mut self, request: WalletControlRequest) -> Result<(), Error> {
+        match &request {
+            WalletControlRequest::CreateAccount { .. }
+            | WalletControlRequest::RecoverAccount { .. } => {
+                // Print passwords only if Trace level is enabled.
+                if log::log_enabled!(log::Level::Trace) {
+                    self.print(&request);
+                }
+            }
+            _ => {
+                self.print(&request);
+            }
+        }
         let request = WalletRequest::WalletControlRequest(request);
         let request = Request {
             kind: RequestKind::WalletsRequest(request),
@@ -922,7 +934,7 @@ impl ConsoleService {
             let request = NodeRequest::SubscribeStatus {};
             self.send_node_request(request)?
         } else if msg == "show accounts" {
-            let request = WalletControlRequest::ListAccounts {};
+            let request = WalletControlRequest::AccountsInfo {};
             self.send_wallet_control_request(request)?;
         } else if msg == "create account" {
             let password = read_password_with_confirmation()?;

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -235,7 +235,8 @@ pub enum AccountRequest {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
 pub enum WalletControlRequest {
-    ListAccounts {},
+    ListAccounts {}, // legacy
+    AccountsInfo {},
     CreateAccount {
         password: String,
     },

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -2198,7 +2198,7 @@ impl WalletService {
         request: WalletControlRequest,
     ) -> Result<WalletControlResponse, Error> {
         match request {
-            WalletControlRequest::ListAccounts {} => {
+            WalletControlRequest::ListAccounts {} | WalletControlRequest::AccountsInfo {} => {
                 let accounts = self
                     .accounts
                     .iter()


### PR DESCRIPTION
Use the common style for naming all API methods.