### PR TITLE
Zap locked_timestamp from UTXO

### DIFF
--- a/blockchain/protos/blockchain.proto
+++ b/blockchain/protos/blockchain.proto
@@ -14,7 +14,7 @@ message PaymentPayloadData {
 message PaymentOutput {
     stegos.crypto.PublicKey recipient = 1;
     stegos.crypto.BulletProof proof = 2;
-    uint64 locked_timestamp = 3;
+    //uint64 locked_timestamp = 3;
     stegos.crypto.Pt ag = 4;
     bytes payload = 5;
 }
@@ -23,7 +23,7 @@ message PublicPaymentOutput {
     stegos.crypto.PublicKey recipient = 1;
     int64 serno = 2;
     int64 amount = 3;
-    uint64 locked_timestamp = 4;
+    //uint64 locked_timestamp = 4;
 }
 
 message StakeOutput {

--- a/blockchain/src/blockchain.rs
+++ b/blockchain/src/blockchain.rs
@@ -1264,14 +1264,9 @@ impl Blockchain {
         {
             let block_reward = self.cfg.block_reward;
             let data = PaymentPayloadData::Comment("Block reward".to_string());
-            let (output, gamma, _rvalue) = PaymentOutput::with_payload(
-                None,
-                &beneficiary_pkey,
-                block_reward,
-                data.clone(),
-                None,
-            )
-            .expect("invalid keys");
+            let (output, gamma, _rvalue) =
+                PaymentOutput::with_payload(None, &beneficiary_pkey, block_reward, data.clone())
+                    .expect("invalid keys");
 
             info!(
                 "Created reward UTXO: hash={}, amount={}, data={:?}",

--- a/blockchain/src/protos.rs
+++ b/blockchain/src/protos.rs
@@ -441,12 +441,6 @@ impl ProtoConvert for PaymentOutput {
         let mut proto = blockchain::PaymentOutput::new();
         proto.set_recipient(self.recipient.into_proto());
         proto.set_proof(self.proof.into_proto());
-        let timestamp: u64 = if let Some(locked_timestamp) = self.locked_timestamp {
-            locked_timestamp.into()
-        } else {
-            0u64
-        };
-        proto.set_locked_timestamp(timestamp);
         proto.set_ag(self.ag.into_proto());
         proto.set_payload(self.payload.clone());
         proto
@@ -455,16 +449,11 @@ impl ProtoConvert for PaymentOutput {
     fn from_proto(proto: &Self::Proto) -> Result<Self, Error> {
         let recipient = PublicKey::from_proto(proto.get_recipient())?;
         let proof = BulletProof::from_proto(proto.get_proof())?;
-        let locked_timestamp: Option<Timestamp> = match proto.get_locked_timestamp() {
-            0 => None,
-            n => Some(n.into()),
-        };
         let ag = Pt::from_proto(proto.get_ag())?;
         let payload = proto.get_payload().to_vec();
         Ok(PaymentOutput {
             recipient,
             proof,
-            locked_timestamp,
             ag,
             payload,
         })
@@ -478,13 +467,6 @@ impl ProtoConvert for PublicPaymentOutput {
         proto.set_recipient(self.recipient.into_proto());
         proto.set_amount(self.amount);
         proto.set_serno(self.serno);
-        let timestamp: u64 = if let Some(locked_timestamp) = self.locked_timestamp {
-            locked_timestamp.into()
-        } else {
-            0u64
-        };
-
-        proto.set_locked_timestamp(timestamp);
         proto
     }
 
@@ -492,15 +474,10 @@ impl ProtoConvert for PublicPaymentOutput {
         let recipient = PublicKey::from_proto(proto.get_recipient())?;
         let amount = proto.get_amount();
         let serno = proto.get_serno();
-        let locked_timestamp: Option<Timestamp> = match proto.get_locked_timestamp() {
-            0 => None,
-            n => Some(n.into()),
-        };
         Ok(PublicPaymentOutput {
             recipient,
             amount,
             serno,
-            locked_timestamp,
         })
     }
 }
@@ -1190,7 +1167,7 @@ mod tests {
         let output: Output = output.into();
         roundtrip(&output);
 
-        let output = PublicPaymentOutput::new_locked(&pkey, 100, Timestamp::now());
+        let output = PublicPaymentOutput::new_locked(&pkey, 100);
 
         roundtrip(&output);
         let output: Output = output.into();

--- a/blockchain/src/test.rs
+++ b/blockchain/src/test.rs
@@ -325,7 +325,7 @@ pub fn create_fake_micro_block(
     let coinbase_tx = {
         let data = PaymentPayloadData::Comment(format!("Block reward"));
         let (output, gamma, _rvalue) =
-            PaymentOutput::with_payload(None, &leader.account_pkey, block_reward, data, None)
+            PaymentOutput::with_payload(None, &leader.account_pkey, block_reward, data)
                 .expect("invalid keys");
         CoinbaseTransaction {
             block_reward,
@@ -482,7 +482,7 @@ pub fn create_micro_block_with_coinbase(
 
         let data = PaymentPayloadData::Comment(format!("Block {}", comment));
         let (output_fee, gamma_fee, _rvalue) =
-            PaymentOutput::with_payload(None, &keys.account_pkey, amount, data.clone(), None)
+            PaymentOutput::with_payload(None, &keys.account_pkey, amount, data.clone())
                 .expect("invalid keys");
         gamma -= gamma_fee;
 

--- a/blockchain/src/validation.rs
+++ b/blockchain/src/validation.rs
@@ -26,7 +26,7 @@ use crate::blockchain::{Blockchain, ChainInfo};
 use crate::election::mix;
 use crate::error::{BlockError, BlockchainError, SlashingError, TransactionError};
 use crate::multisignature::check_multi_signature;
-use crate::output::{Output, OutputError, PublicPaymentOutput};
+use crate::output::{Output, PublicPaymentOutput};
 use crate::slashing::confiscate_tx;
 use crate::timestamp::Timestamp;
 use crate::transaction::{
@@ -349,20 +349,15 @@ impl SlashingTransaction {
                     Output::PublicPaymentOutput(PublicPaymentOutput {
                         recipient: recipient1,
                         amount: amount1,
-                        locked_timestamp: locked_timestamp1,
                         serno: _,
                     }),
                     Output::PublicPaymentOutput(PublicPaymentOutput {
                         recipient: recipient2,
                         amount: amount2,
-                        locked_timestamp: locked_timestamp2,
                         serno: _,
                     }),
                 ) => {
-                    if recipient1 != recipient2
-                        || amount1 != amount2
-                        || locked_timestamp1 != locked_timestamp2
-                    {
+                    if recipient1 != recipient2 || amount1 != amount2 {
                         return Err(SlashingError::IncorrectTxins(tx_hash).into());
                     }
                 }
@@ -665,16 +660,6 @@ impl Blockchain {
                     }
                 }
             };
-            if let Some(timestamp) = input.locked_timestamp() {
-                if timestamp >= self.last_macro_block_timestamp() {
-                    return Err(OutputError::UtxoLocked(
-                        *input_hash,
-                        timestamp,
-                        self.last_macro_block_timestamp(),
-                    )
-                    .into());
-                }
-            }
             inputs.push(input);
         }
 
@@ -886,16 +871,6 @@ impl Blockchain {
                 }
             };
 
-            if let Some(timestamp) = input.locked_timestamp() {
-                if timestamp >= self.last_macro_block_timestamp() {
-                    return Err(OutputError::UtxoLocked(
-                        *input_hash,
-                        timestamp,
-                        self.last_macro_block_timestamp(),
-                    )
-                    .into());
-                }
-            }
             // Check that the input is not claimed by other transactions.
             if inputs_set.contains(input_hash) {
                 return Err(TransactionError::DuplicateInput(tx_hash, input_hash.clone()).into());

--- a/node/src/mempool.rs
+++ b/node/src/mempool.rs
@@ -326,7 +326,7 @@ impl Mempool {
 
                 let data = PaymentPayloadData::Comment(format!("Block {}", comment));
                 let (output_fee, gamma_fee, _rvalue) =
-                    PaymentOutput::with_payload(None, recipient_pkey, amount, data.clone(), None)
+                    PaymentOutput::with_payload(None, recipient_pkey, amount, data.clone())
                         .expect("invalid keys");
                 gamma -= gamma_fee;
 

--- a/node/src/validation.rs
+++ b/node/src/validation.rs
@@ -25,7 +25,7 @@ use crate::error::*;
 use crate::mempool::Mempool;
 use failure::Error;
 use stegos_blockchain::Timestamp;
-use stegos_blockchain::{Blockchain, Output, OutputError, Transaction, TransactionError};
+use stegos_blockchain::{Blockchain, Output, Transaction, TransactionError};
 use stegos_crypto::hash::Hash;
 
 ///
@@ -73,17 +73,6 @@ pub(crate) fn validate_external_transaction(
                 return Err(TransactionError::MissingInput(tx_hash, input_hash.clone()).into());
             }
         };
-
-        if let Some(timestamp) = input.locked_timestamp() {
-            if timestamp >= chain.last_macro_block_timestamp() {
-                return Err(OutputError::UtxoLocked(
-                    *input_hash,
-                    timestamp,
-                    chain.last_macro_block_timestamp(),
-                )
-                .into());
-            }
-        }
 
         // Check that the input is not claimed by other transactions.
         if mempool.contains_input(input_hash) {

--- a/src/bin/bootstrap.rs
+++ b/src/bin/bootstrap.rs
@@ -278,7 +278,7 @@ fn main() {
     };
     let output_data = PaymentPayloadData::Comment("Genesis".to_string());
     let (output, outputs_gamma, _rvalue) =
-        PaymentOutput::with_payload(None, &beneficiary_pkey, payout, output_data, None)
+        PaymentOutput::with_payload(None, &beneficiary_pkey, payout, output_data)
             .expect("invalid keys");
     outputs.push(output.into());
 

--- a/wallet/examples/show_utxo_chunks.rs
+++ b/wallet/examples/show_utxo_chunks.rs
@@ -45,8 +45,8 @@ fn main() {
     let tstamp = Timestamp::now();
     let data = PaymentPayloadData::Comment("Testing".to_string());
 
-    let (out, gamma, _rvalue) = PaymentOutput::with_payload(None, &pkey, 1500, data, None)
-        .expect("Can't produce payment output");
+    let (out, gamma, _rvalue) =
+        PaymentOutput::with_payload(None, &pkey, 1500, data).expect("Can't produce payment output");
     let msg = out.into_buffer().expect("can't serialize UTXO");
     println!("UTXO len = {}", msg.len());
     let row = split_message(&msg, None);

--- a/wallet/src/api.rs
+++ b/wallet/src/api.rs
@@ -65,8 +65,6 @@ pub struct PaymentInfo {
     #[serde(flatten)]
     pub data: PaymentPayloadData,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub locked_timestamp: Option<Timestamp>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_timestamp: Option<Timestamp>,
     pub recipient: scc::PublicKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -78,8 +76,6 @@ pub struct PaymentInfo {
 pub struct PublicPaymentInfo {
     pub output_hash: Hash,
     pub amount: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub locked_timestamp: Option<Timestamp>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_timestamp: Option<Timestamp>,
     pub recipient: scc::PublicKey,
@@ -179,21 +175,18 @@ pub enum AccountRequest {
         amount: i64,
         payment_fee: i64,
         comment: String,
-        locked_timestamp: Option<Timestamp>,
         with_certificate: bool,
     },
     PublicPayment {
         recipient: scc::PublicKey,
         amount: i64,
         payment_fee: i64,
-        locked_timestamp: Option<Timestamp>,
     },
     SecurePayment {
         recipient: scc::PublicKey,
         amount: i64,
         payment_fee: i64,
         comment: String,
-        locked_timestamp: Option<Timestamp>,
     },
     StakeAll {
         payment_fee: i64,

--- a/wallet/src/snowball/mod.rs
+++ b/wallet/src/snowball/mod.rs
@@ -99,8 +99,8 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::mem;
 use std::time::Duration;
+use stegos_blockchain::Output;
 use stegos_blockchain::PaymentTransaction;
-use stegos_blockchain::{Output, Timestamp};
 use stegos_blockchain::{PaymentOutput, PaymentPayloadData};
 use stegos_crypto::bulletproofs::{simple_commit, validate_range_proof};
 use stegos_crypto::dicemix::*;
@@ -166,7 +166,6 @@ pub struct ProposedUTXO {
     pub recip: PublicKey, // payee key (uncloaked)
     pub amount: i64,
     pub data: PaymentPayloadData,
-    pub locked_timestamp: Option<Timestamp>,
     pub is_change: bool,
 }
 
@@ -1890,7 +1889,6 @@ impl Snowball {
                 &txout.recip,
                 txout.amount,
                 txout.data,
-                txout.locked_timestamp,
             )
             .expect("Can't produce Payment UTXO");
             outs.push((output, gamma));

--- a/wallet/src/storage.rs
+++ b/wallet/src/storage.rs
@@ -790,7 +790,6 @@ impl PaymentValue {
             output_hash: Hash::digest(&self.output),
             amount: self.amount,
             data: self.data.clone(),
-            locked_timestamp: self.output.locked_timestamp,
             pending_timestamp,
             recipient: self.recipient,
             rvalue: self.rvalue.clone(),
@@ -805,7 +804,6 @@ impl PublicPaymentValue {
         PublicPaymentInfo {
             output_hash: Hash::digest(&self.output),
             amount: self.output.amount,
-            locked_timestamp: self.output.locked_timestamp,
             pending_timestamp,
             recipient: self.output.recipient,
             public_address_id: self.public_address_id,
@@ -958,7 +956,6 @@ mod test {
         let output = PublicPaymentOutput {
             serno: id as i64,
             amount: 10,
-            locked_timestamp: None,
             recipient: PublicKey::zero(),
         };
         let value = PublicPaymentValue {

--- a/wallet/src/test/account_transaction.rs
+++ b/wallet/src/test/account_transaction.rs
@@ -69,7 +69,6 @@ fn create_tx() {
             amount: 10,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -153,7 +152,6 @@ fn create_tx_with_certificate() {
             amount: 10,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: true,
         });
 
@@ -271,7 +269,6 @@ fn full_transfer() {
             amount: balance.payment.current - PAYMENT_FEE,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -329,7 +326,6 @@ fn create_tx_invalid() {
             amount: -10,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -347,7 +343,6 @@ fn create_tx_invalid() {
             amount: balance.payment.current - PAYMENT_FEE + 1, // 1 token more than real balance
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -365,7 +360,6 @@ fn create_tx_invalid() {
             amount: 10,
             payment_fee: PAYMENT_FEE,
             comment: std::iter::repeat('a').take(PAYMENT_DATA_LEN - 1).collect(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -418,7 +412,6 @@ fn wait_for_epoch_end_with_tx() {
             amount: 10,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -492,7 +485,6 @@ fn create_public_tx() {
             recipient,
             amount: 10,
             payment_fee: PAYMENT_FEE,
-            locked_timestamp: None,
         });
 
         assert_eq!(notification.poll(), Ok(Async::NotReady));
@@ -568,7 +560,6 @@ fn recovery_acount_after_tx() {
             amount: 10,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -648,7 +639,6 @@ fn send_node_duplicate_tx() {
             amount: 10,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
 
@@ -753,7 +743,6 @@ fn precondition_each_account_has_tokens(
             amount,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
         genesis_account.poll();
@@ -801,7 +790,6 @@ fn snowball_start(
         amount,
         payment_fee: PAYMENT_FEE,
         comment: "Test".to_string(),
-        locked_timestamp: None,
     });
 
     account.poll();
@@ -1138,7 +1126,6 @@ fn snowball_lock_utxo() {
             amount: SEND_TOKENS,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
         accounts[0].poll();
@@ -1170,7 +1157,6 @@ fn snowball_lock_utxo() {
             amount: SEND_TOKENS,
             payment_fee: PAYMENT_FEE,
             comment: "Test".to_string(),
-            locked_timestamp: None,
             with_certificate: false,
         });
         accounts[0].poll();
@@ -1258,7 +1244,6 @@ fn annihilation() {
                 amount: 1,
                 payment_fee: PAYMENT_FEE,
                 comment: "Test".to_string(),
-                locked_timestamp: None,
                 with_certificate: false,
             });
             accounts[0].poll();


### PR DESCRIPTION
There is no need in this feature anymore.
Since it was never used, this patch removes all code
without leaving any backward compatibility stuff.