### PR TITLE
Make payment fee fixed, improve errors.

### DIFF
--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -28,16 +28,17 @@ use stegos_crypto::scc;
 pub enum WalletError {
     #[fail(display = "Duplicate account: pkey={}", _0)]
     DuplicateAccount(scc::PublicKey),
-    #[fail(display = "Not enough money. Or outputs limit is reached.")]
+    #[fail(display = "Not enough money.")]
     NotEnoughMoney,
+    #[fail(display = "Inputs limit reached. Try to send transaction with smaller amount.")]
+    InputsLimit,
     #[fail(display = "Negative amount: amount={}", _0)]
     NegativeAmount(i64),
-    /// Stake amount is less than fee.
     #[fail(
-        display = "Stake transaction should contain be more than fee: fee={}, got={}.",
+        display = "Transaction should be more than fee: fee={}, got={}.",
         _0, _1
     )]
-    InsufficientStake(i64, i64),
+    InsufficientTransaction(i64, i64),
     /// Enough amount of stake should be unlocked.
     #[fail(
         display = "No enough stake UTXO available: current={}, available={}.",

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -552,7 +552,7 @@ impl UnsealedAccountService {
         }
 
         if payment_amount <= payment_fee {
-            return Err(WalletError::NotEnoughMoney.into());
+            return Err(WalletError::InsufficientTransaction(payment_fee, payment_amount).into());
         }
 
         info!("Found payment outputs: amount={}", payment_amount);
@@ -668,7 +668,7 @@ impl UnsealedAccountService {
             amount += output.amount;
         }
         if amount <= payment_fee {
-            return Err(WalletError::NotEnoughMoney.into());
+            return Err(WalletError::InsufficientTransaction(payment_fee, amount).into());
         }
         self.unstake(amount, payment_fee)
     }


### PR DESCRIPTION
- Split NoEnoughMoney and InputsLimit errors.
- Made payment transactions to always use change fee, for consistency.
- Force spending algorithm to always try spend minimal available utxo.
- Fixed tests.

Closes: 
#169886079 (pivotal)