### PR TITLE
Finish off Private Messaging for general users

### DIFF
--- a/blockchain/src/chat.rs
+++ b/blockchain/src/chat.rs
@@ -114,6 +114,8 @@ pub enum ChatError {
     InvalidGroup(String),
     #[fail(display = "Private Message Data Too Long")]
     DataTooLong,
+    #[fail(display = "Private Message Data Too Short")]
+    DataTooShort,
 }
 
 impl Hashable for ChatMessageOutput {

--- a/blockchain/src/output.rs
+++ b/blockchain/src/output.rs
@@ -489,6 +489,11 @@ impl PaymentPayload {
                 pos += HASH_SIZE;
                 PaymentPayloadData::ContentHash(hash)
             }
+            2 => {
+                let mut data = [0u8; PAYMENT_DATA_LEN - 2];
+                data.copy_from_slice(&payload[pos..pos + PAYMENT_DATA_LEN - 2]);
+                PaymentPayloadData::Data(data.to_vec())
+            }
             code @ _ => return Err(OutputError::UnsupportedDataType(output_hash, code).into()),
         };
 


### PR DESCRIPTION
Adds general GUI functions for constructing private messages with binary data payloads, and decoding of incoming PaymentPayloadData::Data(Vec<u8>) into PrivateMessage types.