### PR TITLE
Fix epoch panic.

### DIFF
--- a/src/bin/stegosd/main.rs
+++ b/src/bin/stegosd/main.rs
@@ -549,7 +549,7 @@ fn run() -> Result<(), Error> {
         timestamp,
     )?;
 
-    let epoch = chain.epoch();
+    let epoch = chain.epoch() - 1;
     // Initialize node
     let (mut node_service, node) = NodeService::new(
         cfg.node.clone(),


### PR DESCRIPTION
Fix a panic when account created and unsealed in init epoch.

Closes: pivotal #170044492