### PR TITLE
Fix assertion panic when not all UTXOs make it across DiceMix sharing

### DIFF
--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -45,10 +45,7 @@ pub enum WalletError {
         _1, _0
     )]
     NoEnoughToStake(i64, i64),
-    #[fail(
-        display = "{} tokens available out of {}. Not enough to pay!",
-        _1, _0
-    )]
+    #[fail(display = "{} tokens available out of {}. Not enough to pay!", _1, _0)]
     NoEnoughToPay(i64, i64),
     #[fail(display = "{} tokens is not enough for a public payment!", _0)]
     NoEnoughToPayPublicly(i64),

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -629,9 +629,11 @@ impl UnsealedAccountService {
     fn unstake(&mut self, amount: i64, payment_fee: i64) -> Result<TransactionInfo, Error> {
         let stake_balance = self.balance().stake;
         if amount > stake_balance.available {
-            return Err(
-                WalletError::NoEnoughToStake(stake_balance.current, stake_balance.available).into(),
-            );
+            return Err(WalletError::NoEnoughToStake(
+                stake_balance.current,
+                stake_balance.available,
+            )
+            .into());
         }
 
         let unspent_iter = self.available_stake_outputs();


### PR DESCRIPTION
Instead of assert(), which can panic, we detect that not all UTXO's came across and perform a session restart. Note that all participants will eventually detect a failed transaction balance condition, if they don't see their own UTXOs missing. So all participants will restart eventually.